### PR TITLE
docs: document wayland behavior for `Moved` event, closes #259

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -320,6 +320,10 @@ pub enum WindowEvent<'a> {
   Resized(PhysicalSize<u32>),
 
   /// The position of the window has changed. Contains the window's new position.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Linux**: Wayland, do not support a global coordinate system, and thus this event will always be (0, 0)
   Moved(PhysicalPosition<i32>),
 
   /// The window has been requested to close.

--- a/src/event.rs
+++ b/src/event.rs
@@ -323,7 +323,7 @@ pub enum WindowEvent<'a> {
   ///
   /// ## Platform-specific
   ///
-  /// - **Linux**: Wayland, do not support a global coordinate system, and thus this event will always be (0, 0)
+  /// - **Linux(Wayland)**: will always be (0, 0) since Wayland doesn't support a global cordinate system.
   Moved(PhysicalPosition<i32>),
 
   /// The window has been requested to close.

--- a/src/window.rs
+++ b/src/window.rs
@@ -493,6 +493,7 @@ impl Window {
   /// - **iOS:** Can only be called on the main thread. Returns the top left coordinates of the
   ///   window in the screen space coordinate system.
   /// - **Android:** Always returns [`NotSupportedError`].
+  /// - **Linux(Wayland)**: Has no effect, since Wayland doesn't support a global cordinate system
   #[inline]
   pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
     self.window.outer_position()


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
