### PR TITLE
refactor(tray): split gtk and ayatana appindicator features

### DIFF
--- a/.changes/refactor-tray-features.md
+++ b/.changes/refactor-tray-features.md
@@ -1,0 +1,5 @@
+---
+"tao": minor
+---
+
+**Breaking change:** Renamed the `ayatana` Cargo feature to `ayatana-appindicator`, now the default feature for tray on Linux, and added the `gtk-appindicator` feature.

--- a/.changes/refactor-tray-features.md
+++ b/.changes/refactor-tray-features.md
@@ -2,4 +2,4 @@
 "tao": minor
 ---
 
-**Breaking change:** Renamed the `ayatana` Cargo feature to `ayatana-appindicator`, now the default feature for tray on Linux, and added the `gtk-appindicator` feature.
+**Breaking change:** Renamed the `ayatana` Cargo feature to `ayatana-tray`, now the default feature for tray on Linux, and added the `gtk-tray` feature.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install ayatana-libappindicator (ubuntu[default/tray] only)
         if: matrix.platform.id == 'ubuntu'
         run: |
-          sudo apt-get install -y libayatana-appindicator3-1
+          sudo apt-get install -y libayatana-appindicator-dev
 
       - name: Install GCC Multilib
         if: (matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev
 
-      - name: Install libappindicator3 (ubuntu[default/tray] only)
+      - name: Install ayatana-libappindicator (ubuntu[default/tray] only)
         if: matrix.platform.id == 'ubuntu'
         run: |
-          sudo apt-get install -y libappindicator3-dev
+          sudo apt-get install -y libayatana-appindicator3-1
 
       - name: Install GCC Multilib
         if: (matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install ayatana-libappindicator (ubuntu[default/tray] only)
         if: matrix.platform.id == 'ubuntu'
         run: |
-          sudo apt-get install -y libayatana-appindicator-dev
+          sudo apt-get install -y libayatana-appindicator3-dev
 
       - name: Install GCC Multilib
         if: (matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ targets = [
 ]
 
 [features]
-default = [ "tray", "ayatana-appindicator" ]
+default = [ "tray", "ayatana-tray" ]
 tray = []
-gtk-appindicator = [ "tray", "libappindicator" ]
-ayatana-appindicator = [ "tray", "libayatana-appindicator" ]
+gtk-tray = [ "tray", "libappindicator" ]
+ayatana-tray = [ "tray", "libayatana-appindicator" ]
 dox = [ "gtk/dox" ]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,10 @@ targets = [
 ]
 
 [features]
-default = [ "tray" ]
-tray = [ "libappindicator" ]
-ayatana = [ "libayatana-appindicator" ]
+default = [ "tray", "ayatana-appindicator" ]
+tray = []
+gtk-appindicator = [ "tray", "libappindicator" ]
+ayatana-appindicator = [ "tray", "libayatana-appindicator" ]
 dox = [ "gtk/dox" ]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ Windows, macOS, Linux, iOS and Android. Built for you, maintained for Tauri.
 Tao provides the following features, which can be enabled in your `Cargo.toml` file:
 * `serde`: Enables serialization/deserialization of certain types with [Serde](https://crates.io/crates/serde).
 * `tray`: Enables system tray and more menu item variants on **Linux**. This flag is enabled by default.
-  You can still create those types if you disable it. They just don't create the actual objects. We set this flag because some implementations require more installed packages. Disable this if you don't want to install `libappindicator` package.
-* `ayatana`: Enable this if you wish to use more update `libayatana-appindicator` since `libappindicator` is no longer
-  maintained.
+  You can still create those types if you disable it. They just don't create the actual objects. We set this flag because some implementations require more installed packages.
+* `ayatana-appindicator`: Enable this if you wish to use more update `libayatana-appindicator` since `libappindicator` is no longer maintained.
+  This flag is enabled by default. Disable this if you don't want to install `libayatana-appindicator` package.
+* `gtk-appindicator`: Enable this if you wish ot use `libappindicator` for tray on **Linux**. The package is supported on more Linux distributions, but it is not maintained anymore.
+  Note that `ayatana-appindicator` and `gtk-appindicator` cannot be enabled at the same time, so `default-features` must be set to `false`.
 
 ## Platform-specific notes
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Tao provides the following features, which can be enabled in your `Cargo.toml` f
 * `serde`: Enables serialization/deserialization of certain types with [Serde](https://crates.io/crates/serde).
 * `tray`: Enables system tray and more menu item variants on **Linux**. This flag is enabled by default.
   You can still create those types if you disable it. They just don't create the actual objects. We set this flag because some implementations require more installed packages.
-* `ayatana-appindicator`: Enable this if you wish to use more update `libayatana-appindicator` since `libappindicator` is no longer maintained.
-  This flag is enabled by default. Disable this if you don't want to install `libayatana-appindicator` package.
-* `gtk-appindicator`: Enable this if you wish ot use `libappindicator` for tray on **Linux**. The package is supported on more Linux distributions, but it is not maintained anymore.
-  Note that `ayatana-appindicator` and `gtk-appindicator` cannot be enabled at the same time, so `default-features` must be set to `false`.
+* `ayatana-tray`: Enable this if you wish to use more update `libayatana-appindicator` since `libappindicator` is no longer maintained.
+  This flag is enabled by default. Disable this if you don't want to install the `libayatana-appindicator` package.
+* `gtk-tray`: Enable this if you wish ot use `libappindicator` for tray on **Linux**. The package is supported on more Linux distributions, but it is not maintained anymore.
+  Note that `ayatana-tray` and `gtk-tray` cannot be enabled at the same time, so `default-features` must be set to `false`.
 
 ## Platform-specific notes
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,11 @@ mod platform_impl;
   target_os = "netbsd",
   target_os = "openbsd"
 ))]
-#[cfg(any(feature = "tray", feature = "ayatana"))]
+#[cfg(all(
+  feature = "tray",
+  any(feature = "gtk-appindicator", feature = "ayatana-appindicator"),
+  not(all(feature = "gtk-appindicator", feature = "ayatana-appindicator"))
+))]
 pub mod system_tray;
 pub mod window;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,8 +185,8 @@ mod platform_impl;
 ))]
 #[cfg(all(
   feature = "tray",
-  any(feature = "gtk-appindicator", feature = "ayatana-appindicator"),
-  not(all(feature = "gtk-appindicator", feature = "ayatana-appindicator"))
+  any(feature = "gtk-tray", feature = "ayatana-tray"),
+  not(all(feature = "gtk-tray", feature = "ayatana-tray"))
 ))]
 pub mod system_tray;
 pub mod window;

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -9,6 +9,22 @@
   target_os = "openbsd"
 ))]
 
+#[cfg(all(
+  feature = "tray",
+  feature = "gtk-appindicator",
+  feature = "ayatana-appindicator"
+))]
+compile_error!(
+  "`gtk-appindicator` and `ayatana-appindicator` Cargo features cannot be enabled at the same time"
+);
+#[cfg(all(
+  feature = "tray",
+  not(any(feature = "gtk-appindicator", feature = "ayatana-appindicator"))
+))]
+compile_error!(
+  "You must enable one of `gtk-appindicator` or `ayatana-appindicator` Cargo features"
+);
+
 mod clipboard;
 mod event_loop;
 mod global_shortcut;
@@ -16,11 +32,19 @@ mod keyboard;
 mod keycode;
 mod menu;
 mod monitor;
-#[cfg(any(feature = "tray", feature = "ayatana"))]
+#[cfg(all(
+  feature = "tray",
+  any(feature = "gtk-appindicator", feature = "ayatana-appindicator"),
+  not(all(feature = "gtk-appindicator", feature = "ayatana-appindicator"))
+))]
 mod system_tray;
 mod window;
 
-#[cfg(any(feature = "tray", feature = "ayatana"))]
+#[cfg(all(
+  feature = "tray",
+  any(feature = "gtk-appindicator", feature = "ayatana-appindicator"),
+  not(all(feature = "gtk-appindicator", feature = "ayatana-appindicator"))
+))]
 pub use self::system_tray::{SystemTray, SystemTrayBuilder};
 pub use self::{
   clipboard::Clipboard,

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -9,21 +9,13 @@
   target_os = "openbsd"
 ))]
 
+#[cfg(all(feature = "tray", feature = "gtk-tray", feature = "ayatana-tray"))]
+compile_error!("`gtk-tray` and `ayatana-tray` Cargo features cannot be enabled at the same time");
 #[cfg(all(
   feature = "tray",
-  feature = "gtk-appindicator",
-  feature = "ayatana-appindicator"
+  not(any(feature = "gtk-tray", feature = "ayatana-tray"))
 ))]
-compile_error!(
-  "`gtk-appindicator` and `ayatana-appindicator` Cargo features cannot be enabled at the same time"
-);
-#[cfg(all(
-  feature = "tray",
-  not(any(feature = "gtk-appindicator", feature = "ayatana-appindicator"))
-))]
-compile_error!(
-  "You must enable one of `gtk-appindicator` or `ayatana-appindicator` Cargo features"
-);
+compile_error!("You must enable one of `gtk-tray` or `ayatana-tray` Cargo features");
 
 mod clipboard;
 mod event_loop;
@@ -34,16 +26,16 @@ mod menu;
 mod monitor;
 #[cfg(all(
   feature = "tray",
-  any(feature = "gtk-appindicator", feature = "ayatana-appindicator"),
-  not(all(feature = "gtk-appindicator", feature = "ayatana-appindicator"))
+  any(feature = "gtk-tray", feature = "ayatana-tray"),
+  not(all(feature = "gtk-tray", feature = "ayatana-tray"))
 ))]
 mod system_tray;
 mod window;
 
 #[cfg(all(
   feature = "tray",
-  any(feature = "gtk-appindicator", feature = "ayatana-appindicator"),
-  not(all(feature = "gtk-appindicator", feature = "ayatana-appindicator"))
+  any(feature = "gtk-tray", feature = "ayatana-tray"),
+  not(all(feature = "gtk-tray", feature = "ayatana-tray"))
 ))]
 pub use self::system_tray::{SystemTray, SystemTrayBuilder};
 pub use self::{

--- a/src/platform_impl/linux/system_tray.rs
+++ b/src/platform_impl/linux/system_tray.rs
@@ -9,9 +9,9 @@ use glib::Sender;
 use std::path::PathBuf;
 
 use gtk::{prelude::WidgetExt, AccelGroup};
-#[cfg(not(feature = "ayatana"))]
+#[cfg(feature = "gtk-appindicator")]
 use libappindicator::{AppIndicator, AppIndicatorStatus};
-#[cfg(feature = "ayatana")]
+#[cfg(feature = "ayatana-appindicator")]
 use libayatana_appindicator::{AppIndicator, AppIndicatorStatus};
 
 use super::{menu::Menu, window::WindowRequest, WindowId};

--- a/src/platform_impl/linux/system_tray.rs
+++ b/src/platform_impl/linux/system_tray.rs
@@ -9,9 +9,9 @@ use glib::Sender;
 use std::path::PathBuf;
 
 use gtk::{prelude::WidgetExt, AccelGroup};
-#[cfg(feature = "gtk-appindicator")]
+#[cfg(feature = "gtk-tray")]
 use libappindicator::{AppIndicator, AppIndicatorStatus};
-#[cfg(feature = "ayatana-appindicator")]
+#[cfg(feature = "ayatana-tray")]
 use libayatana_appindicator::{AppIndicator, AppIndicatorStatus};
 
 use super::{menu::Menu, window::WindowRequest, WindowId};


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

This allows users to have more control on what appindicator package to use, while giving us the possibility to allow both features to be enabled, which would make us resolve the library at runtime.
