### PR TITLE
refactor(windows): `begin_resize_drag` now similar to gtk's

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -157,6 +157,7 @@ impl WindowExtWindows for Window {
   fn begin_resize_drag(&self, edge: isize, button: u32, x: i32, y: i32) {
     unsafe {
       let point = POINT { x, y };
+      winuser::ReleaseCapture();
       winuser::PostMessageW(
         self.hwnd() as _,
         button as minwindef::UINT,

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -18,7 +18,7 @@ use libc;
 use winapi::{
   shared::{
     minwindef::{self, WORD},
-    windef::{HMENU, HWND},
+    windef::{HMENU, HWND, POINT},
   },
   um::winuser,
 };
@@ -114,7 +114,7 @@ pub trait WindowExtWindows {
   fn reset_dead_keys(&self);
 
   /// Starts the resizing drag from given edge
-  fn begin_resize_drag(&self, edge: isize);
+  fn begin_resize_drag(&self, edge: isize, button: u32, x: i32, y: i32);
 
   /// Whether to show the window icon in the taskbar or not.
   fn set_skip_taskbar(&self, skip: bool);
@@ -154,18 +154,12 @@ impl WindowExtWindows for Window {
   }
 
   #[inline]
-  fn begin_resize_drag(&self, edge: isize) {
+  fn begin_resize_drag(&self, edge: isize, button: u32, x: i32, y: i32) {
     unsafe {
-      let point = {
-        let mut pos = std::mem::zeroed();
-        winuser::GetCursorPos(&mut pos);
-        pos
-      };
-
-      winuser::ReleaseCapture();
+      let point = POINT { x, y };
       winuser::PostMessageW(
         self.hwnd() as _,
-        winuser::WM_NCLBUTTONDOWN,
+        button as minwindef::UINT,
         edge as minwindef::WPARAM,
         &point as *const _ as minwindef::LPARAM,
       );


### PR DESCRIPTION
This will give more control, in attempt to make resizing with Touch possible.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
