### PR TITLE
refactor(windows): only skip taskbar if needed when `set_visible` is called

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -174,7 +174,7 @@ impl WindowExtWindows for Window {
 
   #[inline]
   fn set_skip_taskbar(&self, skip: bool) {
-    self.window.set_skip_taskbar(skip, true);
+    self.window.set_skip_taskbar(skip);
   }
 }
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -44,6 +44,7 @@ pub struct WindowState {
   pub window_flags: WindowFlags,
 
   pub skip_taskbar: bool,
+  pub already_skipped: bool,
 }
 
 #[derive(Clone)]
@@ -135,6 +136,7 @@ impl WindowState {
       window_flags: WindowFlags::empty(),
 
       skip_taskbar,
+      already_skipped: false,
     }
   }
 


### PR DESCRIPTION
With this refactor, skipping the window will only happen when needed, and it will remove the flicker caused by current implementation where the window is skipped every time the window is visible.


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [X] No


**The PR fulfills these requirements:**

- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
