### PR TITLE
fix: remove duplicated gdk-rs dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,6 @@ cairo-rs = "0.15"
 gio = "0.15"
 glib = "0.15"
 glib-sys = "0.15"
-gtk = { version = "0.15", features = [ "v3_22" ] }
 gdk = { version = "0.15", features = [ "v3_22" ] }
 gdk-sys = "0.15"
 gdkx11-sys = "0.15"


### PR DESCRIPTION
remove duplicated line of gdk-rs dependency

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
