### PR TITLE
feat(macos): fire `LoopDestroyed` when the dock's `Quit` item is clicked

### DIFF
--- a/.changes/application-will-terminate.md
+++ b/.changes/application-will-terminate.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fire `Event::LoopDestroyed` when the macOS dock `Quit` menu item is clicked.

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -40,6 +40,10 @@ lazy_static! {
       sel!(applicationDidFinishLaunching:),
       did_finish_launching as extern "C" fn(&Object, Sel, id),
     );
+    decl.add_method(
+      sel!(applicationWillTerminate:),
+      application_will_terminate as extern "C" fn(&Object, Sel, id),
+    );
     decl.add_ivar::<*mut c_void>(AUX_DELEGATE_STATE_NAME);
 
     AppDelegateClass(decl.register())
@@ -81,4 +85,10 @@ extern "C" fn did_finish_launching(this: &Object, _: Sel, _: id) {
   trace!("Triggered `applicationDidFinishLaunching`");
   AppState::launched(this);
   trace!("Completed `applicationDidFinishLaunching`");
+}
+
+extern "C" fn application_will_terminate(_: &Object, _: Sel, _: id) {
+  trace!("Triggered `applicationWillTerminate`");
+  AppState::exit();
+  trace!("Completed `applicationWillTerminate`");
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
