### PR TITLE
fix: #268 - Add API for MacOS NSWindow::isDocumentEdited()

### DIFF
--- a/.changes/macos-decoumen-edited.md
+++ b/.changes/macos-decoumen-edited.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Add `WindowExtMacOS::is_doucmented_edited` and `WindowExtMacOS::set_is_doucmented_edited` on macOS.

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -90,7 +90,7 @@ impl WindowExtMacOS for Window {
   }
 
   #[inline]
-   fn set_is_document_edited(&self, edited: bool) {
+  fn set_is_document_edited(&self, edited: bool) {
     self.window.set_is_document_edited(edited)
   }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -48,6 +48,14 @@ pub trait WindowExtMacOS {
 
   /// Sets whether or not the window has shadow.
   fn set_has_shadow(&self, has_shadow: bool);
+
+  /// Put the window in a state which indicates a file save is required.
+  ///
+  /// https://developer.apple.com/documentation/appkit/nswindow/1419311-isdocumentedited
+  fn set_is_document_edited(&self, edited: bool);
+
+  /// Get the window's edit state
+  fn is_document_edited(&self) -> bool;
 }
 
 impl WindowExtMacOS for Window {
@@ -79,6 +87,16 @@ impl WindowExtMacOS for Window {
   #[inline]
   fn set_has_shadow(&self, has_shadow: bool) {
     self.window.set_has_shadow(has_shadow)
+  }
+
+  #[inline]
+   fn set_is_document_edited(&self, edited: bool) {
+    self.window.set_is_document_edited(edited)
+  }
+
+  #[inline]
+  fn is_document_edited(&self) -> bool {
+    self.window.is_document_edited()
   }
 }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -51,7 +51,7 @@ pub trait WindowExtMacOS {
 
   /// Put the window in a state which indicates a file save is required.
   ///
-  /// https://developer.apple.com/documentation/appkit/nswindow/1419311-isdocumentedited
+  /// <https://developer.apple.com/documentation/appkit/nswindow/1419311-isdocumentedited>
   fn set_is_document_edited(&self, edited: bool);
 
   /// Get the window's edit state

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1239,17 +1239,13 @@ impl WindowExtMacOS for UnownedWindow {
 
   #[inline]
   fn set_is_document_edited(&self, edited: bool) {
-    unsafe {
-      self
-        .ns_window
-        .setDocumentEdited_(edited)
-    }
+    unsafe { self.ns_window.setDocumentEdited_(edited) }
   }
 
   #[inline]
   fn is_document_edited(&self) -> bool {
     unsafe {
-      let is_document_edited: BOOL =  msg_send![*self.ns_window, isDocumentEdited];
+      let is_document_edited: BOOL = msg_send![*self.ns_window, isDocumentEdited];
       is_document_edited == YES
     }
   }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1239,7 +1239,7 @@ impl WindowExtMacOS for UnownedWindow {
 
   #[inline]
   fn set_is_document_edited(&self, edited: bool) {
-    unsafe { self.ns_window.setDocumentEdited_(edited) }
+    unsafe { self.ns_window.setDocumentEdited_(edited as i8) }
   }
 
   #[inline]

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1236,6 +1236,24 @@ impl WindowExtMacOS for UnownedWindow {
         .setHasShadow_(if has_shadow { YES } else { NO })
     }
   }
+
+  #[inline]
+  fn set_is_document_edited(&self, edited: bool) {
+    unsafe {
+      self
+        .ns_window
+        .setDocumentEdited_(edited)
+    }
+  }
+
+  #[inline]
+  fn is_document_edited(&self) -> bool {
+    unsafe {
+      self
+        .ns_window
+        .isDocumentEdited()
+    }
+  }
 }
 
 impl Drop for UnownedWindow {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1249,9 +1249,8 @@ impl WindowExtMacOS for UnownedWindow {
   #[inline]
   fn is_document_edited(&self) -> bool {
     unsafe {
-      self
-        .ns_window
-        .isDocumentEdited()
+      let is_document_edited: BOOL =  msg_send![*self.ns_window, isDocumentEdited];
+      is_document_edited == YES
     }
   }
 }


### PR DESCRIPTION

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
This fixes tauri-apps/tao#268 and therefore tauri-apps/tauri#3125


- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] New Binding issue #268
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

The setter API is added upstream in the cocoa crate ([servo/core-foundation-rs PR #493)](https://github.com/servo/core-foundation-rs/pull/493)), which will need to be merged & released before this PR.