### PR TITLE
add `is_resizable` getter to `Window`

### DIFF
--- a/.changes/is-resizable.md
+++ b/.changes/is-resizable.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Add `is_resizable` getter on `Window`

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -512,6 +512,11 @@ impl Window {
     false
   }
 
+  pub fn is_resizable(&self) -> bool {
+    warn!("`Window::is_resizable` is ignored on android");
+    false
+  }
+
   pub fn set_fullscreen(&self, _monitor: Option<window::Fullscreen>) {
     warn!("Cannot set fullscreen on Android");
   }

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -205,6 +205,11 @@ impl Inner {
     false
   }
 
+  pub fn is_resizable(&self) -> bool {
+    warn!("`Window::is_resizable` is ignored on iOS");
+    false
+  }
+
   pub fn set_fullscreen(&self, monitor: Option<Fullscreen>) {
     unsafe {
       let uiscreen = match monitor {

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -467,6 +467,10 @@ impl Window {
     self.maximized.load(Ordering::Acquire)
   }
 
+  pub fn is_resizable(&self) -> bool {
+    self.window.get_resizable()
+  }
+
   pub fn drag_window(&self) -> Result<(), ExternalError> {
     if let Err(e) = self
       .window_requests_tx

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -726,8 +726,8 @@ impl UnownedWindow {
 
   #[inline]
   pub fn is_resizable(&self) -> bool {
-    // TODO
-    false
+    let is_resizable: BOOL = unsafe { msg_send![*self.ns_window, isResizable] };
+    is_resizable == YES
   }
 
   #[inline]

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -725,6 +725,12 @@ impl UnownedWindow {
   }
 
   #[inline]
+  pub fn is_resizable(&self) -> bool {
+    // TODO
+    false
+  }
+
+  #[inline]
   pub fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
     trace!("Locked shared state in `set_fullscreen`");
     let mut shared_state_lock = self.shared_state.lock().unwrap();

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -423,6 +423,12 @@ impl Window {
   }
 
   #[inline]
+  pub fn is_resizable(&self) -> bool {
+    let window_state = self.window_state.lock();
+    window_state.window_flags.contains(WindowFlags::RESIZABLE)
+  }
+
+  #[inline]
   pub fn fullscreen(&self) -> Option<Fullscreen> {
     let window_state = self.window_state.lock();
     window_state.fullscreen.clone()

--- a/src/window.rs
+++ b/src/window.rs
@@ -660,6 +660,16 @@ impl Window {
     self.window.is_maximized()
   }
 
+  /// Gets the window's current resizable state.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **iOS / Android:** Unsupported.
+  #[inline]
+  pub fn is_resizable(&self) -> bool {
+    self.window.is_resizable()
+  }
+
   /// Sets the window to fullscreen or back.
   ///
   /// ## Platform-specific


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [X] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
