### PR TITLE
macOS: Support set_activation_policy during runtime

### DIFF
--- a/.changes/runtime-activation-policy.md
+++ b/.changes/runtime-activation-policy.md
@@ -1,0 +1,5 @@
+---
+tao: minor
+---
+
+Support setting the macOS activation policy during runtime.

--- a/examples/system_tray.rs
+++ b/examples/system_tray.rs
@@ -10,10 +10,7 @@ fn main() {
   #[cfg(target_os = "linux")]
   use std::path::Path;
   #[cfg(target_os = "macos")]
-  use tao::platform::macos::{
-    ActivationPolicy, CustomMenuItemExtMacOS, EventLoopWindowTargetExtMacOS, NativeImage,
-    SystemTrayBuilderExtMacOS,
-  };
+  use tao::platform::macos::{CustomMenuItemExtMacOS, NativeImage, SystemTrayBuilderExtMacOS};
   use tao::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -32,13 +29,6 @@ fn main() {
 
   // open new window menu item
   let open_new_window_element = submenu.add_item(MenuItemAttributes::new("Open new window"));
-
-  #[cfg(target_os = "macos")]
-  let mut is_accessory = false;
-  // Accessory activation policy toggle
-  #[cfg(target_os = "macos")]
-  let mut activation_policy_accessory =
-    submenu.add_item(MenuItemAttributes::new("Accessory Activation Policy").with_selected(false));
 
   // set default icon
   #[cfg(target_os = "macos")]
@@ -163,18 +153,6 @@ fn main() {
           || menu_id == focus_all_window.clone().id()
         {
           create_window_or_focus();
-        }
-        #[cfg(target_os = "macos")]
-        if menu_id == activation_policy_accessory.clone().id() {
-          if is_accessory {
-            is_accessory = false;
-            event_loop.set_activation_policy_at_runtime(ActivationPolicy::Regular);
-            activation_policy_accessory.set_selected(false);
-          } else {
-            is_accessory = true;
-            event_loop.set_activation_policy_at_runtime(ActivationPolicy::Accessory);
-            activation_policy_accessory.set_selected(true);
-          }
         }
         // click on `quit` item
         if menu_id == quit_element.clone().id() {

--- a/examples/system_tray.rs
+++ b/examples/system_tray.rs
@@ -34,12 +34,11 @@ fn main() {
   let open_new_window_element = submenu.add_item(MenuItemAttributes::new("Open new window"));
 
   #[cfg(target_os = "macos")]
-  {
-    let mut is_accessory = false;
-    // Accessory activation policy toggle
-    let mut activation_policy_accessory =
-      submenu.add_item(MenuItemAttributes::new("Accessory Activation Policy").with_selected(false));
-  }
+  let mut is_accessory = false;
+  // Accessory activation policy toggle
+  #[cfg(target_os = "macos")]
+  let mut activation_policy_accessory =
+    submenu.add_item(MenuItemAttributes::new("Accessory Activation Policy").with_selected(false));
 
   // set default icon
   #[cfg(target_os = "macos")]

--- a/examples/system_tray.rs
+++ b/examples/system_tray.rs
@@ -10,7 +10,10 @@ fn main() {
   #[cfg(target_os = "linux")]
   use std::path::Path;
   #[cfg(target_os = "macos")]
-  use tao::platform::macos::{CustomMenuItemExtMacOS, NativeImage, SystemTrayBuilderExtMacOS};
+  use tao::platform::macos::{
+    ActivationPolicy, CustomMenuItemExtMacOS, EventLoopWindowTargetExtMacOS, NativeImage,
+    SystemTrayBuilderExtMacOS,
+  };
   use tao::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -29,6 +32,14 @@ fn main() {
 
   // open new window menu item
   let open_new_window_element = submenu.add_item(MenuItemAttributes::new("Open new window"));
+
+  #[cfg(target_os = "macos")]
+  {
+    let mut is_accessory = false;
+    // Accessory activation policy toggle
+    let mut activation_policy_accessory =
+      submenu.add_item(MenuItemAttributes::new("Accessory Activation Policy").with_selected(false));
+  }
 
   // set default icon
   #[cfg(target_os = "macos")]
@@ -153,6 +164,18 @@ fn main() {
           || menu_id == focus_all_window.clone().id()
         {
           create_window_or_focus();
+        }
+        #[cfg(target_os = "macos")]
+        if menu_id == activation_policy_accessory.clone().id() {
+          if is_accessory {
+            is_accessory = false;
+            event_loop.set_activation_policy(ActivationPolicy::Regular);
+            activation_policy_accessory.set_selected(false);
+          } else {
+            is_accessory = true;
+            event_loop.set_activation_policy(ActivationPolicy::Accessory);
+            activation_policy_accessory.set_selected(true);
+          }
         }
         // click on `quit` item
         if menu_id == quit_element.clone().id() {

--- a/examples/system_tray.rs
+++ b/examples/system_tray.rs
@@ -168,11 +168,11 @@ fn main() {
         if menu_id == activation_policy_accessory.clone().id() {
           if is_accessory {
             is_accessory = false;
-            event_loop.set_activation_policy(ActivationPolicy::Regular);
+            event_loop.set_activation_policy_at_runtime(ActivationPolicy::Regular);
             activation_policy_accessory.set_selected(false);
           } else {
             is_accessory = true;
-            event_loop.set_activation_policy(ActivationPolicy::Accessory);
+            event_loop.set_activation_policy_at_runtime(ActivationPolicy::Accessory);
             activation_policy_accessory.set_selected(true);
           }
         }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -449,6 +449,9 @@ pub trait EventLoopWindowTargetExtMacOS {
   fn show_application(&self);
   /// Hide the other applications. In most applications this is typically triggered with Command+Option-H.
   fn hide_other_applications(&self);
+  /// Sets the activation policy for the application. It is set to
+  /// `NSApplicationActivationPolicyRegular` by default.
+  fn set_activation_policy(&self, activation_policy: ActivationPolicy);
 }
 
 impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
@@ -468,6 +471,12 @@ impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
     let cls = objc::runtime::Class::get("NSApplication").unwrap();
     let app: cocoa::base::id = unsafe { msg_send![cls, sharedApplication] };
     unsafe { msg_send![app, hideOtherApplications: 0] }
+  }
+
+  fn set_activation_policy(&self, activation_policy: ActivationPolicy) {
+    let cls = objc::runtime::Class::get("NSApplication").unwrap();
+    let app: cocoa::base::id = unsafe { msg_send![cls, sharedApplication] };
+    unsafe { msg_send![app, setActivationPolicy: activation_policy] }
   }
 }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -451,7 +451,7 @@ pub trait EventLoopWindowTargetExtMacOS {
   fn hide_other_applications(&self);
   /// Sets the activation policy for the application. It is set to
   /// `NSApplicationActivationPolicyRegular` by default.
-  fn set_activation_policy(&self, activation_policy: ActivationPolicy);
+  fn set_activation_policy_at_runtime(&self, activation_policy: ActivationPolicy);
 }
 
 impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
@@ -473,7 +473,7 @@ impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
     unsafe { msg_send![app, hideOtherApplications: 0] }
   }
 
-  fn set_activation_policy(&self, activation_policy: ActivationPolicy) {
+  fn set_activation_policy_at_runtime(&self, activation_policy: ActivationPolicy) {
     let cls = objc::runtime::Class::get("NSApplication").unwrap();
     let app: cocoa::base::id = unsafe { msg_send![cls, sharedApplication] };
     unsafe { msg_send![app, setActivationPolicy: activation_policy] }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -390,7 +390,7 @@ impl WindowBuilderExtMacOS for WindowBuilder {
 }
 
 pub trait EventLoopExtMacOS {
-  /// Sets the initial activation policy for the application. It is set to
+  /// Sets the activation policy for the application. It is set to
   /// `NSApplicationActivationPolicyRegular` by default.
   ///
   /// This function only takes effect if it's called before calling [`run`](crate::event_loop::EventLoop::run) or

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -390,11 +390,11 @@ impl WindowBuilderExtMacOS for WindowBuilder {
 }
 
 pub trait EventLoopExtMacOS {
-  /// Sets the activation policy for the application. It is set to
+  /// Sets the initial activation policy for the application. It is set to
   /// `NSApplicationActivationPolicyRegular` by default.
   ///
   /// This function only takes effect if it's called before calling [`run`](crate::event_loop::EventLoop::run) or
-  /// [`run_return`](crate::platform::run_return::EventLoopExtRunReturn::run_return)
+  /// [`run_return`](crate::platform::run_return::EventLoopExtRunReturn::run_return). To set the activation policy after that, use [`EventLoopWindowTargetExtMacOS::set_activation_policy_at_runtime`](crate::platform::macos::EventLoopWindowTargetExtMacOS::set_activation_policy_at_runtime).
   fn set_activation_policy(&mut self, activation_policy: ActivationPolicy);
 
   /// Used to prevent a default menubar menu from getting created
@@ -451,6 +451,8 @@ pub trait EventLoopWindowTargetExtMacOS {
   fn hide_other_applications(&self);
   /// Sets the activation policy for the application. It is set to
   /// `NSApplicationActivationPolicyRegular` by default.
+  ///
+  /// To set the activation policy before the app starts running, see [`EventLoopExtMacOS::set_activation_policy`](crate::platform::macos::EventLoopExtMacOS::set_activation_policy).
   fn set_activation_policy_at_runtime(&self, activation_policy: ActivationPolicy);
 }
 


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Example usage:

```rust
event_loop.run(move |event, event_loop_wt, control_flow| {
  // ...
  #[cfg(target_os = "macos")]
  event_loop_wt.set_activation_policy(ActivationPolicy::Accessory)
}
```