### PR TITLE
fix(windows): only show window behaviour when it is visible

### DIFF
--- a/.changes/windows-hidden.md
+++ b/.changes/windows-hidden.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Only show window behaviour when it is visible. winuser::ShowWindow will show the window and make with_visible(false) obsolete.

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -40,7 +40,7 @@ fn main() {
         }
         WindowEvent::KeyboardInput {
           event: KeyEvent {
-            state: ElementState::Released,
+            state: ElementState::Pressed,
             ..
           },
           ..

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -214,13 +214,15 @@ pub fn is_maximized(window: HWND) -> bool {
 
 pub fn set_maximized(window: HWND, maximized: bool) {
   unsafe {
-    winuser::ShowWindow(
-      window,
-      match maximized {
-        true => winuser::SW_MAXIMIZE,
-        false => winuser::SW_RESTORE,
-      },
-    );
+    if winuser::IsWindowVisible(window) != 0 {
+      winuser::ShowWindow(
+        window,
+        match maximized {
+          true => winuser::SW_MAXIMIZE,
+          false => winuser::SW_RESTORE,
+        },
+      );
+    }
   }
 }
 


### PR DESCRIPTION
winuser::ShowWindow will show the window and make set_visible(false) obsolete.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
