### PR TITLE
WIP: Off-screen / headless rendering 

### DIFF
--- a/examples/capture_as_texture.rs
+++ b/examples/capture_as_texture.rs
@@ -1,0 +1,39 @@
+// Copyright 2019-2021 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+
+use tao::{
+  event::{Event, WindowEvent},
+  event_loop::{ControlFlow, EventLoop},
+  window::WindowBuilder,
+};
+
+#[allow(clippy::single_match)]
+fn main() {
+  env_logger::init();
+  let event_loop = EventLoop::new();
+
+  let window = WindowBuilder::new()
+    .with_title("A fantastic window!")
+    .with_inner_size(tao::dpi::LogicalSize::new(128.0, 128.0))
+    .build(&event_loop)
+    .unwrap();
+
+  event_loop.run(move |event, _, control_flow| {
+    *control_flow = ControlFlow::Wait;
+
+    match event {
+      Event::WindowEvent {
+        event: WindowEvent::CloseRequested,
+        window_id,
+        ..
+      } if window_id == window.id() => *control_flow = ControlFlow::Exit,
+      Event::MainEventsCleared => {
+        window.request_redraw();
+      }
+      Event::RedrawRequested(_, textures) => {
+        println!("Received texture bytes: {:?}", textures);
+      }
+      _ => (),
+    }
+  });
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -147,7 +147,7 @@ pub enum Event<'a, T: 'static> {
   /// from [`WidgetExt`] directly.**
   ///
   /// [`WidgetExt`]: https://gtk-rs.org/gtk3-rs/stable/latest/docs/gtk/prelude/trait.WidgetExt.html
-  RedrawRequested(WindowId),
+  RedrawRequested(WindowId, Option<Vec<u8>>),
 
   /// Emitted after all `RedrawRequested` events have been processed and control flow is about to
   /// be taken away from the program. If there are no `RedrawRequested` events, it is emitted
@@ -179,7 +179,7 @@ impl<T: Clone> Clone for Event<'static, T> {
       },
       NewEvents(cause) => NewEvents(*cause),
       MainEventsCleared => MainEventsCleared,
-      RedrawRequested(wid) => RedrawRequested(*wid),
+      RedrawRequested(wid, textures) => RedrawRequested(*wid, textures.clone()),
       RedrawEventsCleared => RedrawEventsCleared,
       LoopDestroyed => LoopDestroyed,
       Suspended => Suspended,
@@ -216,7 +216,7 @@ impl<'a, T> Event<'a, T> {
       DeviceEvent { device_id, event } => Ok(DeviceEvent { device_id, event }),
       NewEvents(cause) => Ok(NewEvents(cause)),
       MainEventsCleared => Ok(MainEventsCleared),
-      RedrawRequested(wid) => Ok(RedrawRequested(wid)),
+      RedrawRequested(wid, textures) => Ok(RedrawRequested(wid, textures)),
       RedrawEventsCleared => Ok(RedrawEventsCleared),
       LoopDestroyed => Ok(LoopDestroyed),
       Suspended => Ok(Suspended),
@@ -255,7 +255,7 @@ impl<'a, T> Event<'a, T> {
       DeviceEvent { device_id, event } => Some(DeviceEvent { device_id, event }),
       NewEvents(cause) => Some(NewEvents(cause)),
       MainEventsCleared => Some(MainEventsCleared),
-      RedrawRequested(wid) => Some(RedrawRequested(wid)),
+      RedrawRequested(wid, textures) => Some(RedrawRequested(wid, textures)),
       RedrawEventsCleared => Some(RedrawEventsCleared),
       LoopDestroyed => Some(LoopDestroyed),
       Suspended => Some(Suspended),


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

This is a WIP pull request for discussing approaches to solving #289, hopefully it's okay to open this. This "works" (as in, prints texture data, and even sends them as an events), but the code is definitely all over in wrong places at `tao`.

I will put most of the questions inline into the code. I can modify according to the feedback.

One non-inlined question:
- this example is for gtk / Linux, not sure if other platforms would allow the access to textures as easily. Any experiences on this?

Also, a few notes:
- input forwarding = keyboard, mouse events (from the caller to tao) should also be investigated
- window could maybe be set hidden by https://docs.rs/gtk/latest/gtk/builders/struct.WindowBuilder.html#method.visible

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [x] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
