### PR TITLE
fix(macos): do not fire Event::Moved when checking is_maximized

### DIFF
--- a/.changes/fix-moved-event.md
+++ b/.changes/fix-moved-event.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Do not fire `WindowEvent::Moved` when `is_maximized` is called on macOS.

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -59,7 +59,7 @@ pub(crate) const DEVICE_ID: RootDeviceId = RootDeviceId(DeviceId);
 pub struct Window {
   window: Arc<UnownedWindow>,
   // We keep this around so that it doesn't get dropped until the window does.
-  _delegate: util::IdRef,
+  delegate: util::IdRef,
 }
 
 #[non_exhaustive]
@@ -86,8 +86,16 @@ impl Window {
     attributes: WindowAttributes,
     pl_attribs: PlatformSpecificWindowBuilderAttributes,
   ) -> Result<Self, RootOsError> {
-    let (window, _delegate) = UnownedWindow::new(attributes, pl_attribs)?;
-    Ok(Window { window, _delegate })
+    let (window, delegate) = UnownedWindow::new(attributes, pl_attribs)?;
+    Ok(Window { window, delegate })
+  }
+
+  #[inline]
+  pub fn is_maximized(&self) -> bool {
+    let () = unsafe { msg_send![*self.delegate, markIsCheckingZoomedIn] };
+    let f = self.window.is_zoomed();
+    let () = unsafe { msg_send![*self.delegate, clearIsCheckingZoomedIn] };
+    f
   }
 }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -674,7 +674,7 @@ impl UnownedWindow {
 
     // Roll back temp styles
     if needs_temp_mask {
-      self.set_style_mask_async(curr_mask);
+      self.set_style_mask_sync(curr_mask);
     }
 
     is_zoomed != NO
@@ -750,11 +750,6 @@ impl UnownedWindow {
   pub fn fullscreen(&self) -> Option<Fullscreen> {
     let shared_state_lock = self.shared_state.lock().unwrap();
     shared_state_lock.fullscreen.clone()
-  }
-
-  #[inline]
-  pub fn is_maximized(&self) -> bool {
-    self.is_zoomed()
   }
 
   #[inline]


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
