### PR TITLE
add `is_decorated` getter on `Window`

### DIFF
--- a/.changes/is-decorated.md
+++ b/.changes/is-decorated.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Add `is_decorated` getter on `Window`

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -512,7 +512,7 @@ impl Window {
     false
   }
   pub fn is_decorated(&self) -> bool {
-    warn!("`Window::is_maximized` is ignored on Android");
+    warn!("`Window::is_decorated` is ignored on Android");
     false
   }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -511,6 +511,10 @@ impl Window {
   pub fn is_maximized(&self) -> bool {
     false
   }
+  pub fn is_decorated(&self) -> bool {
+    warn!("`Window::is_maximized` is ignored on Android");
+    false
+  }
 
   pub fn set_fullscreen(&self, _monitor: Option<window::Fullscreen>) {
     warn!("Cannot set fullscreen on Android");

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -511,6 +511,7 @@ impl Window {
   pub fn is_maximized(&self) -> bool {
     false
   }
+
   pub fn is_decorated(&self) -> bool {
     warn!("`Window::is_decorated` is ignored on Android");
     false

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -204,6 +204,10 @@ impl Inner {
     warn!("`Window::is_maximized` is ignored on iOS");
     false
   }
+  pub fn is_decorated(&self) -> bool {
+    warn!("`Window::is_maximized` is ignored on iOS");
+    false
+  }
 
   pub fn set_fullscreen(&self, monitor: Option<Fullscreen>) {
     unsafe {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -204,6 +204,7 @@ impl Inner {
     warn!("`Window::is_maximized` is ignored on iOS");
     false
   }
+
   pub fn is_decorated(&self) -> bool {
     warn!("`Window::is_decorated` is ignored on iOS");
     false

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -205,7 +205,7 @@ impl Inner {
     false
   }
   pub fn is_decorated(&self) -> bool {
-    warn!("`Window::is_maximized` is ignored on iOS");
+    warn!("`Window::is_decorated` is ignored on iOS");
     false
   }
 

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -260,7 +260,7 @@ impl Window {
     let size: Rc<(AtomicI32, AtomicI32)> = Rc::new((w_size.0.into(), w_size.1.into()));
     let size_clone = size.clone();
 
-    window.connect_configure_event(move |_window, event| {
+    window.connect_configure_event(move |_, event| {
       let (x, y) = event.get_position();
       position_clone.0.store(x, Ordering::Release);
       position_clone.1.store(y, Ordering::Release);
@@ -279,7 +279,6 @@ impl Window {
     window.connect_window_state_event(move |_window, event| {
       let state = event.get_new_window_state();
       max_clone.store(state.contains(WindowState::MAXIMIZED), Ordering::Release);
-
       Inhibit(false)
     });
 
@@ -377,7 +376,6 @@ impl Window {
 
   pub fn outer_size(&self) -> PhysicalSize<u32> {
     let (width, height) = &*self.size;
-
     PhysicalSize::new(
       width.load(Ordering::Acquire) as u32,
       height.load(Ordering::Acquire) as u32,
@@ -465,6 +463,10 @@ impl Window {
 
   pub fn is_maximized(&self) -> bool {
     self.maximized.load(Ordering::Acquire)
+  }
+
+  pub fn is_decorated(&self) -> bool {
+    self.window.get_decorated()
   }
 
   pub fn drag_window(&self) -> Result<(), ExternalError> {

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -376,6 +376,7 @@ impl Window {
 
   pub fn outer_size(&self) -> PhysicalSize<u32> {
     let (width, height) = &*self.size;
+
     PhysicalSize::new(
       width.load(Ordering::Acquire) as u32,
       height.load(Ordering::Acquire) as u32,

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -725,6 +725,12 @@ impl UnownedWindow {
   }
 
   #[inline]
+  pub fn is_decorated(&self) -> bool {
+    // TODO:
+    false
+  }
+
+  #[inline]
   pub fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
     trace!("Locked shared state in `set_fullscreen`");
     let mut shared_state_lock = self.shared_state.lock().unwrap();

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -423,6 +423,12 @@ impl Window {
   }
 
   #[inline]
+  pub fn is_decorated(&self) -> bool {
+    let window_state = self.window_state.lock();
+    window_state.window_flags.contains(WindowFlags::DECORATIONS)
+  }
+
+  #[inline]
   pub fn fullscreen(&self) -> Option<Fullscreen> {
     let window_state = self.window_state.lock();
     window_state.fullscreen.clone()

--- a/src/window.rs
+++ b/src/window.rs
@@ -660,6 +660,16 @@ impl Window {
     self.window.is_maximized()
   }
 
+  /// Gets the window's current decoration state.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **iOS / Android:** Unsupported.
+  #[inline]
+  pub fn is_decorated(&self) -> bool {
+    self.window.is_decorated()
+  }
+
   /// Sets the window to fullscreen or back.
   ///
   /// ## Platform-specific


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [X] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
