### PR TITLE
refactor: Revert d344825, move `set_skip_taskbar` behind platform-ext

### DIFF
--- a/.changes/skip_taskbar_platformext.md
+++ b/.changes/skip_taskbar_platformext.md
@@ -1,0 +1,4 @@
+---
+"tao": patch
+---
+Revert d344825 and move `set_skip_taskbar` back behind a `WindowExtWindows` and `WindowExtUnix`.

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -27,6 +27,6 @@ impl WindowExtUnix for Window {
   }
 
   fn set_skip_taskbar(&self, skip: bool) {
-   self.window.set_skip_taskbar(skip);
+    self.window.set_skip_taskbar(skip);
   }
 }

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -16,10 +16,17 @@ use crate::window::Window;
 pub trait WindowExtUnix {
   /// Returns the `ApplicatonWindow` from gtk crate that is used by this window.
   fn gtk_window(&self) -> &gtk::ApplicationWindow;
+
+  /// Whethe to show the window icon in the taskbar or not.
+  fn set_skip_taskbar(&self, skip: bool);
 }
 
 impl WindowExtUnix for Window {
   fn gtk_window(&self) -> &gtk::ApplicationWindow {
     &self.window.window
+  }
+
+  fn set_skip_taskbar(&self, skip: bool) {
+   self.window.set_skip_taskbar(skip);
   }
 }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -630,8 +630,6 @@ impl Window {
 
   pub fn show_menu(&self) {}
 
-  pub fn set_skip_taskbar(&self, _skip: bool) {}
-
   pub fn set_cursor_icon(&self, _: window::CursorIcon) {}
 
   pub fn set_cursor_position(&self, _: Position) -> Result<(), error::ExternalError> {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -296,10 +296,6 @@ impl Inner {
     warn!("`Window::set_ime_position` is ignored on iOS")
   }
 
-  pub fn set_skip_taskbar(&self, _skip: bool) {
-    warn!("`Window::set_skip_taskbar` is ignored on iOS")
-  }
-
   pub fn request_user_attention(&self, _request_type: Option<UserAttentionType>) {
     warn!("`Window::request_user_attention` is ignored on iOS")
   }

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -250,8 +250,6 @@ impl Window {
       window.hide();
     }
 
-    window.set_skip_taskbar_hint(attributes.skip_taskbar);
-
     let w_pos = window.get_position();
     let position: Rc<(AtomicI32, AtomicI32)> = Rc::new((w_pos.0.into(), w_pos.1.into()));
     let position_clone = position.clone();
@@ -641,7 +639,7 @@ impl Window {
     todo!()
   }
 
-  pub fn set_skip_taskbar(&self, skip: bool) {
+  pub(crate) fn set_skip_taskbar(&self, skip: bool) {
     if let Err(e) = self
       .window_requests_tx
       .send((self.window_id, WindowRequest::SetSkipTaskbar(skip)))

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1039,9 +1039,6 @@ impl UnownedWindow {
   pub fn show_menu(&self) {}
 
   #[inline]
-  pub fn set_skip_taskbar(&self, _skip: bool) {}
-
-  #[inline]
   // Allow directly accessing the current monitor internally without unwrapping.
   pub(crate) fn current_monitor_inner(&self) -> RootMonitorHandle {
     unsafe {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -734,26 +734,6 @@ impl Window {
   }
 
   #[inline]
-  pub fn set_skip_taskbar(&self, skip: bool) {
-    unsafe {
-      let mut taskbar_list: *mut ITaskbarList = std::mem::zeroed();
-      CoCreateInstance(
-        &CLSID_TaskbarList,
-        ptr::null_mut(),
-        CLSCTX_SERVER,
-        &ITaskbarList::uuidof(),
-        &mut taskbar_list as *mut _ as *mut _,
-      );
-      if skip {
-        (*taskbar_list).DeleteTab(self.hwnd());
-      } else {
-        (*taskbar_list).AddTab(self.hwnd());
-      }
-      (*taskbar_list).Release();
-    }
-  }
-
-  #[inline]
   pub fn hide_menu(&self) {
     unsafe {
       winuser::SetMenu(self.hwnd(), ptr::null::<windef::HMENU>() as _);
@@ -972,8 +952,6 @@ unsafe fn init<T: 'static>(
   if attributes.focus {
     force_window_active(win.window.0);
   }
-
-  win.set_skip_taskbar(attributes.skip_taskbar);
 
   Ok(win)
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -202,11 +202,6 @@ pub struct WindowAttributes {
   ///
   /// The default is `None`.
   pub window_menu: Option<platform_impl::Menu>,
-
-  /// Whether or not the window icon should be added to the taskbar.
-  ///
-  /// The default is `false`.
-  pub skip_taskbar: bool,
 }
 
 impl Default for WindowAttributes {
@@ -228,7 +223,6 @@ impl Default for WindowAttributes {
       always_on_top: false,
       window_icon: None,
       window_menu: None,
-      skip_taskbar: false,
     }
   }
 }
@@ -399,17 +393,6 @@ impl WindowBuilder {
   #[inline]
   pub fn with_window_icon(mut self, window_icon: Option<Icon>) -> Self {
     self.window.window_icon = window_icon;
-    self
-  }
-
-  /// Sets whether or not the window icon should be added to the taskbar.
-  ///
-  /// See [`Window::set_skip_taskbar`] for details.
-  ///
-  /// [`Window::set_skip_taskbar`]: crate::window::Window::set_skip_taskbar
-  #[inline]
-  pub fn with_skip_taskbar(mut self, skip: bool) -> Self {
-    self.window.skip_taskbar = skip;
     self
   }
 
@@ -853,20 +836,6 @@ impl Window {
   #[inline]
   pub fn show_menu(&self) {
     self.window.show_menu();
-  }
-
-  /// Whether to show the window icon in the task bar or not.
-  ///
-  /// ## Platform-specific
-  ///
-  /// - **iOS / Android:** Unsupported.
-  ///
-  /// On macOS, you need to change the activation policy with
-  /// `event_loop.set_activation_policy(ActivationPolicy::Accessory);`
-  /// The `set_skip_taskbar` have no effect.
-  ///
-  pub fn set_skip_taskbar(&self, skip: bool) {
-    self.window.set_skip_taskbar(skip);
   }
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
