### PR TITLE
feat: Implement basic menu builder

### DIFF
--- a/.changes/menu-builder.md
+++ b/.changes/menu-builder.md
@@ -2,4 +2,4 @@
 "tao": patch
 ---
 
-Implement basic menu builder for task bar in macOS and Windows.
+Implement basic menu builder for macOS, Windows and Linux.

--- a/.changes/menu-builder.md
+++ b/.changes/menu-builder.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Implement basic menu builder for task bar in macOS and Windows.

--- a/examples/custom_menu.rs
+++ b/examples/custom_menu.rs
@@ -91,7 +91,6 @@ fn main() {
               MenuItem::CloseWindow,
             ],
           )]))
-
         }
 
         println!("Clicked on {:?}", menu_id);

--- a/examples/custom_menu.rs
+++ b/examples/custom_menu.rs
@@ -2,13 +2,15 @@ use simple_logger::SimpleLogger;
 use tao::{
   event::{Event, WindowEvent},
   event_loop::{ControlFlow, EventLoop},
-  menu::{Menu, MenuItem},
+  menu::{Menu, MenuItem, MenuType},
   window::WindowBuilder,
 };
 
 fn main() {
   SimpleLogger::new().init().unwrap();
   let event_loop = EventLoop::new();
+
+  let custom_change_menu = MenuItem::new("Change menu").with_accelerators("F1");
 
   let window = WindowBuilder::new()
     .with_title("A fantastic window!")
@@ -30,7 +32,7 @@ fn main() {
       Menu::new(
         "File",
         vec![
-          MenuItem::new("change_menu", "Change menu").with_accelerators("F1"),
+          custom_change_menu,
           MenuItem::Separator,
           MenuItem::CloseWindow,
         ],
@@ -52,7 +54,7 @@ fn main() {
       Menu::new("Window", vec![MenuItem::Minimize, MenuItem::Zoom]),
       Menu::new(
         "Help",
-        vec![MenuItem::new("help_me", "Custom help")
+        vec![MenuItem::new("Custom help")
           // `Primary` is a platform-agnostic accelerator modifier.
           // On Windows and Linux, `Primary` maps to the `Ctrl` key,
           // and on macOS it maps to the `command` key.
@@ -75,20 +77,15 @@ fn main() {
       }
       // not sure if we should add a new event type?
       // or try to re-use the UserEvent::<T>
-      Event::MenuEvent(unique_menu_id) => {
-        if unique_menu_id == "change_menu" {
-          // update menu
-          window.set_menu(Some(vec![Menu::new(
-            "File",
-            vec![
-              MenuItem::new("add_todo", "Add Todo").with_accelerators("<Primary>+"),
-              MenuItem::Separator,
-              MenuItem::CloseWindow,
-            ],
-          )]))
+      Event::MenuEvent {
+        menu_id,
+        origin: MenuType::Menubar,
+      } => {
+        if menu_id == custom_change_menu.id() {
+          println!("Clicked on custom change menu");
         }
 
-        println!("Clicked on {}", unique_menu_id);
+        println!("Clicked on {:?}", menu_id);
         window.set_title("New window title!");
       }
       _ => (),

--- a/examples/custom_menu.rs
+++ b/examples/custom_menu.rs
@@ -75,8 +75,6 @@ fn main() {
       Event::MainEventsCleared => {
         window.request_redraw();
       }
-      // not sure if we should add a new event type?
-      // or try to re-use the UserEvent::<T>
       Event::MenuEvent {
         menu_id,
         origin: MenuType::Menubar,

--- a/examples/custom_menu.rs
+++ b/examples/custom_menu.rs
@@ -83,6 +83,15 @@ fn main() {
       } => {
         if menu_id == custom_change_menu.id() {
           println!("Clicked on custom change menu");
+          window.set_menu(Some(vec![Menu::new(
+            "File",
+            vec![
+              MenuItem::new("Add Todo").with_accelerators("<Primary>+"),
+              MenuItem::Separator,
+              MenuItem::CloseWindow,
+            ],
+          )]))
+
         }
 
         println!("Clicked on {:?}", menu_id);

--- a/examples/custom_menu.rs
+++ b/examples/custom_menu.rs
@@ -1,0 +1,101 @@
+use simple_logger::SimpleLogger;
+use tao::{
+  event::{Event, WindowEvent},
+  event_loop::{ControlFlow, EventLoop},
+  menu::{Menu, MenuItem},
+  window::WindowBuilder,
+};
+
+pub enum Message {
+  MenuClickAddNewItem,
+}
+
+fn main() {
+  SimpleLogger::new().init().unwrap();
+  let event_loop = EventLoop::new();
+
+  let window = WindowBuilder::new()
+    .with_title("A fantastic window!")
+    .with_menu(vec![
+      Menu::new(
+        // on macOS first menu is always app name
+        "my custom app",
+        vec![
+          MenuItem::About("Todos"),
+          MenuItem::Services,
+          MenuItem::Separator,
+          MenuItem::Hide,
+          MenuItem::HideOthers,
+          MenuItem::ShowAll,
+          MenuItem::Separator,
+          MenuItem::Quit,
+        ],
+      ),
+      Menu::new(
+        "File",
+        vec![
+          MenuItem::new("change_menu", "Change menu").with_accelerators("F1"),
+          MenuItem::Separator,
+          MenuItem::CloseWindow,
+        ],
+      ),
+      Menu::new(
+        "Edit",
+        vec![
+          MenuItem::Undo,
+          MenuItem::Redo,
+          MenuItem::Separator,
+          MenuItem::Cut,
+          MenuItem::Copy,
+          MenuItem::Paste,
+          MenuItem::Separator,
+          MenuItem::SelectAll,
+        ],
+      ),
+      Menu::new("View", vec![MenuItem::EnterFullScreen]),
+      Menu::new("Window", vec![MenuItem::Minimize, MenuItem::Zoom]),
+      Menu::new(
+        "Help",
+        vec![MenuItem::new("help_me", "Custom help")
+          // `Primary` is a platform-agnostic accelerator modifier.
+          // On Windows and Linux, `Primary` maps to the `Ctrl` key,
+          // and on macOS it maps to the `command` key.
+          .with_accelerators("<Primary><Shift>h")],
+      ),
+    ])
+    .build(&event_loop)
+    .unwrap();
+
+  event_loop.run(move |event, _, control_flow| {
+    *control_flow = ControlFlow::Wait;
+
+    match event {
+      Event::WindowEvent {
+        event: WindowEvent::CloseRequested,
+        window_id,
+      } if window_id == window.id() => *control_flow = ControlFlow::Exit,
+      Event::MainEventsCleared => {
+        window.request_redraw();
+      }
+      // not sure if we should add a new event type?
+      // or try to re-use the UserEvent::<T>
+      Event::MenuEvent(menu_id) => {
+        if menu_id == "change_menu" {
+          // update menu
+          window.set_menu(Some(vec![Menu::new(
+            "File",
+            vec![
+              MenuItem::new("add_todo", "Add Todo").with_accelerators("<Primary>+"),
+              MenuItem::Separator,
+              MenuItem::CloseWindow,
+            ],
+          )]))
+        }
+
+        println!("Clicked on {}", menu_id);
+        window.set_title("New window title!");
+      }
+      _ => (),
+    }
+  });
+}

--- a/examples/custom_menu.rs
+++ b/examples/custom_menu.rs
@@ -79,8 +79,8 @@ fn main() {
       }
       // not sure if we should add a new event type?
       // or try to re-use the UserEvent::<T>
-      Event::MenuEvent(menu_id) => {
-        if menu_id == "change_menu" {
+      Event::MenuEvent(unique_menu_id) => {
+        if unique_menu_id == "change_menu" {
           // update menu
           window.set_menu(Some(vec![Menu::new(
             "File",
@@ -92,7 +92,7 @@ fn main() {
           )]))
         }
 
-        println!("Clicked on {}", menu_id);
+        println!("Clicked on {}", unique_menu_id);
         window.set_title("New window title!");
       }
       _ => (),

--- a/examples/custom_menu.rs
+++ b/examples/custom_menu.rs
@@ -6,10 +6,6 @@ use tao::{
   window::WindowBuilder,
 };
 
-pub enum Message {
-  MenuClickAddNewItem,
-}
-
 fn main() {
   SimpleLogger::new().init().unwrap();
   let event_loop = EventLoop::new();

--- a/src/event.rs
+++ b/src/event.rs
@@ -70,6 +70,9 @@ pub enum Event<'a, T: 'static> {
   /// Emitted when an event is sent from [`EventLoopProxy::send_event`](crate::event_loop::EventLoopProxy::send_event)
   UserEvent(T),
 
+  /// Emitted when a menu has been clicked.
+  MenuEvent(String),
+
   /// Emitted when the application has been suspended.
   Suspended,
 
@@ -138,6 +141,7 @@ impl<T: Clone> Clone for Event<'static, T> {
       LoopDestroyed => LoopDestroyed,
       Suspended => Suspended,
       Resumed => Resumed,
+      MenuEvent(event) => MenuEvent(event.clone()),
     }
   }
 }
@@ -156,6 +160,7 @@ impl<'a, T> Event<'a, T> {
       LoopDestroyed => Ok(LoopDestroyed),
       Suspended => Ok(Suspended),
       Resumed => Ok(Resumed),
+      MenuEvent(event) => Ok(MenuEvent(event)),
     }
   }
 
@@ -176,6 +181,7 @@ impl<'a, T> Event<'a, T> {
       LoopDestroyed => Some(LoopDestroyed),
       Suspended => Some(Suspended),
       Resumed => Some(Resumed),
+      MenuEvent(event) => Some(MenuEvent(event)),
     }
   }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -38,6 +38,7 @@ use std::path::PathBuf;
 
 use crate::{
   dpi::{PhysicalPosition, PhysicalSize},
+  menu::{MenuId, MenuType},
   platform_impl,
   window::{Theme, WindowId},
 };
@@ -71,7 +72,7 @@ pub enum Event<'a, T: 'static> {
   UserEvent(T),
 
   /// Emitted when a menu has been clicked.
-  MenuEvent(String),
+  MenuEvent { menu_id: MenuId, origin: MenuType },
 
   /// Emitted when the application has been suspended.
   Suspended,
@@ -141,7 +142,10 @@ impl<T: Clone> Clone for Event<'static, T> {
       LoopDestroyed => LoopDestroyed,
       Suspended => Suspended,
       Resumed => Resumed,
-      MenuEvent(event) => MenuEvent(event.clone()),
+      MenuEvent { menu_id, origin } => MenuEvent {
+        menu_id: *menu_id,
+        origin: origin.clone(),
+      },
     }
   }
 }
@@ -160,7 +164,7 @@ impl<'a, T> Event<'a, T> {
       LoopDestroyed => Ok(LoopDestroyed),
       Suspended => Ok(Suspended),
       Resumed => Ok(Resumed),
-      MenuEvent(event) => Ok(MenuEvent(event)),
+      MenuEvent { menu_id, origin } => Ok(MenuEvent { menu_id, origin }),
     }
   }
 
@@ -181,7 +185,7 @@ impl<'a, T> Event<'a, T> {
       LoopDestroyed => Some(LoopDestroyed),
       Suspended => Some(Suspended),
       Resumed => Some(Resumed),
-      MenuEvent(event) => Some(MenuEvent(event)),
+      MenuEvent { menu_id, origin } => Some(MenuEvent { menu_id, origin }),
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@ pub mod error;
 pub mod event;
 pub mod event_loop;
 mod icon;
+pub mod menu;
 pub mod monitor;
 mod platform_impl;
 pub mod window;

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -4,13 +4,13 @@ use std::{
 };
 
 #[derive(Debug, Clone)]
-pub struct Menu<'a> {
+pub struct Menu {
   pub title: String,
-  pub items: Vec<MenuItem<'a>>,
+  pub items: Vec<MenuItem>,
 }
 
-impl<'a> Menu<'a> {
-  pub fn new(title: &str, items: Vec<MenuItem<'a>>) -> Self {
+impl Menu {
+  pub fn new(title: &str, items: Vec<MenuItem>) -> Self {
     Self {
       title: String::from(title),
       items,
@@ -20,17 +20,17 @@ impl<'a> Menu<'a> {
 
 #[derive(Debug, Clone, Hash, Copy)]
 /// CustomMenu is a custom menu who emit an event inside the EventLoop.
-pub struct CustomMenu<'a> {
+pub struct CustomMenu {
   pub _id: MenuId,
-  pub name: &'a str,
+  pub name: &'static str,
   pub keyboard_accelerators: Option<&'static str>,
 }
 
 /// A menu item, binded to a pre-defined action or `Custom` emit an event.
 #[derive(Debug, Clone, Copy)]
-pub enum MenuItem<'a> {
+pub enum MenuItem {
   /// A custom menu emit an event inside the EventLoop.
-  Custom(CustomMenu<'a>),
+  Custom(CustomMenu),
 
   /// Shows a standard "About" item
   ///
@@ -38,7 +38,7 @@ pub enum MenuItem<'a> {
   ///
   /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
-  About(&'a str),
+  About(&'static str),
 
   /// A standard "hide the app" menu item.
   ///
@@ -171,10 +171,10 @@ pub enum MenuItem<'a> {
   Separator,
 }
 
-impl<'a> MenuItem<'a> {
+impl MenuItem {
   /// Create new custom menu item.
   /// unique_menu_id is the unique ID for the menu item returned in the EventLoop `Event::MenuEvent(unique_menu_id)`
-  pub fn new(title: &'a str) -> Self {
+  pub fn new(title: &'static str) -> Self {
     MenuItem::Custom(CustomMenu {
       _id: MenuId::new(title),
       name: title,

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -14,6 +14,7 @@ impl Menu {
 }
 
 #[derive(Debug, Clone)]
+/// CustomMenu is a custom menu who emit an event inside the EventLoop.
 pub struct CustomMenu {
   // todo: replace id by a type that
   // we can send from the with_menu::<T>()
@@ -24,38 +25,82 @@ pub struct CustomMenu {
   pub keyboard_accelerators: Option<&'static str>,
 }
 
+/// A menu item, binded to a pre-defined action or `Custom` emit an event.
 #[derive(Debug, Clone)]
 pub enum MenuItem {
-  /// A custom MenuItem
+  /// A custom menu emit an event inside the EventLoop.
   Custom(CustomMenu),
 
   /// Shows a standard "About" item
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   About(&'static str),
 
   /// A standard "hide the app" menu item.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   Hide,
 
   /// A standard "Services" menu item.
+  ///
   /// ## Platform-specific
-  /// macOS only.
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   Services,
 
   /// A "hide all other windows" menu item.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   HideOthers,
 
   /// A menu item to show all the windows for this app.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   ShowAll,
 
   /// Close the current window.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   CloseWindow,
 
   /// A "quit this app" menu icon.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   Quit,
 
   /// A menu item for enabling copying (often text) from responders.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   Copy,
 
   /// A menu item for enabling cutting (often text) from responders.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   Cut,
 
   /// An "undo" menu item; particularly useful for supporting the cut/copy/paste/undo lifecycle
@@ -64,24 +109,59 @@ pub enum MenuItem {
 
   /// An "redo" menu item; particularly useful for supporting the cut/copy/paste/undo lifecycle
   /// of events.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   Redo,
 
   /// A menu item for selecting all (often text) from responders.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   SelectAll,
 
   /// A menu item for pasting (often text) into responders.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   Paste,
 
   /// A standard "enter full screen" item.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   EnterFullScreen,
 
   /// An item for minimizing the window with the standard system controls.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   Minimize,
 
   /// An item for instructing the app to zoom
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   Zoom,
 
   /// Represents a Separator
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   Separator,
 }
 
@@ -100,7 +180,12 @@ impl MenuItem {
     })
   }
 
-  /// Assign keyboard shortcut
+  /// Assign keyboard shortcut to the menu action. Works only with `MenuItem::Custom`.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   pub fn with_accelerators(mut self, keyboard_accelerators: &'static str) -> Self {
     if let MenuItem::Custom(ref mut custom_menu) = self {
       custom_menu.keyboard_accelerators = Some(keyboard_accelerators);

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -36,7 +36,7 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   About(&'a str),
 
@@ -44,7 +44,7 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   Hide,
 
@@ -52,7 +52,7 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   Services,
 
@@ -60,7 +60,7 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   HideOthers,
 
@@ -68,7 +68,7 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   ShowAll,
 
@@ -76,7 +76,7 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   CloseWindow,
 
@@ -84,7 +84,7 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   Quit,
 
@@ -92,7 +92,7 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   Copy,
 
@@ -100,12 +100,17 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   Cut,
 
   /// An "undo" menu item; particularly useful for supporting the cut/copy/paste/undo lifecycle
   /// of events.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
+  ///
   Undo,
 
   /// An "redo" menu item; particularly useful for supporting the cut/copy/paste/undo lifecycle
@@ -113,7 +118,7 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   Redo,
 
@@ -121,7 +126,7 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   SelectAll,
 
@@ -129,7 +134,7 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   Paste,
 
@@ -137,7 +142,7 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   EnterFullScreen,
 
@@ -145,7 +150,7 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   Minimize,
 
@@ -153,7 +158,7 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   Zoom,
 
@@ -161,7 +166,7 @@ pub enum MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   Separator,
 }
@@ -182,7 +187,7 @@ impl<'a> MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   pub fn with_accelerators(mut self, keyboard_accelerators: &'static str) -> Self {
     if let MenuItem::Custom(ref mut custom_menu) = self {
@@ -195,7 +200,7 @@ impl<'a> MenuItem<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   pub fn id(mut self) -> MenuId {
     if let MenuItem::Custom(ref mut custom_menu) = self {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -176,7 +176,6 @@ impl<'a> MenuItem<'a> {
   /// unique_menu_id is the unique ID for the menu item returned in the EventLoop `Event::MenuEvent(unique_menu_id)`
   pub fn new(title: &'a str) -> Self {
     MenuItem::Custom(CustomMenu {
-      // todo: would be great if we could pass a type instead of an ID?
       _id: MenuId::new(title),
       name: title,
       keyboard_accelerators: None,
@@ -197,11 +196,6 @@ impl<'a> MenuItem<'a> {
   }
 
   /// Return unique menu ID. Works only with `MenuItem::Custom`.
-  ///
-  /// ## Platform-specific
-  ///
-  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
-  ///
   pub fn id(mut self) -> MenuId {
     if let MenuItem::Custom(ref mut custom_menu) = self {
       return custom_menu._id;
@@ -213,7 +207,7 @@ impl<'a> MenuItem<'a> {
   }
 }
 
-/// Identifier of a menu item.
+/// Identifier of a custom menu item.
 ///
 /// Whenever you receive an event arising from a particular menu, this event contains a `MenuId` which
 /// identifies its origin.

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,0 +1,110 @@
+#[derive(Debug, Clone)]
+pub struct Menu {
+  pub title: String,
+  pub items: Vec<MenuItem>,
+}
+
+impl Menu {
+  pub fn new(title: &str, items: Vec<MenuItem>) -> Self {
+    Self {
+      title: String::from(title),
+      items,
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct CustomMenu {
+  // todo: replace id by a type that
+  // we can send from the with_menu::<T>()
+  // or we could check to use the UserEvent::<T> but
+  // my latest test failed
+  pub id: String,
+  pub name: String,
+  pub keyboard_accelerators: Option<&'static str>,
+}
+
+#[derive(Debug, Clone)]
+pub enum MenuItem {
+  /// A custom MenuItem
+  Custom(CustomMenu),
+
+  /// Shows a standard "About" item
+  About(&'static str),
+
+  /// A standard "hide the app" menu item.
+  Hide,
+
+  /// A standard "Services" menu item.
+  /// ## Platform-specific
+  /// macOS only.
+  Services,
+
+  /// A "hide all other windows" menu item.
+  HideOthers,
+
+  /// A menu item to show all the windows for this app.
+  ShowAll,
+
+  /// Close the current window.
+  CloseWindow,
+
+  /// A "quit this app" menu icon.
+  Quit,
+
+  /// A menu item for enabling copying (often text) from responders.
+  Copy,
+
+  /// A menu item for enabling cutting (often text) from responders.
+  Cut,
+
+  /// An "undo" menu item; particularly useful for supporting the cut/copy/paste/undo lifecycle
+  /// of events.
+  Undo,
+
+  /// An "redo" menu item; particularly useful for supporting the cut/copy/paste/undo lifecycle
+  /// of events.
+  Redo,
+
+  /// A menu item for selecting all (often text) from responders.
+  SelectAll,
+
+  /// A menu item for pasting (often text) into responders.
+  Paste,
+
+  /// A standard "enter full screen" item.
+  EnterFullScreen,
+
+  /// An item for minimizing the window with the standard system controls.
+  Minimize,
+
+  /// An item for instructing the app to zoom
+  Zoom,
+
+  /// Represents a Separator
+  Separator,
+}
+
+impl MenuItem {
+  /// Create new custom menu item.
+  /// unique_menu_id is the unique ID for the menu item returned in the EventLoop `Event::MenuEvent(unique_menu_id)`
+  pub fn new<T>(unique_menu_id: T, title: T) -> Self
+  where
+    T: Into<String>,
+  {
+    MenuItem::Custom(CustomMenu {
+      // todo: would be great if we could pass a type instead of an ID?
+      id: unique_menu_id.into(),
+      name: title.into(),
+      keyboard_accelerators: None,
+    })
+  }
+
+  /// Assign keyboard shortcut
+  pub fn with_accelerators(mut self, keyboard_accelerators: &'static str) -> Self {
+    if let MenuItem::Custom(ref mut custom_menu) = self {
+      custom_menu.keyboard_accelerators = Some(keyboard_accelerators);
+    }
+    self
+  }
+}

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -499,7 +499,7 @@ impl Window {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   pub fn set_menu(&self, _menu: Option<Vec<Menu>>) {}
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -4,8 +4,8 @@ use crate::{
   dpi::{PhysicalPosition, PhysicalSize, Position, Size},
   error, event,
   event_loop::{self, ControlFlow},
-  monitor, window,
   menu::Menu,
+  monitor, window,
 };
 use ndk::{
   configuration::Configuration,
@@ -495,6 +495,12 @@ impl Window {
 
   pub fn set_title(&self, _title: &str) {}
 
+  /// Set menu
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   pub fn set_menu(&self, _menu: Option<Vec<Menu>>) {}
 
   pub fn set_visible(&self, _visibility: bool) {}

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -5,6 +5,7 @@ use crate::{
   error, event,
   event_loop::{self, ControlFlow},
   monitor, window,
+  menu::Menu,
 };
 use ndk::{
   configuration::Configuration,
@@ -493,6 +494,8 @@ impl Window {
   pub fn set_max_inner_size(&self, _: Option<Size>) {}
 
   pub fn set_title(&self, _title: &str) {}
+
+  pub fn set_menu(&self, _menu: Option<Vec<Menu>>) {}
 
   pub fn set_visible(&self, _visibility: bool) {}
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -501,7 +501,7 @@ impl Window {
   ///
   /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
-  pub fn set_menu(&self, _menu: Option<Vec<Menu<'_>>>) {}
+  pub fn set_menu(&self, _menu: Option<Vec<Menu>>) {}
 
   pub fn set_visible(&self, _visibility: bool) {}
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -501,7 +501,7 @@ impl Window {
   ///
   /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
-  pub fn set_menu(&self, _menu: Option<Vec<Menu>>) {}
+  pub fn set_menu(&self, _menu: Option<Vec<Menu<'_>>>) {}
 
   pub fn set_visible(&self, _visibility: bool) {}
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -48,6 +48,12 @@ impl Inner {
     debug!("`Window::set_title` is ignored on iOS")
   }
 
+  /// Set menu
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   pub fn set_menu(&self, _menu: Option<Vec<Menu>>) {
     debug!("`Window::set_menu` is ignored on iOS")
   }

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -52,7 +52,7 @@ impl Inner {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   pub fn set_menu(&self, _menu: Option<Vec<Menu>>) {
     debug!("`Window::set_menu` is ignored on iOS")

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -54,7 +54,7 @@ impl Inner {
   ///
   /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
-  pub fn set_menu(&self, _menu: Option<Vec<Menu<'_>>>) {
+  pub fn set_menu(&self, _menu: Option<Vec<Menu>>) {
     debug!("`Window::set_menu` is ignored on iOS")
   }
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -54,7 +54,7 @@ impl Inner {
   ///
   /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
-  pub fn set_menu(&self, _menu: Option<Vec<Menu>>) {
+  pub fn set_menu(&self, _menu: Option<Vec<Menu<'_>>>) {
     debug!("`Window::set_menu` is ignored on iOS")
   }
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -11,6 +11,7 @@ use crate::{
   error::{ExternalError, NotSupportedError, OsError as RootOsError},
   event::{Event, WindowEvent},
   icon::Icon,
+  menu::Menu,
   monitor::MonitorHandle as RootMonitorHandle,
   platform::ios::{MonitorHandleExtIOS, ScreenEdge, ValidOrientations},
   platform_impl::platform::{
@@ -45,6 +46,10 @@ impl Drop for Inner {
 impl Inner {
   pub fn set_title(&self, _title: &str) {
     debug!("`Window::set_title` is ignored on iOS")
+  }
+
+  pub fn set_menu(&self, _menu: Option<Vec<Menu>>) {
+    debug!("`Window::set_menu` is ignored on iOS")
   }
 
   pub fn set_visible(&self, visible: bool) {

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -25,6 +25,7 @@ use crate::{
   event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootELW},
   monitor::MonitorHandle as RootMonitorHandle,
   window::{CursorIcon, WindowId as RootWindowId},
+  menu::MenuItem
 };
 
 use super::{
@@ -469,7 +470,11 @@ impl<T: 'static> EventLoop<T> {
             WindowRequest::Menu(m) => {
                 // TODO other MenuItem variant
                 match m {
-                    
+                    MenuItem::Custom(c) => {
+                        if let Err(e) = event_tx.send(Event::MenuEvent(c.id)) {
+                            log::warn!("Failed to send menu event to event channel: {}", e);
+                        }
+                    } 
                     _ => window.close(),
                 }
             },

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -144,333 +144,330 @@ impl<T: 'static> EventLoop<T> {
 
       // Widnow Request
       if let Ok((id, request)) = window_target.p.window_requests_rx.try_recv() {
-        let window = window_target
-          .p
-          .app
-          .get_window_by_id(id.0)
-          .expect("Failed to send closed window event!");
-
-        match request {
-          WindowRequest::Title(title) => window.set_title(&title),
-          WindowRequest::Position((x, y)) => window.move_(x, y),
-          WindowRequest::Size((w, h)) => window.resize(w, h),
-          WindowRequest::MinSize((min_width, min_height)) => window
-            .set_geometry_hints::<ApplicationWindow>(
-              None,
-              Some(&gdk::Geometry {
-                min_width,
-                min_height,
-                max_width: 0,
-                max_height: 0,
-                base_width: 0,
-                base_height: 0,
-                width_inc: 0,
-                height_inc: 0,
-                min_aspect: 0f64,
-                max_aspect: 0f64,
-                win_gravity: gdk::Gravity::Center,
-              }),
-              gdk::WindowHints::MIN_SIZE,
-            ),
-          WindowRequest::MaxSize((max_width, max_height)) => window
-            .set_geometry_hints::<ApplicationWindow>(
-              None,
-              Some(&gdk::Geometry {
-                min_width: 0,
-                min_height: 0,
-                max_width,
-                max_height,
-                base_width: 0,
-                base_height: 0,
-                width_inc: 0,
-                height_inc: 0,
-                min_aspect: 0f64,
-                max_aspect: 0f64,
-                win_gravity: gdk::Gravity::Center,
-              }),
-              gdk::WindowHints::MAX_SIZE,
-            ),
-          WindowRequest::Visible(visible) => {
-            if visible {
-              window.show_all();
-            } else {
-              window.hide();
+        if let Some(window) = window_target.p.app.get_window_by_id(id.0) {
+          match request {
+            WindowRequest::Title(title) => window.set_title(&title),
+            WindowRequest::Position((x, y)) => window.move_(x, y),
+            WindowRequest::Size((w, h)) => window.resize(w, h),
+            WindowRequest::MinSize((min_width, min_height)) => window
+              .set_geometry_hints::<ApplicationWindow>(
+                None,
+                Some(&gdk::Geometry {
+                  min_width,
+                  min_height,
+                  max_width: 0,
+                  max_height: 0,
+                  base_width: 0,
+                  base_height: 0,
+                  width_inc: 0,
+                  height_inc: 0,
+                  min_aspect: 0f64,
+                  max_aspect: 0f64,
+                  win_gravity: gdk::Gravity::Center,
+                }),
+                gdk::WindowHints::MIN_SIZE,
+              ),
+            WindowRequest::MaxSize((max_width, max_height)) => window
+              .set_geometry_hints::<ApplicationWindow>(
+                None,
+                Some(&gdk::Geometry {
+                  min_width: 0,
+                  min_height: 0,
+                  max_width,
+                  max_height,
+                  base_width: 0,
+                  base_height: 0,
+                  width_inc: 0,
+                  height_inc: 0,
+                  min_aspect: 0f64,
+                  max_aspect: 0f64,
+                  win_gravity: gdk::Gravity::Center,
+                }),
+                gdk::WindowHints::MAX_SIZE,
+              ),
+            WindowRequest::Visible(visible) => {
+              if visible {
+                window.show_all();
+              } else {
+                window.hide();
+              }
             }
-          }
-          WindowRequest::Resizable(resizable) => window.set_resizable(resizable),
-          WindowRequest::Minimized(minimized) => {
-            if minimized {
-              window.iconify();
-            } else {
-              window.deiconify();
+            WindowRequest::Resizable(resizable) => window.set_resizable(resizable),
+            WindowRequest::Minimized(minimized) => {
+              if minimized {
+                window.iconify();
+              } else {
+                window.deiconify();
+              }
             }
-          }
-          WindowRequest::Maximized(maximized) => {
-            if maximized {
-              window.maximize();
-            } else {
-              window.unmaximize();
+            WindowRequest::Maximized(maximized) => {
+              if maximized {
+                window.maximize();
+              } else {
+                window.unmaximize();
+              }
             }
-          }
-          WindowRequest::DragWindow => {
-            let display = window.get_display();
-            if let Some(cursor) = display
-              .get_device_manager()
-              .and_then(|device_manager| device_manager.get_client_pointer())
-            {
-              let (_, x, y) = cursor.get_position();
-              window.begin_move_drag(1, x, y, 0);
-            }
-          }
-          WindowRequest::Fullscreen(fullscreen) => match fullscreen {
-            Some(_) => window.fullscreen(),
-            None => window.unfullscreen(),
-          },
-          WindowRequest::Decorations(decorations) => window.set_decorated(decorations),
-          WindowRequest::AlwaysOnTop(always_on_top) => window.set_keep_above(always_on_top),
-          WindowRequest::WindowIcon(window_icon) => {
-            if let Some(icon) = window_icon {
-              window.set_icon(Some(&icon.inner.into()));
-            }
-          }
-          WindowRequest::UserAttention(request_type) => {
-            if request_type.is_some() {
-              window.set_urgency_hint(true)
-            }
-          }
-          WindowRequest::SkipTaskbar => window.set_skip_taskbar_hint(true),
-          WindowRequest::CursorIcon(cursor) => {
-            if let Some(gdk_window) = window.get_window() {
-              let display = window.get_display();
-              match cursor {
-                Some(cr) => gdk_window.set_cursor(
-                  Cursor::from_name(
-                    &display,
-                    match cr {
-                      CursorIcon::Crosshair => "crosshair",
-                      CursorIcon::Hand => "pointer",
-                      CursorIcon::Arrow => "crosshair",
-                      CursorIcon::Move => "move",
-                      CursorIcon::Text => "text",
-                      CursorIcon::Wait => "wait",
-                      CursorIcon::Help => "help",
-                      CursorIcon::Progress => "progress",
-                      CursorIcon::NotAllowed => "not-allowed",
-                      CursorIcon::ContextMenu => "context-menu",
-                      CursorIcon::Cell => "cell",
-                      CursorIcon::VerticalText => "vertical-text",
-                      CursorIcon::Alias => "alias",
-                      CursorIcon::Copy => "copy",
-                      CursorIcon::NoDrop => "no-drop",
-                      CursorIcon::Grab => "grab",
-                      CursorIcon::Grabbing => "grabbing",
-                      CursorIcon::AllScroll => "all-scroll",
-                      CursorIcon::ZoomIn => "zoom-in",
-                      CursorIcon::ZoomOut => "zoom-out",
-                      CursorIcon::EResize => "e-resize",
-                      CursorIcon::NResize => "n-resize",
-                      CursorIcon::NeResize => "ne-resize",
-                      CursorIcon::NwResize => "nw-resize",
-                      CursorIcon::SResize => "s-resize",
-                      CursorIcon::SeResize => "se-resize",
-                      CursorIcon::SwResize => "sw-resize",
-                      CursorIcon::WResize => "w-resize",
-                      CursorIcon::EwResize => "ew-resize",
-                      CursorIcon::NsResize => "ns-resize",
-                      CursorIcon::NeswResize => "nesw-resize",
-                      CursorIcon::NwseResize => "nwse-resize",
-                      CursorIcon::ColResize => "col-resize",
-                      CursorIcon::RowResize => "row-resize",
-                      CursorIcon::Default => "default",
-                    },
-                  )
-                  .as_ref(),
-                ),
-                None => gdk_window.set_cursor(Some(&Cursor::new_for_display(
-                  &display,
-                  CursorType::BlankCursor,
-                ))),
-              }
-            };
-          }
-          WindowRequest::WireUpEvents => {
-            let windows_rc = window_target.p.windows.clone();
-            let tx_clone = event_tx.clone();
-
-            window.connect_delete_event(move |_, _| {
-              windows_rc.borrow_mut().remove(&id);
-              if let Err(e) = tx_clone.send(Event::WindowEvent {
-                window_id: RootWindowId(id),
-                event: WindowEvent::CloseRequested,
-              }) {
-                log::warn!("Failed to send window close event to event channel: {}", e);
-              }
-              Inhibit(false)
-            });
-
-            let tx_clone = event_tx.clone();
-            window.connect_configure_event(move |_, event| {
-              let (x, y) = event.get_position();
-              if let Err(e) = tx_clone.send(Event::WindowEvent {
-                window_id: RootWindowId(id),
-                event: WindowEvent::Moved(PhysicalPosition::new(x, y)),
-              }) {
-                log::warn!("Failed to send window moved event to event channel: {}", e);
-              }
-
-              let (w, h) = event.get_size();
-              if let Err(e) = tx_clone.send(Event::WindowEvent {
-                window_id: RootWindowId(id),
-                event: WindowEvent::Resized(PhysicalSize::new(w, h)),
-              }) {
-                log::warn!(
-                  "Failed to send window resized event to event channel: {}",
-                  e
-                );
-              }
-              false
-            });
-
-            let tx_clone = event_tx.clone();
-            window.connect_window_state_event(move |_window, event| {
-              let state = event.get_new_window_state();
-
-              if let Err(e) = tx_clone.send(Event::WindowEvent {
-                window_id: RootWindowId(id),
-                event: WindowEvent::Focused(state.contains(WindowState::FOCUSED)),
-              }) {
-                log::warn!(
-                  "Failed to send window focused event to event channel: {}",
-                  e
-                );
-              }
-              Inhibit(false)
-            });
-
-            let tx_clone = event_tx.clone();
-            window.connect_destroy_event(move |_, _| {
-              if let Err(e) = tx_clone.send(Event::WindowEvent {
-                window_id: RootWindowId(id),
-                event: WindowEvent::Destroyed,
-              }) {
-                log::warn!(
-                  "Failed to send window destroyed event to event channel: {}",
-                  e
-                );
-              }
-              Inhibit(false)
-            });
-
-            let tx_clone = event_tx.clone();
-            window.connect_enter_notify_event(move |_, _| {
-              if let Err(e) = tx_clone.send(Event::WindowEvent {
-                window_id: RootWindowId(id),
-                event: WindowEvent::CursorEntered {
-                  // FIXME: currently we use a dummy device id, find if we can get device id from gtk
-                  device_id: RootDeviceId(DeviceId(0)),
-                },
-              }) {
-                log::warn!(
-                  "Failed to send cursor entered event to event channel: {}",
-                  e
-                );
-              }
-              Inhibit(false)
-            });
-
-            let tx_clone = event_tx.clone();
-            window.connect_motion_notify_event(move |window, _| {
+            WindowRequest::DragWindow => {
               let display = window.get_display();
               if let Some(cursor) = display
                 .get_device_manager()
                 .and_then(|device_manager| device_manager.get_client_pointer())
               {
                 let (_, x, y) = cursor.get_position();
+                window.begin_move_drag(1, x, y, 0);
+              }
+            }
+            WindowRequest::Fullscreen(fullscreen) => match fullscreen {
+              Some(_) => window.fullscreen(),
+              None => window.unfullscreen(),
+            },
+            WindowRequest::Decorations(decorations) => window.set_decorated(decorations),
+            WindowRequest::AlwaysOnTop(always_on_top) => window.set_keep_above(always_on_top),
+            WindowRequest::WindowIcon(window_icon) => {
+              if let Some(icon) = window_icon {
+                window.set_icon(Some(&icon.inner.into()));
+              }
+            }
+            WindowRequest::UserAttention(request_type) => {
+              if request_type.is_some() {
+                window.set_urgency_hint(true)
+              }
+            }
+            WindowRequest::SkipTaskbar => window.set_skip_taskbar_hint(true),
+            WindowRequest::CursorIcon(cursor) => {
+              if let Some(gdk_window) = window.get_window() {
+                let display = window.get_display();
+                match cursor {
+                  Some(cr) => gdk_window.set_cursor(
+                    Cursor::from_name(
+                      &display,
+                      match cr {
+                        CursorIcon::Crosshair => "crosshair",
+                        CursorIcon::Hand => "pointer",
+                        CursorIcon::Arrow => "crosshair",
+                        CursorIcon::Move => "move",
+                        CursorIcon::Text => "text",
+                        CursorIcon::Wait => "wait",
+                        CursorIcon::Help => "help",
+                        CursorIcon::Progress => "progress",
+                        CursorIcon::NotAllowed => "not-allowed",
+                        CursorIcon::ContextMenu => "context-menu",
+                        CursorIcon::Cell => "cell",
+                        CursorIcon::VerticalText => "vertical-text",
+                        CursorIcon::Alias => "alias",
+                        CursorIcon::Copy => "copy",
+                        CursorIcon::NoDrop => "no-drop",
+                        CursorIcon::Grab => "grab",
+                        CursorIcon::Grabbing => "grabbing",
+                        CursorIcon::AllScroll => "all-scroll",
+                        CursorIcon::ZoomIn => "zoom-in",
+                        CursorIcon::ZoomOut => "zoom-out",
+                        CursorIcon::EResize => "e-resize",
+                        CursorIcon::NResize => "n-resize",
+                        CursorIcon::NeResize => "ne-resize",
+                        CursorIcon::NwResize => "nw-resize",
+                        CursorIcon::SResize => "s-resize",
+                        CursorIcon::SeResize => "se-resize",
+                        CursorIcon::SwResize => "sw-resize",
+                        CursorIcon::WResize => "w-resize",
+                        CursorIcon::EwResize => "ew-resize",
+                        CursorIcon::NsResize => "ns-resize",
+                        CursorIcon::NeswResize => "nesw-resize",
+                        CursorIcon::NwseResize => "nwse-resize",
+                        CursorIcon::ColResize => "col-resize",
+                        CursorIcon::RowResize => "row-resize",
+                        CursorIcon::Default => "default",
+                      },
+                    )
+                    .as_ref(),
+                  ),
+                  None => gdk_window.set_cursor(Some(&Cursor::new_for_display(
+                    &display,
+                    CursorType::BlankCursor,
+                  ))),
+                }
+              };
+            }
+            WindowRequest::WireUpEvents => {
+              let windows_rc = window_target.p.windows.clone();
+              let tx_clone = event_tx.clone();
+
+              window.connect_delete_event(move |_, _| {
+                windows_rc.borrow_mut().remove(&id);
                 if let Err(e) = tx_clone.send(Event::WindowEvent {
                   window_id: RootWindowId(id),
-                  event: WindowEvent::CursorMoved {
-                    position: PhysicalPosition::new(x as f64, y as f64),
+                  event: WindowEvent::CloseRequested,
+                }) {
+                  log::warn!("Failed to send window close event to event channel: {}", e);
+                }
+                Inhibit(false)
+              });
+
+              let tx_clone = event_tx.clone();
+              window.connect_configure_event(move |_, event| {
+                let (x, y) = event.get_position();
+                if let Err(e) = tx_clone.send(Event::WindowEvent {
+                  window_id: RootWindowId(id),
+                  event: WindowEvent::Moved(PhysicalPosition::new(x, y)),
+                }) {
+                  log::warn!("Failed to send window moved event to event channel: {}", e);
+                }
+
+                let (w, h) = event.get_size();
+                if let Err(e) = tx_clone.send(Event::WindowEvent {
+                  window_id: RootWindowId(id),
+                  event: WindowEvent::Resized(PhysicalSize::new(w, h)),
+                }) {
+                  log::warn!(
+                    "Failed to send window resized event to event channel: {}",
+                    e
+                  );
+                }
+                false
+              });
+
+              let tx_clone = event_tx.clone();
+              window.connect_window_state_event(move |_window, event| {
+                let state = event.get_new_window_state();
+
+                if let Err(e) = tx_clone.send(Event::WindowEvent {
+                  window_id: RootWindowId(id),
+                  event: WindowEvent::Focused(state.contains(WindowState::FOCUSED)),
+                }) {
+                  log::warn!(
+                    "Failed to send window focused event to event channel: {}",
+                    e
+                  );
+                }
+                Inhibit(false)
+              });
+
+              let tx_clone = event_tx.clone();
+              window.connect_destroy_event(move |_, _| {
+                if let Err(e) = tx_clone.send(Event::WindowEvent {
+                  window_id: RootWindowId(id),
+                  event: WindowEvent::Destroyed,
+                }) {
+                  log::warn!(
+                    "Failed to send window destroyed event to event channel: {}",
+                    e
+                  );
+                }
+                Inhibit(false)
+              });
+
+              let tx_clone = event_tx.clone();
+              window.connect_enter_notify_event(move |_, _| {
+                if let Err(e) = tx_clone.send(Event::WindowEvent {
+                  window_id: RootWindowId(id),
+                  event: WindowEvent::CursorEntered {
+                    // FIXME: currently we use a dummy device id, find if we can get device id from gtk
+                    device_id: RootDeviceId(DeviceId(0)),
+                  },
+                }) {
+                  log::warn!(
+                    "Failed to send cursor entered event to event channel: {}",
+                    e
+                  );
+                }
+                Inhibit(false)
+              });
+
+              let tx_clone = event_tx.clone();
+              window.connect_motion_notify_event(move |window, _| {
+                let display = window.get_display();
+                if let Some(cursor) = display
+                  .get_device_manager()
+                  .and_then(|device_manager| device_manager.get_client_pointer())
+                {
+                  let (_, x, y) = cursor.get_position();
+                  if let Err(e) = tx_clone.send(Event::WindowEvent {
+                    window_id: RootWindowId(id),
+                    event: WindowEvent::CursorMoved {
+                      position: PhysicalPosition::new(x as f64, y as f64),
+                      // FIXME: currently we use a dummy device id, find if we can get device id from gtk
+                      device_id: RootDeviceId(DeviceId(0)),
+                      // this field is depracted so it is fine to pass empty state
+                      modifiers: ModifiersState::empty(),
+                    },
+                  }) {
+                    log::warn!("Failed to send cursor moved event to event channel: {}", e);
+                  }
+                }
+                Inhibit(false)
+              });
+
+              let tx_clone = event_tx.clone();
+              window.connect_leave_notify_event(move |_, _| {
+                if let Err(e) = tx_clone.send(Event::WindowEvent {
+                  window_id: RootWindowId(id),
+                  event: WindowEvent::CursorLeft {
+                    // FIXME: currently we use a dummy device id, find if we can get device id from gtk
+                    device_id: RootDeviceId(DeviceId(0)),
+                  },
+                }) {
+                  log::warn!("Failed to send cursor left event to event channel: {}", e);
+                }
+                Inhibit(false)
+              });
+
+              let tx_clone = event_tx.clone();
+              window.connect_button_press_event(move |_, event| {
+                let button = event.get_button();
+                if let Err(e) = tx_clone.send(Event::WindowEvent {
+                  window_id: RootWindowId(id),
+                  event: WindowEvent::MouseInput {
+                    button: match button {
+                      1 => MouseButton::Left,
+                      2 => MouseButton::Middle,
+                      3 => MouseButton::Right,
+                      _ => MouseButton::Other(button as u16),
+                    },
+                    state: ElementState::Pressed,
                     // FIXME: currently we use a dummy device id, find if we can get device id from gtk
                     device_id: RootDeviceId(DeviceId(0)),
                     // this field is depracted so it is fine to pass empty state
                     modifiers: ModifiersState::empty(),
                   },
                 }) {
-                  log::warn!("Failed to send cursor moved event to event channel: {}", e);
+                  log::warn!(
+                    "Failed to send mouse input preseed event to event channel: {}",
+                    e
+                  );
                 }
-              }
-              Inhibit(false)
-            });
+                Inhibit(false)
+              });
 
-            let tx_clone = event_tx.clone();
-            window.connect_leave_notify_event(move |_, _| {
-              if let Err(e) = tx_clone.send(Event::WindowEvent {
-                window_id: RootWindowId(id),
-                event: WindowEvent::CursorLeft {
-                  // FIXME: currently we use a dummy device id, find if we can get device id from gtk
-                  device_id: RootDeviceId(DeviceId(0)),
-                },
-              }) {
-                log::warn!("Failed to send cursor left event to event channel: {}", e);
-              }
-              Inhibit(false)
-            });
-
-            let tx_clone = event_tx.clone();
-            window.connect_button_press_event(move |_, event| {
-              let button = event.get_button();
-              if let Err(e) = tx_clone.send(Event::WindowEvent {
-                window_id: RootWindowId(id),
-                event: WindowEvent::MouseInput {
-                  button: match button {
-                    1 => MouseButton::Left,
-                    2 => MouseButton::Middle,
-                    3 => MouseButton::Right,
-                    _ => MouseButton::Other(button as u16),
+              let tx_clone = event_tx.clone();
+              window.connect_button_release_event(move |_, event| {
+                let button = event.get_button();
+                if let Err(e) = tx_clone.send(Event::WindowEvent {
+                  window_id: RootWindowId(id),
+                  event: WindowEvent::MouseInput {
+                    button: match button {
+                      1 => MouseButton::Left,
+                      2 => MouseButton::Middle,
+                      3 => MouseButton::Right,
+                      _ => MouseButton::Other(button as u16),
+                    },
+                    state: ElementState::Released,
+                    // FIXME: currently we use a dummy device id, find if we can get device id from gtk
+                    device_id: RootDeviceId(DeviceId(0)),
+                    // this field is depracted so it is fine to pass empty state
+                    modifiers: ModifiersState::empty(),
                   },
-                  state: ElementState::Pressed,
-                  // FIXME: currently we use a dummy device id, find if we can get device id from gtk
-                  device_id: RootDeviceId(DeviceId(0)),
-                  // this field is depracted so it is fine to pass empty state
-                  modifiers: ModifiersState::empty(),
-                },
-              }) {
-                log::warn!(
-                  "Failed to send mouse input preseed event to event channel: {}",
-                  e
-                );
-              }
-              Inhibit(false)
-            });
-
-            let tx_clone = event_tx.clone();
-            window.connect_button_release_event(move |_, event| {
-              let button = event.get_button();
-              if let Err(e) = tx_clone.send(Event::WindowEvent {
-                window_id: RootWindowId(id),
-                event: WindowEvent::MouseInput {
-                  button: match button {
-                    1 => MouseButton::Left,
-                    2 => MouseButton::Middle,
-                    3 => MouseButton::Right,
-                    _ => MouseButton::Other(button as u16),
-                  },
-                  state: ElementState::Released,
-                  // FIXME: currently we use a dummy device id, find if we can get device id from gtk
-                  device_id: RootDeviceId(DeviceId(0)),
-                  // this field is depracted so it is fine to pass empty state
-                  modifiers: ModifiersState::empty(),
-                },
-              }) {
-                log::warn!(
-                  "Failed to send mouse input released event to event channel: {}",
-                  e
-                );
-              }
-              Inhibit(false)
-            });
+                }) {
+                  log::warn!(
+                    "Failed to send mouse input released event to event channel: {}",
+                    e
+                  );
+                }
+                Inhibit(false)
+              });
+            }
+            WindowRequest::Redraw => window.queue_draw(),
+            WindowRequest::Close => window.close(),
           }
-          WindowRequest::Redraw => window.queue_draw(),
         }
       }
 

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -466,7 +466,13 @@ impl<T: 'static> EventLoop<T> {
               });
             }
             WindowRequest::Redraw => window.queue_draw(),
-            WindowRequest::Close => window.close(),
+            WindowRequest::Menu(m) => {
+                // TODO other MenuItem variant
+                match m {
+                    
+                    _ => window.close(),
+                }
+            },
           }
         }
       }

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -23,9 +23,9 @@ use crate::{
     WindowEvent,
   },
   event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootELW},
+  menu::{MenuId, MenuItem, MenuType},
   monitor::MonitorHandle as RootMonitorHandle,
   window::{CursorIcon, WindowId as RootWindowId},
-  menu::MenuItem
 };
 
 use super::{
@@ -468,16 +468,19 @@ impl<T: 'static> EventLoop<T> {
             }
             WindowRequest::Redraw => window.queue_draw(),
             WindowRequest::Menu(m) => {
-                // TODO other MenuItem variant
-                match m {
-                    MenuItem::Custom(c) => {
-                        if let Err(e) = event_tx.send(Event::MenuEvent(c.id)) {
-                            log::warn!("Failed to send menu event to event channel: {}", e);
-                        }
-                    } 
-                    _ => window.close(),
+              // TODO other MenuItem variant
+              match m {
+                MenuItem::Custom(c) => {
+                  if let Err(e) = event_tx.send(Event::MenuEvent {
+                    menu_id: c._id,
+                    origin: MenuType::Menubar,
+                  }) {
+                    log::warn!("Failed to send menu event to event channel: {}", e);
+                  }
                 }
-            },
+                _ => window.close(),
+              }
+            }
           }
         }
       }

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -23,7 +23,7 @@ use crate::{
     WindowEvent,
   },
   event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootELW},
-  menu::{MenuId, MenuItem, MenuType},
+  menu::{MenuItem, MenuType},
   monitor::MonitorHandle as RootMonitorHandle,
   window::{CursorIcon, WindowId as RootWindowId},
 };

--- a/src/platform_impl/linux/menu.rs
+++ b/src/platform_impl/linux/menu.rs
@@ -40,7 +40,6 @@ pub fn initialize(
         _ => MenuItem::with_label("Close Window"),
       };
 
-
       let tx_ = tx.clone();
       item.connect_activate(move |_| {
         if let Err(e) = tx_.send((id, WindowRequest::Menu(i.clone()))) {

--- a/src/platform_impl/linux/menu.rs
+++ b/src/platform_impl/linux/menu.rs
@@ -1,0 +1,45 @@
+use std::sync::mpsc::Sender;
+
+use gtk::{prelude::*, ApplicationWindow, Menu, MenuBar, MenuItem, Orientation};
+
+use super::window::{WindowId, WindowRequest};
+use crate::menu::Menu as RootMenu;
+
+pub fn initialize(
+  window: &ApplicationWindow,
+  menus: Vec<RootMenu>,
+  tx: Sender<(WindowId, WindowRequest)>,
+) {
+  let id = WindowId(window.get_id());
+  let vbox = gtk::Box::new(Orientation::Vertical, 0);
+  let menubar = MenuBar::new();
+  window.add(&vbox);
+
+  for menu in menus {
+    let title = MenuItem::with_label(&menu.title);
+    let submenu = Menu::new();
+
+    for i in menu.items {
+      let item = match i {
+        // TODO other MenuItem variant
+        _ => {
+          let item = MenuItem::with_label("Quit");
+          let tx_ = tx.clone();
+          item.connect_activate(move |_| {
+            if let Err(e) = tx_.send((id, WindowRequest::Close)) {
+              log::warn!("Fail to send close window request: {}", e);
+            }
+          });
+          item
+        }
+      };
+
+      submenu.append(&item);
+    }
+
+    title.set_submenu(Some(&submenu));
+    menubar.append(&title);
+  }
+
+  vbox.pack_start(&menubar, false, false, 0);
+}

--- a/src/platform_impl/linux/menu.rs
+++ b/src/platform_impl/linux/menu.rs
@@ -7,7 +7,7 @@ use crate::menu::{Menu as RootMenu, MenuItem as RootMenuItem};
 
 pub fn initialize(
   window: &ApplicationWindow,
-  menus: Vec<RootMenu<'_>>,
+  menus: Vec<RootMenu<'static>>,
   tx: Sender<(WindowId, WindowRequest)>,
 ) {
   let id = WindowId(window.get_id());

--- a/src/platform_impl/linux/menu.rs
+++ b/src/platform_impl/linux/menu.rs
@@ -7,7 +7,7 @@ use crate::menu::{Menu as RootMenu, MenuItem as RootMenuItem};
 
 pub fn initialize(
   window: &ApplicationWindow,
-  menus: Vec<RootMenu>,
+  menus: Vec<RootMenu<'_>>,
   tx: Sender<(WindowId, WindowRequest)>,
 ) {
   let id = WindowId(window.get_id());

--- a/src/platform_impl/linux/menu.rs
+++ b/src/platform_impl/linux/menu.rs
@@ -7,7 +7,7 @@ use crate::menu::{Menu as RootMenu, MenuItem as RootMenuItem};
 
 pub fn initialize(
   window: &ApplicationWindow,
-  menus: Vec<RootMenu<'static>>,
+  menus: Vec<RootMenu>,
   tx: Sender<(WindowId, WindowRequest)>,
 ) {
   let id = WindowId(window.get_id());

--- a/src/platform_impl/linux/menu.rs
+++ b/src/platform_impl/linux/menu.rs
@@ -3,7 +3,7 @@ use std::sync::mpsc::Sender;
 use gtk::{prelude::*, ApplicationWindow, Menu, MenuBar, MenuItem, Orientation};
 
 use super::window::{WindowId, WindowRequest};
-use crate::menu::Menu as RootMenu;
+use crate::menu::{Menu as RootMenu, MenuItem as RootMenuItem};
 
 pub fn initialize(
   window: &ApplicationWindow,
@@ -20,19 +20,33 @@ pub fn initialize(
     let submenu = Menu::new();
 
     for i in menu.items {
-      let item = match i {
-        // TODO other MenuItem variant
-        _ => {
-          let item = MenuItem::with_label("Quit");
-          let tx_ = tx.clone();
-          item.connect_activate(move |_| {
-            if let Err(e) = tx_.send((id, WindowRequest::Close)) {
-              log::warn!("Fail to send close window request: {}", e);
-            }
-          });
-          item
-        }
+      let item = match &i {
+        RootMenuItem::Custom(m) => MenuItem::with_label(&m.name),
+        RootMenuItem::About(s) => MenuItem::with_label(&format!("About {}", s)),
+        RootMenuItem::Hide => MenuItem::with_label("Hide"),
+        RootMenuItem::Services => MenuItem::with_label("Services"),
+        RootMenuItem::HideOthers => MenuItem::with_label("Hide Others"),
+        RootMenuItem::ShowAll => MenuItem::with_label("Show All"),
+        RootMenuItem::CloseWindow => MenuItem::with_label("Close Window"),
+        RootMenuItem::Quit => MenuItem::with_label("Quit"),
+        RootMenuItem::Copy => MenuItem::with_label("Copy"),
+        RootMenuItem::Cut => MenuItem::with_label("Cut"),
+        RootMenuItem::Undo => MenuItem::with_label("Undo"),
+        RootMenuItem::Redo => MenuItem::with_label("Redo"),
+        RootMenuItem::SelectAll => MenuItem::with_label("Select All"),
+        RootMenuItem::Paste => MenuItem::with_label("Paste"),
+        RootMenuItem::Zoom => MenuItem::with_label("Zoom"),
+        RootMenuItem::Separator => MenuItem::with_label("Separator"),
+        _ => MenuItem::with_label("Close Window"),
       };
+
+
+      let tx_ = tx.clone();
+      item.connect_activate(move |_| {
+        if let Err(e) = tx_.send((id, WindowRequest::Menu(i.clone()))) {
+          log::warn!("Fail to send menu request: {}", e);
+        }
+      });
 
       submenu.append(&item);
     }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -7,6 +7,7 @@
 ))]
 
 mod event_loop;
+mod menu;
 mod monitor;
 mod window;
 

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -604,7 +604,7 @@ pub enum WindowRequest {
   CursorIcon(Option<CursorIcon>),
   WireUpEvents,
   Redraw,
-  Menu(MenuItem<'static>),
+  Menu(MenuItem),
 }
 
 pub fn hit_test(window: &gdk::Window, cx: f64, cy: f64) -> WindowEdge {

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -411,7 +411,7 @@ impl Window {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   pub fn set_menu(&self, _menu: Option<Vec<Menu<'_>>>) {
     debug!("`Window::set_menu` is ignored on linux")

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -21,9 +21,9 @@ use crate::{
   dpi::{PhysicalPosition, PhysicalSize, Position, Size},
   error::{ExternalError, NotSupportedError, OsError as RootOsError},
   icon::{BadIcon, Icon},
+  menu::Menu,
   monitor::MonitorHandle as RootMonitorHandle,
   window::{CursorIcon, Fullscreen, UserAttentionType, WindowAttributes},
-  menu::Menu,
 };
 
 use super::{event_loop::EventLoopWindowTarget, monitor::MonitorHandle};
@@ -403,6 +403,12 @@ impl Window {
     }
   }
 
+  /// Set menu
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   pub fn set_menu(&self, _menu: Option<Vec<Menu>>) {
     debug!("`Window::set_menu` is ignored on linux")
   }

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -413,7 +413,7 @@ impl Window {
   ///
   /// - **Windows/Linux:** Unsupported (noop).
   ///
-  pub fn set_menu(&self, _menu: Option<Vec<Menu>>) {
+  pub fn set_menu(&self, _menu: Option<Vec<Menu<'_>>>) {
     debug!("`Window::set_menu` is ignored on linux")
   }
 

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -23,6 +23,7 @@ use crate::{
   icon::{BadIcon, Icon},
   monitor::MonitorHandle as RootMonitorHandle,
   window::{CursorIcon, Fullscreen, UserAttentionType, WindowAttributes},
+  menu::Menu,
 };
 
 use super::{event_loop::EventLoopWindowTarget, monitor::MonitorHandle};
@@ -400,6 +401,10 @@ impl Window {
     {
       log::warn!("Fail to send title request: {}", e);
     }
+  }
+
+  pub fn set_menu(&self, _menu: Option<Vec<Menu>>) {
+    debug!("`Window::set_menu` is ignored on linux")
   }
 
   pub fn set_visible(&self, visible: bool) {

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -21,7 +21,7 @@ use crate::{
   dpi::{PhysicalPosition, PhysicalSize, Position, Size},
   error::{ExternalError, NotSupportedError, OsError as RootOsError},
   icon::{BadIcon, Icon},
-  menu::Menu,
+  menu::{Menu, MenuItem},
   monitor::MonitorHandle as RootMonitorHandle,
   window::{CursorIcon, Fullscreen, UserAttentionType, WindowAttributes},
 };
@@ -604,7 +604,7 @@ pub enum WindowRequest {
   CursorIcon(Option<CursorIcon>),
   WireUpEvents,
   Redraw,
-  Close,
+  Menu(MenuItem),
 }
 
 pub fn hit_test(window: &gdk::Window, cx: f64, cy: f64) -> WindowEdge {

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -413,7 +413,7 @@ impl Window {
   ///
   /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
-  pub fn set_menu(&self, _menu: Option<Vec<Menu<'_>>>) {
+  pub fn set_menu(&self, _menu: Option<Vec<Menu>>) {
     debug!("`Window::set_menu` is ignored on linux")
   }
 

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -604,7 +604,7 @@ pub enum WindowRequest {
   CursorIcon(Option<CursorIcon>),
   WireUpEvents,
   Redraw,
-  Menu(MenuItem),
+  Menu(MenuItem<'static>),
 }
 
 pub fn hit_test(window: &gdk::Window, cx: f64, cy: f64) -> WindowEdge {

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -31,7 +31,6 @@ use crate::{
     platform::{
       event::{EventProxy, EventWrapper},
       event_loop::{post_dummy_event, PanicInfo},
-      menu,
       observer::{CFRunLoopGetMain, CFRunLoopWakeUp, EventLoopWaker},
       util::{IdRef, Never},
       window::get_window_id,
@@ -287,12 +286,6 @@ impl AppState {
     };
     HANDLER.set_ready();
     HANDLER.waker().start();
-    let create_default_menu = unsafe { get_aux_state_mut(app_delegate).create_default_menu };
-    if create_default_menu {
-      // The menubar initialization should be before the `NewEvents` event, to allow
-      // overriding of the default menu even if it's created
-      menu::initialize();
-    }
     HANDLER.set_in_callback(true);
     HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::NewEvents(
       StartCause::Init,

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -26,7 +26,7 @@ struct KeyEquivalent<'a> {
 #[derive(Debug)]
 struct Action(Box<u32>);
 
-pub fn initialize(menu: Vec<Menu<'_>>) {
+pub fn initialize(menu: Vec<Menu>) {
   autoreleasepool(|| unsafe {
     let menubar = NSMenu::new(nil).autorelease();
 

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -1,6 +1,8 @@
-use cocoa::appkit::{NSApp, NSApplication, NSEventModifierFlags, NSMenu, NSMenuItem};
-use cocoa::base::{id, nil, selector};
-use cocoa::foundation::{NSAutoreleasePool, NSString};
+use cocoa::{
+  appkit::{NSApp, NSApplication, NSEventModifierFlags, NSMenu, NSMenuItem},
+  base::{id, nil, selector},
+  foundation::{NSAutoreleasePool, NSString},
+};
 use objc::{
   declare::ClassDecl,
   rc::autoreleasepool,
@@ -8,8 +10,10 @@ use objc::{
 };
 use std::sync::Once;
 
-use crate::event::Event;
-use crate::menu::{Menu, MenuItem};
+use crate::{
+  event::Event,
+  menu::{Menu, MenuItem},
+};
 
 use super::{app_state::AppState, event::EventWrapper};
 

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -206,7 +206,7 @@ pub unsafe fn set_title_async(ns_window: id, title: String) {
 }
 
 // `setMenu:` isn't thread-safe.
-pub unsafe fn set_menu_async(_ns_window: id, menu: Option<Vec<Menu<'static>>>) {
+pub unsafe fn set_menu_async(_ns_window: id, menu: Option<Vec<Menu>>) {
   // todo: if None we should set an empty menu maybe?
   // on windows we can remove it, in macOS we can't
   if let Some(menu) = menu {

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -206,7 +206,7 @@ pub unsafe fn set_title_async(ns_window: id, title: String) {
 }
 
 // `setMenu:` isn't thread-safe.
-pub unsafe fn set_menu_async(_ns_window: id, menu: Option<Vec<Menu>>) {
+pub unsafe fn set_menu_async(_ns_window: id, menu: Option<Vec<Menu<'static>>>) {
   // todo: if None we should set an empty menu maybe?
   // on windows we can remove it, in macOS we can't
   if let Some(menu) = menu {

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -13,7 +13,8 @@ use objc::{rc::autoreleasepool, runtime::NO};
 
 use crate::{
   dpi::LogicalSize,
-  platform_impl::platform::{ffi, util::IdRef, window::SharedState},
+  menu::Menu,
+  platform_impl::platform::{ffi, menu, util::IdRef, window::SharedState},
 };
 
 // Unsafe wrapper type that allows us to dispatch things that aren't Send.
@@ -202,6 +203,17 @@ pub unsafe fn set_title_async(ns_window: id, title: String) {
     let title = IdRef::new(NSString::alloc(nil).init_str(&title));
     ns_window.setTitle_(*title);
   });
+}
+
+// `setMenu:` isn't thread-safe.
+pub unsafe fn set_menu_async(_ns_window: id, menu: Option<Vec<Menu>>) {
+  // todo: if None we should set an empty menu maybe?
+  // on windows we can remove it, in macOS we can't
+  if let Some(menu) = menu {
+    Queue::main().exec_async(move || {
+      menu::initialize(menu);
+    });
+  }
 }
 
 // `close:` is thread-safe, but we want the event to be triggered from the main

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -444,7 +444,7 @@ impl UnownedWindow {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
   pub fn set_menu(&self, menu: Option<Vec<Menu<'static>>>) {
     unsafe {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -15,11 +15,12 @@ use crate::{
   },
   error::{ExternalError, NotSupportedError, OsError as RootOsError},
   icon::Icon,
+  menu::Menu,
   monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
   platform::macos::WindowExtMacOS,
   platform_impl::platform::{
     app_state::{AppState, INTERRUPT_EVENT_LOOP_EXIT},
-    ffi,
+    ffi, menu,
     monitor::{self, MonitorHandle, VideoMode},
     util::{self, IdRef},
     view::{self, new_view, CursorState},
@@ -230,6 +231,9 @@ fn create_window(
       if attrs.position.is_none() {
         ns_window.center();
       }
+      if let Some(window_menu) = attrs.window_menu.clone() {
+        menu::initialize(window_menu);
+      }
       ns_window
     });
     pool.drain();
@@ -433,6 +437,12 @@ impl UnownedWindow {
   pub fn set_title(&self, title: &str) {
     unsafe {
       util::set_title_async(*self.ns_window, title.to_string());
+    }
+  }
+
+  pub fn set_menu(&self, menu: Option<Vec<Menu>>) {
+    unsafe {
+      util::set_menu_async(*self.ns_window, menu);
     }
   }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -446,7 +446,7 @@ impl UnownedWindow {
   ///
   /// - **Windows/Linux:** Unsupported (noop).
   ///
-  pub fn set_menu(&self, menu: Option<Vec<Menu>>) {
+  pub fn set_menu(&self, menu: Option<Vec<Menu<'static>>>) {
     unsafe {
       util::set_menu_async(*self.ns_window, menu);
     }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -446,7 +446,7 @@ impl UnownedWindow {
   ///
   /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///
-  pub fn set_menu(&self, menu: Option<Vec<Menu<'static>>>) {
+  pub fn set_menu(&self, menu: Option<Vec<Menu>>) {
     unsafe {
       util::set_menu_async(*self.ns_window, menu);
     }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -440,6 +440,12 @@ impl UnownedWindow {
     }
   }
 
+  /// Set menu
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///
   pub fn set_menu(&self, menu: Option<Vec<Menu>>) {
     unsafe {
       util::set_menu_async(*self.ns_window, menu);

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -1,0 +1,192 @@
+use raw_window_handle::RawWindowHandle;
+use std::os::windows::ffi::OsStrExt;
+use winapi::{
+  ctypes::c_void,
+  shared::{
+    basetsd,
+    guiddef::REFIID,
+    minwindef,
+    minwindef::{DWORD, UINT, ULONG},
+    windef,
+    windef::{HWND, POINTL},
+    winerror::S_OK,
+  },
+  um::{
+    commctrl,
+    objidl::IDataObject,
+    oleidl::{IDropTarget, IDropTargetVtbl, DROPEFFECT_COPY, DROPEFFECT_NONE},
+    shellapi, unknwnbase,
+    winnt::HRESULT,
+    winuser,
+  },
+};
+
+use std::{
+  cell::RefCell,
+  collections::HashMap,
+  ptr,
+  sync::atomic::{AtomicUsize, Ordering},
+};
+
+use crate::menu::{Menu, MenuItem};
+use crate::{event::Event, window::WindowId as SuperWindowId};
+
+pub struct MenuHandler {
+  window: HWND,
+  send_event: Box<dyn Fn(Event<'static, ()>)>,
+}
+
+thread_local! {
+  static MENU_INDEX: RefCell<u32> = RefCell::new(1);
+  static MENU_MAP: RefCell<HashMap<u32, String>> = RefCell::new(HashMap::new());
+}
+
+#[allow(non_snake_case)]
+impl MenuHandler {
+  pub fn new(window: HWND, send_event: Box<dyn Fn(Event<'static, ()>)>) -> MenuHandler {
+    MenuHandler { window, send_event }
+  }
+  fn send_click_event(&self, menu_id: u32) {
+    MENU_MAP.with(|cell| {
+      let current_hash_map = cell.borrow();
+      if let Some(real_menu_id) = current_hash_map.get(&menu_id) {
+        (self.send_event)(Event::MenuEvent(real_menu_id.to_string()));
+      }
+    });
+  }
+}
+
+pub fn initialize(menu: Vec<Menu>, window_handle: RawWindowHandle, menu_handler: MenuHandler) {
+  if let RawWindowHandle::Windows(handle) = window_handle {
+    let sender: *mut MenuHandler = Box::into_raw(Box::new(menu_handler));
+
+    unsafe {
+      commctrl::SetWindowSubclass(
+        handle.hwnd as *mut _,
+        Some(subclass_proc),
+        0,
+        sender as basetsd::DWORD_PTR,
+      );
+
+      let app_menu = winuser::CreateMenu();
+      let mut main_menu_position = 0;
+      for menu in menu {
+        let sub_menu = winuser::CreateMenu();
+        let mut sub_menu_position = 0;
+        for item in &menu.items {
+          let sub_item = match item {
+            MenuItem::Custom(custom_menu) => {
+              // it's a custom menu, let's add it to our hashmap
+              let mut current_id = 0;
+              MENU_INDEX.with(|cell| {
+                current_id = cell.replace_with(|&mut i| i + 1);
+              });
+
+              // save our reference to match later in the click event
+              MENU_MAP.with(|cell| {
+                cell.borrow_mut().insert(current_id, custom_menu.id.clone());
+              });
+
+              make_menu_item(Some(current_id.clone()), custom_menu.name.as_str())
+            }
+            MenuItem::Separator => None,
+            MenuItem::About(_app_name) => make_menu_item(None, "About"),
+            MenuItem::CloseWindow => make_menu_item(None, "Close"),
+            MenuItem::Quit => make_menu_item(None, "Quit"),
+            MenuItem::Hide => make_menu_item(None, "Hide"),
+            MenuItem::HideOthers => make_menu_item(None, "Hide Others"),
+            MenuItem::ShowAll => make_menu_item(None, "Show All"),
+            MenuItem::EnterFullScreen => make_menu_item(None, "Enter Full Screen"),
+            MenuItem::Minimize => make_menu_item(None, "Minimize"),
+            MenuItem::Zoom => make_menu_item(None, "Zoom"),
+            MenuItem::Copy => make_menu_item(None, "Copy"),
+            MenuItem::Cut => make_menu_item(None, "Cut"),
+            MenuItem::Paste => make_menu_item(None, "Paste"),
+            MenuItem::Undo => make_menu_item(None, "Undo"),
+            MenuItem::Redo => make_menu_item(None, "Redo"),
+            MenuItem::SelectAll => make_menu_item(None, "Select All"),
+            MenuItem::Services => None,
+          };
+          if let Some(sub_item) = sub_item {
+            sub_menu_position += 1;
+            winuser::InsertMenuItemW(sub_menu, sub_menu_position, 0, &sub_item as *const _);
+          }
+        }
+
+        let item = winuser::MENUITEMINFOW {
+          cbSize: std::mem::size_of::<winuser::MENUITEMINFOW>() as u32,
+          fMask: winuser::MIIM_STRING | winuser::MIIM_SUBMENU,
+          fType: winuser::MFT_STRING,
+          fState: winuser::MFS_ENABLED,
+          wID: 0,
+          hSubMenu: sub_menu,
+          hbmpChecked: std::ptr::null_mut(),
+          hbmpUnchecked: std::ptr::null_mut(),
+          dwItemData: 0,
+          dwTypeData: to_wstring(&menu.title).as_mut_ptr(),
+          cch: 5,
+          hbmpItem: std::ptr::null_mut(),
+        };
+        main_menu_position += 1;
+        winuser::InsertMenuItemW(app_menu, main_menu_position, 0, &item as *const _);
+      }
+
+      winuser::SetMenu(handle.hwnd as *mut _, app_menu);
+    }
+  }
+}
+
+fn make_menu_item(id: Option<u32>, title: &str) -> Option<winuser::MENUITEMINFOW> {
+  let mut real_id = 0;
+  if let Some(id) = id {
+    real_id = id;
+  }
+
+  Some(winuser::MENUITEMINFOW {
+    cbSize: std::mem::size_of::<winuser::MENUITEMINFOW>() as u32,
+    fMask: winuser::MIIM_STRING | winuser::MIIM_ID,
+    fType: winuser::MFT_STRING,
+    fState: winuser::MFS_ENABLED,
+    // Received on low-word of wParam when WM_COMMAND
+    // It represent the unique menu ID
+    wID: real_id,
+    hSubMenu: std::ptr::null_mut(),
+    hbmpChecked: std::ptr::null_mut(),
+    hbmpUnchecked: std::ptr::null_mut(),
+    dwItemData: 0,
+    dwTypeData: to_wstring(title).as_mut_ptr(),
+    cch: 5,
+    hbmpItem: std::ptr::null_mut(),
+  })
+}
+
+fn to_wstring(str: &str) -> Vec<u16> {
+  let v: Vec<u16> = std::ffi::OsStr::new(str)
+    .encode_wide()
+    .chain(Some(0).into_iter())
+    .collect();
+  v
+}
+
+unsafe extern "system" fn subclass_proc(
+  hwnd: windef::HWND,
+  u_msg: minwindef::UINT,
+  w_param: minwindef::WPARAM,
+  l_param: minwindef::LPARAM,
+  _id: basetsd::UINT_PTR,
+  data: basetsd::DWORD_PTR,
+) -> minwindef::LRESULT {
+  match u_msg {
+    winuser::WM_COMMAND => {
+      let proxy = &mut *(data as *mut MenuHandler);
+      let lo_word = minwindef::LOWORD(w_param as u32);
+      proxy.send_click_event(lo_word.into());
+      0
+    }
+    winuser::WM_DESTROY => {
+      Box::from_raw(data as *mut MenuHandler);
+      0
+    }
+    _ => commctrl::DefSubclassProc(hwnd, u_msg, w_param, l_param),
+  }
+}

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -1,7 +1,7 @@
 use raw_window_handle::RawWindowHandle;
 use std::os::windows::ffi::OsStrExt;
 use winapi::{
-  shared::{basetsd, minwindef, windef, windef::HWND},
+  shared::{basetsd, minwindef, windef},
   um::{commctrl, winuser},
 };
 
@@ -10,11 +10,9 @@ use std::{cell::RefCell, collections::HashMap};
 use crate::{
   event::Event,
   menu::{Menu, MenuItem},
-  window::WindowId as SuperWindowId,
 };
 
 pub struct MenuHandler {
-  window: HWND,
   send_event: Box<dyn Fn(Event<'static, ()>)>,
 }
 
@@ -25,8 +23,8 @@ thread_local! {
 
 #[allow(non_snake_case)]
 impl MenuHandler {
-  pub fn new(window: HWND, send_event: Box<dyn Fn(Event<'static, ()>)>) -> MenuHandler {
-    MenuHandler { window, send_event }
+  pub fn new(send_event: Box<dyn Fn(Event<'static, ()>)>) -> MenuHandler {
+    MenuHandler { send_event }
   }
   fn send_click_event(&self, menu_id: u32) {
     MENU_MAP.with(|cell| {

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -1,32 +1,11 @@
 use raw_window_handle::RawWindowHandle;
 use std::os::windows::ffi::OsStrExt;
 use winapi::{
-  ctypes::c_void,
-  shared::{
-    basetsd,
-    guiddef::REFIID,
-    minwindef,
-    minwindef::{DWORD, UINT, ULONG},
-    windef,
-    windef::{HWND, POINTL},
-    winerror::S_OK,
-  },
-  um::{
-    commctrl,
-    objidl::IDataObject,
-    oleidl::{IDropTarget, IDropTargetVtbl, DROPEFFECT_COPY, DROPEFFECT_NONE},
-    shellapi, unknwnbase,
-    winnt::HRESULT,
-    winuser,
-  },
+  shared::{basetsd, minwindef, windef, windef::HWND},
+  um::{commctrl, winuser},
 };
 
-use std::{
-  cell::RefCell,
-  collections::HashMap,
-  ptr,
-  sync::atomic::{AtomicUsize, Ordering},
-};
+use std::{cell::RefCell, collections::HashMap};
 
 use crate::menu::{Menu, MenuItem};
 use crate::{event::Event, window::WindowId as SuperWindowId};
@@ -89,23 +68,8 @@ pub fn initialize(menu: Vec<Menu>, window_handle: RawWindowHandle, menu_handler:
 
               make_menu_item(Some(current_id.clone()), custom_menu.name.as_str())
             }
-            MenuItem::Separator => None,
-            MenuItem::About(_app_name) => make_menu_item(None, "About"),
-            MenuItem::CloseWindow => make_menu_item(None, "Close"),
-            MenuItem::Quit => make_menu_item(None, "Quit"),
-            MenuItem::Hide => make_menu_item(None, "Hide"),
-            MenuItem::HideOthers => make_menu_item(None, "Hide Others"),
-            MenuItem::ShowAll => make_menu_item(None, "Show All"),
-            MenuItem::EnterFullScreen => make_menu_item(None, "Enter Full Screen"),
-            MenuItem::Minimize => make_menu_item(None, "Minimize"),
-            MenuItem::Zoom => make_menu_item(None, "Zoom"),
-            MenuItem::Copy => make_menu_item(None, "Copy"),
-            MenuItem::Cut => make_menu_item(None, "Cut"),
-            MenuItem::Paste => make_menu_item(None, "Paste"),
-            MenuItem::Undo => make_menu_item(None, "Undo"),
-            MenuItem::Redo => make_menu_item(None, "Redo"),
-            MenuItem::SelectAll => make_menu_item(None, "Select All"),
-            MenuItem::Services => None,
+            // Let's support only custom menu in windows for now
+            _ => None,
           };
           if let Some(sub_item) = sub_item {
             sub_menu_position += 1;

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -7,8 +7,11 @@ use winapi::{
 
 use std::{cell::RefCell, collections::HashMap};
 
-use crate::menu::{Menu, MenuItem};
-use crate::{event::Event, window::WindowId as SuperWindowId};
+use crate::{
+  event::Event,
+  menu::{Menu, MenuItem},
+  window::WindowId as SuperWindowId,
+};
 
 pub struct MenuHandler {
   window: HWND,

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -27,7 +27,7 @@ impl MenuHandler {
   }
 }
 
-pub fn initialize(menu: Vec<Menu<'_>>, window_handle: RawWindowHandle, menu_handler: MenuHandler) {
+pub fn initialize(menu: Vec<Menu>, window_handle: RawWindowHandle, menu_handler: MenuHandler) {
   if let RawWindowHandle::Windows(handle) = window_handle {
     let sender: *mut MenuHandler = Box::into_raw(Box::new(menu_handler));
 

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -1,4 +1,5 @@
 use raw_window_handle::RawWindowHandle;
+use std::os::windows::ffi::OsStrExt;
 use winapi::{
   shared::{basetsd, minwindef, windef},
   um::{commctrl, winuser},

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -7,7 +7,7 @@ use winapi::{
 
 use crate::{
   event::Event,
-  menu::{Menu, MenuItem, MenuId, MenuType},
+  menu::{Menu, MenuId, MenuItem, MenuType},
 };
 
 pub struct MenuHandler {
@@ -46,7 +46,9 @@ pub fn initialize(menu: Vec<Menu<'_>>, window_handle: RawWindowHandle, menu_hand
         let mut sub_menu_position = 0;
         for item in &menu.items {
           let sub_item = match item {
-            MenuItem::Custom(custom_menu) => make_menu_item(Some(custom_menu._id.0), custom_menu.name),
+            MenuItem::Custom(custom_menu) => {
+              make_menu_item(Some(custom_menu._id.0), custom_menu.name)
+            }
             // Let's support only custom menu in windows for now
             _ => None,
           };

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -15,6 +15,7 @@ pub use self::{
 pub use self::icon::WinIcon as PlatformIcon;
 
 use crate::{event::DeviceId as RootDeviceId, icon::Icon, window::Theme};
+mod menu;
 
 #[derive(Clone)]
 pub enum Parent {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -142,7 +142,7 @@ impl Window {
   /// - **Windows/Linux:** Unsupported (noop).
   ///  
   // todo(lemarier): allow menu update
-  pub fn set_menu(&self, new_menu: Option<Vec<Menu>>) {}
+  pub fn set_menu(&self, _new_menu: Option<Vec<Menu>>) {}
 
   #[inline]
   pub fn set_visible(&self, visible: bool) {
@@ -855,14 +855,11 @@ unsafe fn init<T: 'static>(
     let event_loop_runner = event_loop.runner_shared.clone();
     let window_handle = win.raw_window_handle();
 
-    let menu_handler = menu::MenuHandler::new(
-      win.window.0,
-      Box::new(move |event| {
-        if let Ok(e) = event.map_nonuser_event() {
-          event_loop_runner.send_event(e)
-        }
-      }),
-    );
+    let menu_handler = menu::MenuHandler::new(Box::new(move |event| {
+      if let Ok(e) = event.map_nonuser_event() {
+        event_loop_runner.send_event(e)
+      }
+    }));
 
     menu::initialize(window_menu, window_handle, menu_handler);
   }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -139,7 +139,7 @@ impl Window {
   ///
   /// ## Platform-specific
   ///
-  /// - **Windows/Linux:** Unsupported (noop).
+  /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///  
   // todo(lemarier): allow menu update
   pub fn set_menu(&self, _new_menu: Option<Vec<Menu<'_>>>) {}

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -135,7 +135,12 @@ impl Window {
     }
   }
 
-  /// Noop on windows
+  /// Set menu
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows/Linux:** Unsupported (noop).
+  ///  
   // todo(lemarier): allow menu update
   pub fn set_menu(&self, new_menu: Option<Vec<Menu>>) {}
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -142,7 +142,7 @@ impl Window {
   /// - **Windows / Linux / Android / iOS:** Unsupported (noop).
   ///  
   // todo(lemarier): allow menu update
-  pub fn set_menu(&self, _new_menu: Option<Vec<Menu<'_>>>) {}
+  pub fn set_menu(&self, _new_menu: Option<Vec<Menu>>) {}
 
   #[inline]
   pub fn set_visible(&self, visible: bool) {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -35,6 +35,7 @@ use crate::{
   dpi::{PhysicalPosition, PhysicalSize, Position, Size},
   error::{ExternalError, NotSupportedError, OsError as RootOsError},
   icon::Icon,
+  menu::Menu,
   monitor::MonitorHandle as RootMonitorHandle,
   platform_impl::platform::{
     dark_mode::try_theme,
@@ -42,7 +43,7 @@ use crate::{
     drop_handler::FileDropHandler,
     event_loop::{self, EventLoopWindowTarget, DESTROY_MSG_ID},
     icon::{self, IconType},
-    monitor, util,
+    menu, monitor, util,
     window_state::{CursorFlags, SavedWindow, WindowFlags, WindowState},
     Parent, PlatformSpecificWindowBuilderAttributes, WindowId,
   },
@@ -133,6 +134,10 @@ impl Window {
       winuser::SetWindowTextW(self.window.0, text.as_ptr() as LPCWSTR);
     }
   }
+
+  /// Noop on windows
+  // todo(lemarier): allow menu update
+  pub fn set_menu(&self, new_menu: Option<Vec<Menu>>) {}
 
   #[inline]
   pub fn set_visible(&self, visible: bool) {
@@ -839,6 +844,22 @@ unsafe fn init<T: 'static>(
 
   if let Some(position) = attributes.position {
     win.set_outer_position(position);
+  }
+
+  if let Some(window_menu) = attributes.window_menu {
+    let event_loop_runner = event_loop.runner_shared.clone();
+    let window_handle = win.raw_window_handle();
+
+    let menu_handler = menu::MenuHandler::new(
+      win.window.0,
+      Box::new(move |event| {
+        if let Ok(e) = event.map_nonuser_event() {
+          event_loop_runner.send_event(e)
+        }
+      }),
+    );
+
+    menu::initialize(window_menu, window_handle, menu_handler);
   }
 
   Ok(win)

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -142,7 +142,7 @@ impl Window {
   /// - **Windows/Linux:** Unsupported (noop).
   ///  
   // todo(lemarier): allow menu update
-  pub fn set_menu(&self, _new_menu: Option<Vec<Menu>>) {}
+  pub fn set_menu(&self, _new_menu: Option<Vec<Menu<'_>>>) {}
 
   #[inline]
   pub fn set_visible(&self, visible: bool) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -193,7 +193,7 @@ pub struct WindowAttributes {
   /// The window menu.
   ///
   /// The default is `None`.
-  pub window_menu: Option<Vec<Menu<'static>>>,
+  pub window_menu: Option<Vec<Menu>>,
 }
 
 impl Default for WindowAttributes {
@@ -297,7 +297,7 @@ impl WindowBuilder {
   ///
   /// [`Window::set_menu`]: crate::window::Window::set_menu
   #[inline]
-  pub fn with_menu<M: Into<Vec<Menu<'static>>>>(mut self, menu: M) -> Self {
+  pub fn with_menu<M: Into<Vec<Menu>>>(mut self, menu: M) -> Self {
     self.window.window_menu = Some(menu.into());
     self
   }
@@ -592,7 +592,7 @@ impl Window {
   /// - **Windows:** Unsupported.
 
   #[inline]
-  pub fn set_menu(&self, menu: Option<Vec<Menu<'static>>>) {
+  pub fn set_menu(&self, menu: Option<Vec<Menu>>) {
     self.window.set_menu(menu)
   }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -5,6 +5,7 @@ use crate::{
   dpi::{PhysicalPosition, PhysicalSize, Position, Size},
   error::{ExternalError, NotSupportedError, OsError},
   event_loop::EventLoopWindowTarget,
+  menu::Menu,
   monitor::{MonitorHandle, VideoMode},
   platform_impl,
 };
@@ -188,6 +189,11 @@ pub struct WindowAttributes {
   ///
   /// The default is `None`.
   pub window_icon: Option<Icon>,
+
+  /// The window menu.
+  ///
+  /// The default is `None`.
+  pub window_menu: Option<Vec<Menu>>,
 }
 
 impl Default for WindowAttributes {
@@ -207,6 +213,7 @@ impl Default for WindowAttributes {
       decorations: true,
       always_on_top: false,
       window_icon: None,
+      window_menu: None,
     }
   }
 }
@@ -281,6 +288,17 @@ impl WindowBuilder {
   #[inline]
   pub fn with_title<T: Into<String>>(mut self, title: T) -> Self {
     self.window.title = title.into();
+    self
+  }
+
+  /// Requests a specific title for the window.
+  ///
+  /// See [`Window::set_menu`] for details.
+  ///
+  /// [`Window::set_menu`]: crate::window::Window::set_menu
+  #[inline]
+  pub fn with_menu<M: Into<Vec<Menu>>>(mut self, menu: M) -> Self {
+    self.window.window_menu = Some(menu.into());
     self
   }
 
@@ -566,6 +584,17 @@ impl Window {
   #[inline]
   pub fn set_title(&self, title: &str) {
     self.window.set_title(title)
+  }
+
+  /// Modifies the menu of the window.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Windows:** Unsupported.
+
+  #[inline]
+  pub fn set_menu(&self, menu: Option<Vec<Menu>>) {
+    self.window.set_menu(menu)
   }
 
   /// Modifies the window's visibility.

--- a/src/window.rs
+++ b/src/window.rs
@@ -193,7 +193,7 @@ pub struct WindowAttributes {
   /// The window menu.
   ///
   /// The default is `None`.
-  pub window_menu: Option<Vec<Menu>>,
+  pub window_menu: Option<Vec<Menu<'static>>>,
 }
 
 impl Default for WindowAttributes {
@@ -297,7 +297,7 @@ impl WindowBuilder {
   ///
   /// [`Window::set_menu`]: crate::window::Window::set_menu
   #[inline]
-  pub fn with_menu<M: Into<Vec<Menu>>>(mut self, menu: M) -> Self {
+  pub fn with_menu<M: Into<Vec<Menu<'static>>>>(mut self, menu: M) -> Self {
     self.window.window_menu = Some(menu.into());
     self
   }
@@ -592,7 +592,7 @@ impl Window {
   /// - **Windows:** Unsupported.
 
   #[inline]
-  pub fn set_menu(&self, menu: Option<Vec<Menu>>) {
+  pub fn set_menu(&self, menu: Option<Vec<Menu<'static>>>) {
     self.window.set_menu(menu)
   }
 


### PR DESCRIPTION
Implement basic menu builder for macOS and windows.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that have not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Basic menu builder for windows, macOS and Linux.
<s>I've checked Linux and it shouldn't be hard to add. I think it shouldn't be a blocker to get started with `wry` integration as it uses the same struct and</s> right now it's a simple `noop` like ios and android.

### API

Please see the [example](https://github.com/tauri-apps/tao/blob/feat/menu-bar/examples/custom_menu.rs#L15-L61)

In macOS, it uses the latest registered menu, if you open 2 windows with different menus, the latest window opened will be the application menu.

Declaring [custom menu](https://github.com/tauri-apps/tao/blob/feat/menu-bar/examples/custom_menu.rs#L55-L59) can include an accelerator (keyboard shortcut). (only supported on macOS right now -- windows seems quite complex) 

Customs menu is supported on Windows and macOS.

The menu builder exposes pre-defined menu action and they are only supported on macOS for now. 
In windows, nothing is rendered.

Click [events](https://github.com/tauri-apps/tao/blob/feat/menu-bar/examples/custom_menu.rs#L78-L93) are sent into the event loop with the `unique_menu_id` declared when we [create a custom menu](https://github.com/tauri-apps/tao/blob/feat/menu-bar/examples/custom_menu.rs#L33)

I think in wry maybe we should provide a default menu for macOS, to include copy, paste, select all, etc... to fix keyboard shortcuts, but the user can overwrite it? In windows, we can make it optional.

### Run the example
```
cargo run --example custom_menu
```

### macOS
https://user-images.githubusercontent.com/22237916/117036350-54759100-acd3-11eb-9008-8233dd0dbaa4.mov

### Windows
https://user-images.githubusercontent.com/22237916/117037201-352b3380-acd4-11eb-9a7a-7db5fdd71bed.mov