### PR TITLE
fix: `MenuItem::Quit` on Windows

### DIFF
--- a/.changes/fix-close-menuitem-windows.md
+++ b/.changes/fix-close-menuitem-windows.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fixes the `MenuItem::Close` behavior on Windows.

--- a/.changes/fix-close-menuitem-windows.md
+++ b/.changes/fix-close-menuitem-windows.md
@@ -1,5 +1,0 @@
----
-"tao": patch
----
-
-Fixes the `MenuItem::Close` behavior on Windows.

--- a/.changes/fix-quit-menuitem-windows.md
+++ b/.changes/fix-quit-menuitem-windows.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fixes the `MenuItem::Quit` behavior on Windows.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -222,7 +222,11 @@ impl<T: 'static> EventLoop<T> {
         .p
         .runner_shared
         .set_event_handler(move |event, control_flow| {
-          event_handler(event, event_loop_windows_ref, control_flow)
+          let loop_destroyed = matches!(event, Event::LoopDestroyed);
+          event_handler(event, event_loop_windows_ref, control_flow);
+          if loop_destroyed {
+            *control_flow = ControlFlow::Exit;
+          }
         });
     }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -222,11 +222,7 @@ impl<T: 'static> EventLoop<T> {
         .p
         .runner_shared
         .set_event_handler(move |event, control_flow| {
-          let loop_destroyed = matches!(event, Event::LoopDestroyed);
           event_handler(event, event_loop_windows_ref, control_flow);
-          if loop_destroyed {
-            *control_flow = ControlFlow::Exit;
-          }
         });
     }
 

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -341,6 +341,7 @@ pub(crate) unsafe extern "system" fn subclass_proc(
         }
         QUIT_ID => {
           subclass_input.send_event(Event::LoopDestroyed);
+          PostQuitMessage(0);
         }
         MINIMIZE_ID => {
           ShowWindow(hwnd, SW_MINIMIZE);


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

The `MenuItem::Close` currently does not trigger the application close. This is related to the Linux bugfix [commited here](https://github.com/tauri-apps/tao/commit/55e52a9149adf37131e365fa667a97f9a24f1e4f), a fix that wasn't applied to Windows.

When the Close menu item is clicked, we emit a LoopDestroyed event, [see source here](https://github.com/tauri-apps/tao/blob/7811284e464f983485977b06010b6d1db134ca4e/src/platform_impl/windows/menu.rs#L343). However that is not handled by the Windows event loop implementation, so the event is emitted to the user but the control flow is not changed.
