### PR TITLE
build the system_tray module when "ayatana" feature is enabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ mod platform_impl;
   target_os = "netbsd",
   target_os = "openbsd"
 ))]
-#[cfg(feature = "tray")]
+#[cfg(any(feature = "tray", feature = "ayatana"))]
 pub mod system_tray;
 pub mod window;
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -16,11 +16,11 @@ mod keyboard;
 mod keycode;
 mod menu;
 mod monitor;
-#[cfg(feature = "tray")]
+#[cfg(any(feature = "tray", feature = "ayatana"))]
 mod system_tray;
 mod window;
 
-#[cfg(feature = "tray")]
+#[cfg(any(feature = "tray", feature = "ayatana"))]
 pub use self::system_tray::{SystemTray, SystemTrayBuilder};
 pub use self::{
   clipboard::Clipboard,


### PR DESCRIPTION
Without those cfg feature checks, the "ayatana" feature does
actually not enable anything.