### PR TITLE
feat(macos): Fix `with_titlebar_transparent`, add `WindowExtMacOS::set_titlebar_transparent`

### DIFF
--- a/.changes/fix-titlebar-transparent copy.md
+++ b/.changes/fix-titlebar-transparent copy.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Add macOS `WindowExtMacOS::set_titlebar_transparent`

--- a/.changes/fix-titlebar-transparent.md
+++ b/.changes/fix-titlebar-transparent.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix macOS `WindowBuilderExtMacOS::with_titlebar_transparent`

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -1,7 +1,6 @@
 // Copyright 2019-2021 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
-use tao::platform::macos::WindowBuilderExtMacOS;
 use tao::{
   dpi::LogicalSize,
   event::{ElementState, Event, KeyEvent, WindowEvent},
@@ -20,7 +19,6 @@ fn main() {
   let window = WindowBuilder::new()
     .with_title("Hit space to toggle resizability.")
     .with_inner_size(LogicalSize::new(400.0, 200.0))
-    .with_titlebar_style_hidden(true)
     .with_resizable(resizable)
     .build(&event_loop)
     .unwrap();

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -1,6 +1,7 @@
 // Copyright 2019-2021 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
+use tao::platform::macos::{WindowBuilderExtMacOS, WindowExtMacOS};
 use tao::{
   dpi::LogicalSize,
   event::{ElementState, Event, KeyEvent, WindowEvent},
@@ -19,6 +20,8 @@ fn main() {
   let window = WindowBuilder::new()
     .with_title("Hit space to toggle resizability.")
     .with_inner_size(LogicalSize::new(400.0, 200.0))
+    // .with_titlebar_hidden(true)
+    .with_titlebar_transparent(true)
     .with_resizable(resizable)
     .build(&event_loop)
     .unwrap();
@@ -40,6 +43,7 @@ fn main() {
         } => {
           resizable = !resizable;
           println!("Resizable: {}", resizable);
+          window.set_titlebar_transparent(resizable);
           window.set_resizable(resizable);
         }
         _ => (),

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -1,6 +1,7 @@
 // Copyright 2019-2021 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
+use tao::platform::macos::WindowBuilderExtMacOS;
 use tao::{
   dpi::LogicalSize,
   event::{ElementState, Event, KeyEvent, WindowEvent},
@@ -19,6 +20,7 @@ fn main() {
   let window = WindowBuilder::new()
     .with_title("Hit space to toggle resizability.")
     .with_inner_size(LogicalSize::new(400.0, 200.0))
+    .with_titlebar_style_hidden(true)
     .with_resizable(resizable)
     .build(&event_loop)
     .unwrap();

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -1,7 +1,6 @@
 // Copyright 2019-2021 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
-use tao::platform::macos::{WindowBuilderExtMacOS, WindowExtMacOS};
 use tao::{
   dpi::LogicalSize,
   event::{ElementState, Event, KeyEvent, WindowEvent},
@@ -20,8 +19,6 @@ fn main() {
   let window = WindowBuilder::new()
     .with_title("Hit space to toggle resizability.")
     .with_inner_size(LogicalSize::new(400.0, 200.0))
-    // .with_titlebar_hidden(true)
-    .with_titlebar_transparent(true)
     .with_resizable(resizable)
     .build(&event_loop)
     .unwrap();
@@ -43,7 +40,6 @@ fn main() {
         } => {
           resizable = !resizable;
           println!("Resizable: {}", resizable);
-          window.set_titlebar_transparent(resizable);
           window.set_resizable(resizable);
         }
         _ => (),

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -49,14 +49,14 @@ pub trait WindowExtMacOS {
   /// space or taking control over the entire monitor.
   fn set_simple_fullscreen(&self, fullscreen: bool) -> bool;
 
+  /// Makes the titlebar transparent and allows the content to appear behind it.
+  fn set_titlebar_transparent(&self, transparent: bool);
+
   /// Returns whether or not the window has shadow.
   fn has_shadow(&self) -> bool;
 
   /// Sets whether or not the window has shadow.
   fn set_has_shadow(&self, has_shadow: bool);
-
-  /// Makes the titlebar transparent and allows the content to appear behind it.
-  fn set_titlebar_transparent(&self, transparent: bool);
 }
 
 impl WindowExtMacOS for Window {
@@ -81,6 +81,11 @@ impl WindowExtMacOS for Window {
   }
 
   #[inline]
+  fn set_titlebar_transparent(&self, transparent: bool) {
+    self.window.set_titlebar_transparent(transparent)
+  }
+
+  #[inline]
   fn has_shadow(&self) -> bool {
     self.window.has_shadow()
   }
@@ -88,11 +93,6 @@ impl WindowExtMacOS for Window {
   #[inline]
   fn set_has_shadow(&self, has_shadow: bool) {
     self.window.set_has_shadow(has_shadow)
-  }
-
-  #[inline]
-  fn set_titlebar_transparent(&self, transparent: bool) {
-    self.window.set_titlebar_transparent(transparent)
   }
 }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -55,8 +55,8 @@ pub trait WindowExtMacOS {
   /// Sets whether or not the window has shadow.
   fn set_has_shadow(&self, has_shadow: bool);
 
-  /// Hides the window titlebar, but not the traffic light buttons.
-  fn set_titlebar_style_hidden(&self, transparent: bool);
+  /// Makes the titlebar transparent and allows the content to appear behind it.
+  fn set_titlebar_transparent(&self, transparent: bool);
 }
 
 impl WindowExtMacOS for Window {
@@ -91,8 +91,8 @@ impl WindowExtMacOS for Window {
   }
 
   #[inline]
-  fn set_titlebar_style_hidden(&self, transparent: bool) {
-    self.window.set_titlebar_style_hidden(transparent)
+  fn set_titlebar_transparent(&self, transparent: bool) {
+    self.window.set_titlebar_transparent(transparent)
   }
 }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -338,8 +338,6 @@ pub trait WindowBuilderExtMacOS {
   fn with_title_hidden(self, title_hidden: bool) -> WindowBuilder;
   /// Hides the window titlebar.
   fn with_titlebar_hidden(self, titlebar_hidden: bool) -> WindowBuilder;
-  /// Hides the window titlebar, but not the traffic light buttons.
-  fn with_titlebar_style_hidden(self, titlebar_hidden: bool) -> WindowBuilder;
   /// Hides the window titlebar buttons.
   fn with_titlebar_buttons_hidden(self, titlebar_buttons_hidden: bool) -> WindowBuilder;
   /// Makes the window content appear behind the titlebar.
@@ -375,12 +373,6 @@ impl WindowBuilderExtMacOS for WindowBuilder {
   #[inline]
   fn with_titlebar_hidden(mut self, titlebar_hidden: bool) -> WindowBuilder {
     self.platform_specific.titlebar_hidden = titlebar_hidden;
-    self
-  }
-
-  #[inline]
-  fn with_titlebar_style_hidden(mut self, titlebar_hidden: bool) -> WindowBuilder {
-    self.platform_specific.titlebar_style_hidden = titlebar_hidden;
     self
   }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -54,6 +54,9 @@ pub trait WindowExtMacOS {
 
   /// Sets whether or not the window has shadow.
   fn set_has_shadow(&self, has_shadow: bool);
+
+  /// Hides the window titlebar, but not the traffic light buttons.
+  fn set_titlebar_style_hidden(&self, transparent: bool);
 }
 
 impl WindowExtMacOS for Window {
@@ -85,6 +88,11 @@ impl WindowExtMacOS for Window {
   #[inline]
   fn set_has_shadow(&self, has_shadow: bool) {
     self.window.set_has_shadow(has_shadow)
+  }
+
+  #[inline]
+  fn set_titlebar_style_hidden(&self, transparent: bool) {
+    self.window.set_titlebar_style_hidden(transparent)
   }
 }
 
@@ -330,6 +338,8 @@ pub trait WindowBuilderExtMacOS {
   fn with_title_hidden(self, title_hidden: bool) -> WindowBuilder;
   /// Hides the window titlebar.
   fn with_titlebar_hidden(self, titlebar_hidden: bool) -> WindowBuilder;
+  /// Hides the window titlebar, but not the traffic light buttons.
+  fn with_titlebar_style_hidden(self, titlebar_hidden: bool) -> WindowBuilder;
   /// Hides the window titlebar buttons.
   fn with_titlebar_buttons_hidden(self, titlebar_buttons_hidden: bool) -> WindowBuilder;
   /// Makes the window content appear behind the titlebar.
@@ -365,6 +375,12 @@ impl WindowBuilderExtMacOS for WindowBuilder {
   #[inline]
   fn with_titlebar_hidden(mut self, titlebar_hidden: bool) -> WindowBuilder {
     self.platform_specific.titlebar_hidden = titlebar_hidden;
+    self
+  }
+
+  #[inline]
+  fn with_titlebar_style_hidden(mut self, titlebar_hidden: bool) -> WindowBuilder {
+    self.platform_specific.titlebar_style_hidden = titlebar_hidden;
     self
   }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -36,7 +36,7 @@ use cocoa::{
   appkit::{
     self, CGFloat, NSApp, NSApplication, NSApplicationPresentationOptions, NSColor,
     NSRequestUserAttentionType, NSScreen, NSView, NSWindow, NSWindowButton, NSWindowOrderingMode,
-    NSWindowStyleMask, NSWindowTitleVisibility,
+    NSWindowStyleMask,
   },
   base::{id, nil},
   foundation::{NSAutoreleasePool, NSDictionary, NSPoint, NSRect, NSSize, NSUInteger},
@@ -254,7 +254,6 @@ fn create_window(
       if !pl_attrs.has_shadow {
         ns_window.setHasShadow_(NO);
       }
-
       if attrs.position.is_none() {
         ns_window.center();
       }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -212,7 +212,6 @@ fn create_window(
         );
         ns_window.setStyleMask_(style_mask);
 
-        ns_window.setTitleVisibility_(NSWindowTitleVisibility::NSWindowTitleHidden);
         ns_window.setTitlebarAppearsTransparent_(YES);
       }
       if pl_attrs.title_hidden {
@@ -1244,7 +1243,7 @@ impl WindowExtMacOS for UnownedWindow {
   }
 
   #[inline]
-  fn set_titlebar_style_hidden(&self, transparent: bool) {
+  fn set_titlebar_transparent(&self, transparent: bool) {
     unsafe {
       let id = self.ns_window() as cocoa::base::id;
       let mut style_mask = id.styleMask();
@@ -1254,11 +1253,6 @@ impl WindowExtMacOS for UnownedWindow {
       );
       self.ns_window.setStyleMask_(style_mask);
 
-      id.setTitleVisibility_(if transparent {
-        NSWindowTitleVisibility::NSWindowTitleHidden
-      } else {
-        NSWindowTitleVisibility::NSWindowTitleVisible
-      });
       id.setTitlebarAppearsTransparent_(if transparent { YES } else { NO });
     }
   }


### PR DESCRIPTION
### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Used @JonasKruckenberg's code from https://github.com/tauri-apps/tauri/issues/2663, and it looks like it works!

Fixes `with_titlebar_transparent` by setting a style mask, and adds `WindowExtMacOS::set_titlebar_transparent`