### PR TITLE
The `cocoa` crate links to AppKit, which made the symbol `CGDisplayCr…

### DIFF
--- a/.changes/mac-link.md
+++ b/.changes/mac-link.md
@@ -1,0 +1,6 @@
+---
+"tao": patch
+---
+
+Fix linking to the `ColorSync` framework on macOS 10.7, and in newer Rust versions.
+

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -168,9 +168,18 @@ pub const IO8BitOverlayPixels: &str = "O8";
 pub type CGWindowLevel = i32;
 pub type CGDisplayModeRef = *mut libc::c_void;
 
+// `CGDisplayCreateUUIDFromDisplayID` comes from the `ColorSync` framework.
+// However, that framework was only introduced "publicly" in macOS 10.13.
+//
+// Since we want to support older versions, we can't link to `ColorSync`
+// directly. Fortunately, it has always been available as a subframework of
+// `ApplicationServices`, see:
+// https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/OSX_Technology_Overview/SystemFrameworks/SystemFrameworks.html#//apple_ref/doc/uid/TP40001067-CH210-BBCFFIEG
+//
+// TODO: Remove the WINIT_LINK_COLORSYNC hack, it is probably not needed.
 #[cfg_attr(
   not(use_colorsync_cgdisplaycreateuuidfromdisplayid),
-  link(name = "CoreGraphics", kind = "framework")
+  link(name = "ApplicationServices", kind = "framework")
 )]
 #[cfg_attr(
   use_colorsync_cgdisplaycreateuuidfromdisplayid,


### PR DESCRIPTION
…eateUUIDFromDisplayID` from ApplicationServices/ColorSync (which AppKit uses internally) available to us on macOS 10.8 to 10.13.

However, this does not work on macOS 10.7 (where AppKit does not link to ColorSync internally). Instead of relying on this, we should just link to ApplicationServices directly.

Co-authored-by: madsmtm <mads@marquart.dk>

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
