### PR TITLE
fix(macos): make sure `set_icon_as_template` is a mutable reference

### DIFF
--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -479,12 +479,12 @@ pub trait SystemTrayExtMacOS {
   ///
   /// You need to update this value before changing the icon.
   ///
-  fn set_icon_as_template(self, is_template: bool);
+  fn set_icon_as_template(&mut self, is_template: bool);
 }
 
 #[cfg(feature = "tray")]
 impl SystemTrayExtMacOS for SystemTray {
-  fn set_icon_as_template(mut self, is_template: bool) {
+  fn set_icon_as_template(&mut self, is_template: bool) {
     self.0.icon_is_template = is_template
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
