### PR TITLE
add Window::request_close method

### DIFF
--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -585,6 +585,14 @@ impl<T: 'static> EventLoop<T> {
                 menu.show_all();
               }
             }
+            WindowRequest::Close => {
+              if let Err(e) = event_tx.send(Event::WindowEvent {
+                window_id: RootWindowId(id),
+                event: WindowEvent::CloseRequested,
+              }) {
+                log::warn!("Failed to send window close event to event channel: {}", e);
+              }
+            }
           }
         } else if id == WindowId::dummy() {
           if let WindowRequest::Menu(MenuItem::Custom(c)) = request {

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -596,6 +596,15 @@ impl Window {
       log::warn!("Fail to send skip taskbar request: {}", e);
     }
   }
+
+  pub fn request_close(&self) {
+    if let Err(e) = self
+      .window_requests_tx
+      .send((self.window_id, WindowRequest::Close))
+    {
+      log::warn!("Fail to send window close request: {}", e);
+    }
+  }
 }
 
 // We need GtkWindow to initialize WebView, so we have to keep it in the field.
@@ -626,6 +635,7 @@ pub enum WindowRequest {
   Redraw,
   Menu(MenuItem),
   SetMenu((Option<Vec<Menu>>, AccelGroup, gtk::Box)),
+  Close,
 }
 
 pub fn hit_test(window: &gdk::Window, cx: f64, cy: f64) -> WindowEdge {

--- a/src/window.rs
+++ b/src/window.rs
@@ -475,6 +475,17 @@ impl Window {
   pub fn request_redraw(&self) {
     self.window.request_redraw()
   }
+
+  /// Emits a `WindowEvent::CloseRequested` event with the current window in the event loop.
+  ///
+  /// This is the way to request closing the window programmatically from anywhere you might have
+  /// only a reference to the [`Window`]. It is still the responsibility of the event loop handler
+  /// to handle the event when encountered. To comply with the request, the [`Window`] should be
+  /// closed and dropped.
+  #[inline]
+  pub fn request_close(&self) {
+    self.window.request_close()
+  }
 }
 
 /// Position and size functions.


### PR DESCRIPTION
This should be called from programs that want to close the associated window.
The event loop handler should decide if the CloseRequested event should do
anything.

(linux only until i know this interface will work)

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
this is a linux only draft until we know this is the way we want to approach it.

Adds `Window::request_close` which triggers `WindowEvent::CloseRequested` with the window id. This allows code that only has a reference to the window (like in certain places in `wry`) to request the window to be closed programmatically. This comes up in wry when wanting to let `window.close()` in javascript work, or allowing webdriver clients to close the window after finishing their tests.

It is up to the event loop handler to decide what to do with the request, and dropping it if they wish to close the window.