### PR TITLE
fix(linux): fallback to primary monitor on `current_monitor` impl

### DIFF
--- a/.changes/fix-current-monitor-panic.md
+++ b/.changes/fix-current-monitor-panic.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+The `current_monitor` function now fallbacks to the primary monitor when the window is invisible.

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -612,9 +612,19 @@ impl Window {
 
   pub fn current_monitor(&self) -> Option<RootMonitorHandle> {
     let screen = self.window.display().default_screen();
-    let window = self.window.window().unwrap();
-    #[allow(deprecated)] // Gtk3 Window only accepts Gdkscreen
-    let number = screen.monitor_at_window(&window);
+    // `.window()` returns `None` if the window is invisible;
+    // we fallback to the primary monitor
+    let number = self
+      .window
+      .window()
+      .map(|window| {
+        #[allow(deprecated)] // Gtk3 Window only accepts Gdkscreen
+        screen.monitor_at_window(&window)
+      })
+      .unwrap_or_else(|| {
+        #[allow(deprecated)] // Gtk3 Window only accepts Gdkscreen
+        screen.primary_monitor()
+      });
     let handle = MonitorHandle::new(&self.window.display(), number);
     Some(RootMonitorHandle { inner: handle })
   }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

See https://github.com/tauri-apps/tauri/issues/4149

We could also return `None` instead and fallback in tauri, let me know what you think @wusyong 
