### PR TITLE
Set activation policy at runtime

### DIFF
--- a/.changes/add-runtime-activation-policy-mac.md
+++ b/.changes/add-runtime-activation-policy-mac.md
@@ -1,0 +1,5 @@
+---
+"tao": minor
+---
+
+Add `set_activation_policy` as a runtime API.

--- a/.changes/add-runtime-activation-policy-mac.md
+++ b/.changes/add-runtime-activation-policy-mac.md
@@ -2,4 +2,4 @@
 "tao": minor
 ---
 
-Add `set_activation_policy_at_runtime`.
+Add `EventLoopWindowTargetExtMacOS::set_activation_policy_at_runtime`.

--- a/.changes/add-runtime-activation-policy-mac.md
+++ b/.changes/add-runtime-activation-policy-mac.md
@@ -2,4 +2,4 @@
 "tao": minor
 ---
 
-Add `set_activation_policy` as a runtime API.
+Add `set_activation_policy_at_runtime`.

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -17,7 +17,12 @@ use crate::{
 #[cfg(feature = "tray")]
 use crate::system_tray::{SystemTray, SystemTrayBuilder};
 
-use cocoa::{appkit, base::id};
+use cocoa::{appkit::{
+  self, NSApplicationActivationPolicy,
+  NSApplicationActivationPolicyRegular,
+  NSApplicationActivationPolicyAccessory,
+  NSApplicationActivationPolicyProhibited,
+}, base::id};
 
 /// Additional methods on `Window` that are specific to MacOS.
 pub trait WindowExtMacOS {
@@ -97,6 +102,16 @@ pub enum ActivationPolicy {
 impl Default for ActivationPolicy {
   fn default() -> Self {
     ActivationPolicy::Regular
+  }
+}
+
+impl From<ActivationPolicy> for NSApplicationActivationPolicy {
+  fn from(act_pol: ActivationPolicy) -> Self {
+    match act_pol {
+      ActivationPolicy::Regular => NSApplicationActivationPolicyRegular,
+      ActivationPolicy::Accessory => NSApplicationActivationPolicyAccessory,
+      ActivationPolicy::Prohibited => NSApplicationActivationPolicyProhibited,
+    }
   }
 }
 
@@ -449,6 +464,8 @@ pub trait EventLoopWindowTargetExtMacOS {
   fn show_application(&self);
   /// Hide the other applications. In most applications this is typically triggered with Command+Option-H.
   fn hide_other_applications(&self);
+  /// Set activation policy at runtime.
+  fn set_activation_policy(&self, activation_policy: ActivationPolicy);
 }
 
 impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
@@ -468,6 +485,13 @@ impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
     let cls = objc::runtime::Class::get("NSApplication").unwrap();
     let app: cocoa::base::id = unsafe { msg_send![cls, sharedApplication] };
     unsafe { msg_send![app, hideOtherApplications: 0] }
+  }
+
+  fn set_activation_policy(&self, activation_policy: ActivationPolicy) {
+    let cls = objc::runtime::Class::get("NSApplication").unwrap();
+    let app: cocoa::base::id = unsafe { msg_send![cls, sharedApplication] };
+    let ns_activation_policy: NSApplicationActivationPolicy = activation_policy.into();
+    unsafe { msg_send![app, setActivationPolicy: ns_activation_policy] }
   }
 }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -408,8 +408,11 @@ pub trait EventLoopExtMacOS {
   /// Sets the activation policy for the application. It is set to
   /// `NSApplicationActivationPolicyRegular` by default.
   ///
-  /// This function only takes effect if it's called before calling [`run`](crate::event_loop::EventLoop::run) or
-  /// [`run_return`](crate::platform::run_return::EventLoopExtRunReturn::run_return)
+  /// This function only takes effect if it's called before calling
+  /// [`run`](crate::event_loop::EventLoop::run) or
+  /// [`run_return`](crate::platform::run_return::EventLoopExtRunReturn::run_return).
+  /// To set the activation policy after that, use
+  /// [`EventLoopWindowTargetExtMacOS::set_activation_policy_at_runtime`](crate::platform::macos::EventLoopWindowTargetExtMacOS::set_activation_policy_at_runtime).
   fn set_activation_policy(&mut self, activation_policy: ActivationPolicy);
 
   /// Used to prevent a default menubar menu from getting created
@@ -464,7 +467,11 @@ pub trait EventLoopWindowTargetExtMacOS {
   fn show_application(&self);
   /// Hide the other applications. In most applications this is typically triggered with Command+Option-H.
   fn hide_other_applications(&self);
-  /// Set activation policy at runtime.
+  /// Sets the activation policy for the application. It is set to
+  /// `NSApplicationActivationPolicyRegular` by default.
+  ///
+  /// To set the activation policy before the app starts running, see
+  /// [`EventLoopExtMacOS::set_activation_policy`](crate::platform::macos::EventLoopExtMacOS::set_activation_policy).
   fn set_activation_policy_at_runtime(&self, activation_policy: ActivationPolicy);
 }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -17,12 +17,13 @@ use crate::{
 #[cfg(feature = "tray")]
 use crate::system_tray::{SystemTray, SystemTrayBuilder};
 
-use cocoa::{appkit::{
-  self, NSApplicationActivationPolicy,
-  NSApplicationActivationPolicyRegular,
-  NSApplicationActivationPolicyAccessory,
-  NSApplicationActivationPolicyProhibited,
-}, base::id};
+use cocoa::{
+  appkit::{
+    self, NSApplicationActivationPolicy, NSApplicationActivationPolicyAccessory,
+    NSApplicationActivationPolicyProhibited, NSApplicationActivationPolicyRegular,
+  },
+  base::id,
+};
 
 /// Additional methods on `Window` that are specific to MacOS.
 pub trait WindowExtMacOS {

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -465,7 +465,7 @@ pub trait EventLoopWindowTargetExtMacOS {
   /// Hide the other applications. In most applications this is typically triggered with Command+Option-H.
   fn hide_other_applications(&self);
   /// Set activation policy at runtime.
-  fn set_activation_policy(&self, activation_policy: ActivationPolicy);
+  fn set_activation_policy_at_runtime(&self, activation_policy: ActivationPolicy);
 }
 
 impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
@@ -487,7 +487,7 @@ impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
     unsafe { msg_send![app, hideOtherApplications: 0] }
   }
 
-  fn set_activation_policy(&self, activation_policy: ActivationPolicy) {
+  fn set_activation_policy_at_runtime(&self, activation_policy: ActivationPolicy) {
     let cls = objc::runtime::Class::get("NSApplication").unwrap();
     let app: cocoa::base::id = unsafe { msg_send![cls, sharedApplication] };
     let ns_activation_policy: NSApplicationActivationPolicy = activation_policy.into();


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

There's already a set_activation_policy API, but it's at build time only. This change simply adds an equivalent for runtime use -- using the standard OS X API (just like show/hide application does today). Thanks!

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
