### PR TITLE
fix: use source::Priority regardless of specific feature

### DIFF
--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -12,11 +12,11 @@ use std::{
 
 use gdk::{Cursor, CursorType, WindowExt, WindowState};
 use gio::{prelude::*, Cancellable};
-use glib::{Continue, MainContext};
+use glib::{source::Priority, Continue, MainContext};
 use gtk::{prelude::*, AboutDialog, ApplicationWindow, Inhibit};
 
 #[cfg(any(feature = "menu", feature = "tray"))]
-use glib::{source::Priority, Cast};
+use glib::Cast;
 #[cfg(any(feature = "menu", feature = "tray"))]
 use gtk::{Clipboard, Entry};
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

it will fix the compilation error below:

```sh
# /your/path/to/tauri/examples/helloworld
$ cargo tauri build 
   Compiling tao v0.2.4
   Compiling helloworld v0.1.0 (~/your/path/to/tauri/examples/helloworld/src-tauri)
error[E0433]: failed to resolve: use of undeclared type `Priority`
  --> /home/you/.cargo/registry/src/github.com-1ecc6299db9ec823/tao-0.2.4/src/platform_impl/linux/event_loop.rs:87:79
   |
87 |     let (window_requests_tx, window_requests_rx) = glib::MainContext::channel(Priority::default());
   |                                                                               ^^^^^^^^ not found in this scope
   |
help: consider importing this struct
   |
4  | use glib::Priority;
   |

error[E0433]: failed to resolve: use of undeclared type `Priority`
  --> /home/you/.cargo/registry/src/github.com-1ecc6299db9ec823/tao-0.2.4/src/platform_impl/linux/event_loop.rs:96:69
   |
96 |     let (user_event_tx, user_event_rx) = glib::MainContext::channel(Priority::default());
   |                                                                     ^^^^^^^^ not found in this scope
   |
help: consider importing this struct
   |
4  | use glib::Priority;
   |

error[E0433]: failed to resolve: use of undeclared type `Priority`
   --> /home/you/.cargo/registry/src/github.com-1ecc6299db9ec823/tao-0.2.4/src/platform_impl/linux/event_loop.rs:127:75
    |
127 |     let (event_tx, event_rx) = glib::MainContext::channel::<Event<'_, T>>(Priority::default());
    |                                                                           ^^^^^^^^ not found in this scope
    |
help: consider importing this struct
    |
4   | use glib::Priority;
    |

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0433`.
error: could not compile `tao`

To learn more, run the command again with --verbose.
Error: failed to build app

Caused by:
    Result of `cargo build` operation was unsuccessful: exit code: 101
```
