### PR TITLE
fix(Windows): fix a deadlock in `WindowState`

### DIFF
--- a/.changes/window-state.keyboard-deadlock.md
+++ b/.changes/window-state.keyboard-deadlock.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+Fix a deadlock on Windows when using `Window::set_visible(true)` in the `EventLoop::run` closure.

--- a/src/platform_impl/windows/keyboard.rs
+++ b/src/platform_impl/windows/keyboard.rs
@@ -1,6 +1,10 @@
+use parking_lot::{Mutex, MutexGuard};
 use std::{
-  char, collections::HashSet, ffi::OsString, mem::MaybeUninit, os::windows::ffi::OsStringExt,
-  sync::MutexGuard,
+  char,
+  collections::{HashMap, HashSet},
+  ffi::OsString,
+  mem::MaybeUninit,
+  os::windows::ffi::OsStringExt,
 };
 
 use windows::Win32::{
@@ -17,10 +21,13 @@ use unicode_segmentation::UnicodeSegmentation;
 use crate::{
   event::{ElementState, KeyEvent},
   keyboard::{Key, KeyCode, KeyLocation, NativeKeyCode},
-  platform_impl::platform::{
-    event_loop::ProcResult,
-    keyboard_layout::{get_or_insert_str, Layout, LayoutCache, WindowsModifiers, LAYOUT_CACHE},
-    KeyEventExtra,
+  platform_impl::{
+    platform::{
+      event_loop::ProcResult,
+      keyboard_layout::{get_or_insert_str, Layout, LayoutCache, WindowsModifiers, LAYOUT_CACHE},
+      KeyEventExtra,
+    },
+    WindowId,
   },
 };
 
@@ -35,6 +42,11 @@ pub type ExScancode = u16;
 pub struct MessageAsKeyEvent {
   pub event: KeyEvent,
   pub is_synthetic: bool,
+}
+
+lazy_static! {
+  pub(crate) static ref KEY_EVENT_BUILDERS: Mutex<HashMap<WindowId, KeyEventBuilder>> =
+    Mutex::new(HashMap::new());
 }
 
 /// Stores information required to make `KeyEvent`s.
@@ -98,7 +110,7 @@ impl KeyEventBuilder {
         }
         *result = ProcResult::Value(LRESULT(0));
 
-        let mut layouts = LAYOUT_CACHE.lock().unwrap();
+        let mut layouts = LAYOUT_CACHE.lock();
         let event_info =
           PartialKeyEventInfo::from_message(wparam, lparam, ElementState::Pressed, &mut layouts);
 
@@ -148,7 +160,7 @@ impl KeyEventBuilder {
         // At this point, we know that there isn't going to be any more events related to
         // this key press
         let event_info = self.event_info.take().unwrap();
-        let mut layouts = LAYOUT_CACHE.lock().unwrap();
+        let mut layouts = LAYOUT_CACHE.lock();
         let ev = event_info.finalize(&mut layouts.strings);
         return vec![MessageAsKeyEvent {
           event: ev,
@@ -220,7 +232,7 @@ impl KeyEventBuilder {
               return vec![];
             }
           };
-          let mut layouts = LAYOUT_CACHE.lock().unwrap();
+          let mut layouts = LAYOUT_CACHE.lock();
           // It's okay to call `ToUnicode` here, because at this point the dead key
           // is already consumed by the character.
           let kbd_state = get_kbd_state();
@@ -259,7 +271,7 @@ impl KeyEventBuilder {
       win32wm::WM_KEYUP | win32wm::WM_SYSKEYUP => {
         *result = ProcResult::Value(LRESULT(0));
 
-        let mut layouts = LAYOUT_CACHE.lock().unwrap();
+        let mut layouts = LAYOUT_CACHE.lock();
         let event_info =
           PartialKeyEventInfo::from_message(wparam, lparam, ElementState::Released, &mut layouts);
         let mut next_msg = MaybeUninit::uninit();
@@ -306,7 +318,7 @@ impl KeyEventBuilder {
   ) -> Vec<MessageAsKeyEvent> {
     let mut key_events = Vec::new();
 
-    let mut layouts = LAYOUT_CACHE.lock().unwrap();
+    let mut layouts = LAYOUT_CACHE.lock();
     let (locale_id, _) = layouts.get_current_layout();
 
     let is_key_pressed = |vk: VIRTUAL_KEY| &kbd_state[usize::from(vk)] & 0x80 != 0;

--- a/src/platform_impl/windows/keyboard_layout.rs
+++ b/src/platform_impl/windows/keyboard_layout.rs
@@ -1,8 +1,8 @@
+use parking_lot::Mutex;
 use std::{
   collections::{hash_map::Entry, HashMap, HashSet},
   ffi::OsString,
   os::windows::ffi::OsStringExt,
-  sync::Mutex,
 };
 
 use lazy_static::lazy_static;

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -52,6 +52,8 @@ use crate::{
   },
 };
 
+use super::keyboard::{KeyEventBuilder, KEY_EVENT_BUILDERS};
+
 struct HMenuWrapper(HMENU);
 unsafe impl Send for HMenuWrapper {}
 unsafe impl Sync for HMenuWrapper {}
@@ -912,6 +914,10 @@ unsafe fn init<T: 'static>(
     thread_executor: event_loop.create_thread_executor(),
     menu: None,
   };
+
+  KEY_EVENT_BUILDERS
+    .lock()
+    .insert(win.id(), KeyEventBuilder::default());
 
   win.set_skip_taskbar(pl_attribs.skip_taskbar);
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -5,7 +5,7 @@ use crate::{
   dpi::{PhysicalPosition, Size},
   icon::Icon,
   keyboard::ModifiersState,
-  platform_impl::platform::{event_loop, keyboard::KeyEventBuilder, minimal_ime::MinimalIme, util},
+  platform_impl::platform::{event_loop, minimal_ime::MinimalIme, util},
   window::{CursorIcon, Fullscreen, Theme, WindowAttributes},
 };
 use parking_lot::MutexGuard;
@@ -36,7 +36,6 @@ pub struct WindowState {
   pub preferred_theme: Option<Theme>,
   pub high_surrogate: Option<u16>,
 
-  pub key_event_builder: KeyEventBuilder,
   pub ime_handler: MinimalIme,
 
   pub window_flags: WindowFlags,
@@ -126,7 +125,6 @@ impl WindowState {
       current_theme,
       preferred_theme,
       high_surrogate: None,
-      key_event_builder: KeyEventBuilder::default(),
       ime_handler: MinimalIme::default(),
       window_flags: WindowFlags::empty(),
     }


### PR DESCRIPTION
~~Reported in https://github.com/tauri-apps/tauri/issues/3534~~ turned out to be a different issue.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [X] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information
It only happens with `set_visible(true)` and I am not sure why.