### PR TITLE
Update the windows-rs crate to 0.37.0

### DIFF
--- a/.changes/windows-0.37.0.md
+++ b/.changes/windows-0.37.0.md
@@ -2,6 +2,4 @@
 "tao": patch
 ---
 
-Update the `windows` crate to the latest 0.37.0 release.
-
-The `#[implement]` macro in `windows-implement` depends on `const` generic features which were just stabilized in `rustc` version 1.61, so this change also raises the MSRV from 1.56 to 1.61.
+Update the windows-rs crate to the latest 0.37.0 release. This depends on rustc version 1.61 for some `const` generic support which was just stabilized, so on Windows the MSRV is effectively 1.61 now.

--- a/.changes/windows-0.37.0.md
+++ b/.changes/windows-0.37.0.md
@@ -2,4 +2,6 @@
 "tao": patch
 ---
 
-Update the windows-rs crate to the latest 0.37.0 release. This depends on rustc version 1.61 for some `const` generic support which was just stabilized, so on Windows the MSRV is effectively 1.61 now.
+Update the `windows` crate to the latest 0.37.0 release.
+
+The `#[implement]` macro in `windows-implement` depends on `const` generic features which were just stabilized in `rustc` version 1.61, so this change also raises the MSRV from 1.56 to 1.61.

--- a/.changes/windows-0.37.0.md
+++ b/.changes/windows-0.37.0.md
@@ -2,4 +2,8 @@
 "tao": patch
 ---
 
-Update the windows-rs crate to the latest 0.37.0 release. This depends on rustc version 1.61 for some `const` generic support which was just stabilized, so on Windows the MSRV is effectively 1.61 now.
+Update the `windows` crate to the latest 0.37.0 release.
+
+The `#[implement]` macro in `windows-implement` and the `implement` feature in `windows` depend on some `const` generic features which stabilized in `rustc` 1.61. The MSRV on Windows targets is effectively 1.61, but other targets do not require these features.
+
+Since developers on non-Windows platforms are not always able to upgrade their toolchain with `rustup`, the package remains at 1.56. Windows developers may get less friendly compiler errors about using unstable language features until they upgrade their toolchain if they build `tao` without `wry`, which has some Windows-specific dependencies that transitively raise the MSRV for `wry` to 1.61.

--- a/.changes/windows-0.37.0.md
+++ b/.changes/windows-0.37.0.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Update the windows-rs crate to the latest 0.37.0 release. This depends on rustc version 1.61 for some `const` generic support which was just stabilized, so on Windows the MSRV is effectively 1.61 now.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
   "The winit contributors"
 ]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.56"
 keywords = [ "windowing" ]
 license = "Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,12 +72,13 @@ cc = "1"
 [target."cfg(target_os = \"windows\")".dependencies]
 parking_lot = "0.11"
 unicode-segmentation = "1.8.0"
-windows_macros = "0.30.0"
+windows-implement = "0.32.0"
 
   [target."cfg(target_os = \"windows\")".dependencies.windows]
-  version = "0.30.0"
+  version = "0.32.0"
   features = [
   "alloc",
+  "implement",
   "Win32_Devices_HumanInterfaceDevice",
   "Win32_Foundation",
   "Win32_Globalization",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,10 +73,10 @@ cc = "1"
 [target."cfg(target_os = \"windows\")".dependencies]
 parking_lot = "0.11"
 unicode-segmentation = "1.8.0"
-windows-implement = "0.33.0"
+windows-implement = "0.36.1"
 
   [target."cfg(target_os = \"windows\")".dependencies.windows]
-  version = "0.33.0"
+  version = "0.36.1"
   features = [
   "alloc",
   "implement",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,10 +76,10 @@ cc = "1"
 [target."cfg(target_os = \"windows\")".dependencies]
 parking_lot = "0.11"
 unicode-segmentation = "1.8.0"
-windows-implement = "0.36.1"
+windows-implement = "0.37.0"
 
   [target."cfg(target_os = \"windows\")".dependencies.windows]
-  version = "0.36.1"
+  version = "0.37.0"
   features = [
   "alloc",
   "implement",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,10 +72,10 @@ cc = "1"
 [target."cfg(target_os = \"windows\")".dependencies]
 parking_lot = "0.11"
 unicode-segmentation = "1.8.0"
-windows-implement = "0.32.0"
+windows-implement = "0.33.0"
 
   [target."cfg(target_os = \"windows\")".dependencies.windows]
-  version = "0.32.0"
+  version = "0.33.0"
   features = [
   "alloc",
   "implement",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
   "The winit contributors"
 ]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.61"
 keywords = [ "windowing" ]
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/platform_impl/windows/accelerator.rs
+++ b/src/platform_impl/windows/accelerator.rs
@@ -37,7 +37,7 @@ pub(crate) struct AccelTable {
 
 impl AccelTable {
   fn new(accel: &[ACCEL]) -> AccelTable {
-    let accel = unsafe { CreateAcceleratorTableW(accel as *const _ as *mut _, accel.len() as i32) };
+    let accel = unsafe { CreateAcceleratorTableW(accel) }.unwrap_or_default();
     AccelTable {
       accel: AccelHandle(accel.0),
     }

--- a/src/platform_impl/windows/clipboard.rs
+++ b/src/platform_impl/windows/clipboard.rs
@@ -30,8 +30,8 @@ impl Clipboard {
 
   pub(crate) fn read_text(&self) -> Option<String> {
     with_clipboard(|| unsafe {
-      let handle = GetClipboardData(CF_UNICODETEXT.0);
-      if handle.0 == 0 {
+      let handle = GetClipboardData(CF_UNICODETEXT.0).unwrap_or_default();
+      if handle.is_invalid() {
         None
       } else {
         let unic_str = PWSTR(GlobalLock(handle.0) as *mut _);
@@ -66,13 +66,11 @@ impl Clipboard {
             continue;
           }
         };
-        let result = SetClipboardData(format_id, handle);
-        if result.0 == 0 {
+        if let Err(err) = SetClipboardData(format_id, handle) {
           #[cfg(debug_assertions)]
           println!(
             "failed to set clipboard for fmt {}, error: {}",
-            &format.identifier,
-            windows::core::Error::from_win32().code().0
+            &format.identifier, err
           );
         }
       }

--- a/src/platform_impl/windows/clipboard.rs
+++ b/src/platform_impl/windows/clipboard.rs
@@ -4,7 +4,7 @@
 use crate::clipboard::{ClipboardFormat, FormatId};
 use std::{ffi::OsStr, os::windows::ffi::OsStrExt, ptr};
 use windows::Win32::{
-  Foundation::{HANDLE, HWND, PSTR, PWSTR},
+  Foundation::{HANDLE, HWND, PWSTR},
   System::{
     DataExchange::{
       CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, RegisterClipboardFormatA,
@@ -27,7 +27,7 @@ impl Clipboard {
 
   pub(crate) fn read_text(&self) -> Option<String> {
     with_clipboard(|| unsafe {
-      let handle = GetClipboardData(CF_UNICODETEXT);
+      let handle = GetClipboardData(CF_UNICODETEXT.0);
       if handle.0 == 0 {
         None
       } else {
@@ -82,7 +82,7 @@ fn get_format_id(format: FormatId) -> Option<u32> {
     return Some(*id);
   }
   match format {
-    ClipboardFormat::TEXT => Some(CF_UNICODETEXT),
+    ClipboardFormat::TEXT => Some(CF_UNICODETEXT.0),
     other => register_identifier(other),
   }
 }
@@ -108,14 +108,14 @@ unsafe fn make_handle(format: &ClipboardFormat) -> HANDLE {
     let s: &OsStr = std::str::from_utf8_unchecked(&format.data).as_ref();
     let wstr: Vec<u16> = s.encode_wide().chain(Some(0)).collect();
     let handle = GlobalAlloc(GMEM_MOVEABLE, wstr.len() * std::mem::size_of::<u16>());
-    let locked = PWSTR(GlobalLock(handle) as *mut _);
-    ptr::copy_nonoverlapping(wstr.as_ptr(), locked.0, wstr.len());
+    let locked = GlobalLock(handle) as *mut _;
+    ptr::copy_nonoverlapping(wstr.as_ptr(), locked, wstr.len());
     GlobalUnlock(handle);
     handle
   } else {
     let handle = GlobalAlloc(GMEM_MOVEABLE, format.data.len() * std::mem::size_of::<u8>());
-    let locked = PSTR(GlobalLock(handle) as *mut _);
-    ptr::copy_nonoverlapping(format.data.as_ptr(), locked.0, format.data.len());
+    let locked = GlobalLock(handle) as *mut _;
+    ptr::copy_nonoverlapping(format.data.as_ptr(), locked, format.data.len());
     GlobalUnlock(handle);
     handle
   })

--- a/src/platform_impl/windows/clipboard.rs
+++ b/src/platform_impl/windows/clipboard.rs
@@ -3,15 +3,18 @@
 
 use crate::clipboard::{ClipboardFormat, FormatId};
 use std::{ffi::OsStr, os::windows::ffi::OsStrExt, ptr};
-use windows::Win32::{
-  Foundation::{HANDLE, HWND, PWSTR},
-  System::{
-    DataExchange::{
-      CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, RegisterClipboardFormatA,
-      SetClipboardData,
+use windows::{
+  core::PWSTR,
+  Win32::{
+    Foundation::{HANDLE, HWND},
+    System::{
+      DataExchange::{
+        CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, RegisterClipboardFormatA,
+        SetClipboardData,
+      },
+      Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE},
+      SystemServices::CF_UNICODETEXT,
     },
-    Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE},
-    SystemServices::CF_UNICODETEXT,
   },
 };
 

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -159,7 +159,7 @@ fn should_apps_use_dark_mode() -> bool {
       unsafe {
         const UXTHEME_SHOULDAPPSUSEDARKMODE_ORDINAL: u16 = 132;
 
-        let module = LoadLibraryA("uxtheme.dll");
+        let module = LoadLibraryA("uxtheme.dll").unwrap_or_default();
 
         if module.is_invalid() {
           return None;

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -3,10 +3,13 @@
 
 /// This is a simple implementation of support for Windows Dark Mode,
 /// which is inspired by the solution in https://github.com/ysc3839/win32-darkmode
-use windows::Win32::{
-  Foundation::{BOOL, HWND, PSTR, PWSTR},
-  System::LibraryLoader::*,
-  UI::{Accessibility::*, Controls::*, WindowsAndMessaging::*},
+use windows::{
+  core::{PCSTR, PCWSTR},
+  Win32::{
+    Foundation::{BOOL, HWND},
+    System::LibraryLoader::*,
+    UI::{Accessibility::*, Controls::*, WindowsAndMessaging::*},
+  },
 };
 
 use std::ffi::c_void;
@@ -83,15 +86,15 @@ pub fn try_theme(hwnd: HWND, preferred_theme: Option<Theme>) -> Theme {
     } else {
       Theme::Light
     };
-    let theme_name = PWSTR(
+    let theme_name = PCWSTR(
       match theme {
         Theme::Dark => DARK_THEME_NAME.clone(),
         Theme::Light => LIGHT_THEME_NAME.clone(),
       }
-      .as_mut_ptr(),
+      .as_ptr(),
     );
 
-    let status = unsafe { SetWindowTheme(hwnd, theme_name, PWSTR::default()) };
+    let status = unsafe { SetWindowTheme(hwnd, theme_name, PCWSTR::default()) };
 
     if status.is_ok() && set_dark_mode_for_window(hwnd, is_dark_mode) {
       return theme;
@@ -164,7 +167,7 @@ fn should_apps_use_dark_mode() -> bool {
 
         let handle = GetProcAddress(
           module,
-          PSTR(UXTHEME_SHOULDAPPSUSEDARKMODE_ORDINAL as usize as *mut _),
+          PCSTR(UXTHEME_SHOULDAPPSUSEDARKMODE_ORDINAL as usize as *mut _),
         );
 
         handle.map(|handle| std::mem::transmute(handle))
@@ -183,7 +186,7 @@ fn is_high_contrast() -> bool {
   let mut hc = HIGHCONTRASTA {
     cbSize: 0,
     dwFlags: Default::default(),
-    lpszDefaultScheme: PSTR::default(),
+    lpszDefaultScheme: Default::default(),
   };
 
   let ok = unsafe {

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -182,7 +182,7 @@ const HCF_HIGHCONTRASTON: u32 = 1;
 fn is_high_contrast() -> bool {
   let mut hc = HIGHCONTRASTA {
     cbSize: 0,
-    dwFlags: 0,
+    dwFlags: Default::default(),
     lpszDefaultScheme: PSTR::default(),
   };
 
@@ -191,9 +191,9 @@ fn is_high_contrast() -> bool {
       SPI_GETHIGHCONTRAST,
       std::mem::size_of_val(&hc) as _,
       &mut hc as *mut _ as _,
-      0,
+      Default::default(),
     )
   };
 
-  ok.as_bool() && (HCF_HIGHCONTRASTON & hc.dwFlags) != 0
+  ok.as_bool() && (HCF_HIGHCONTRASTON & hc.dwFlags.0) != 0
 }

--- a/src/platform_impl/windows/drop_handler.rs
+++ b/src/platform_impl/windows/drop_handler.rs
@@ -3,26 +3,23 @@
 
 use std::{ffi::OsString, os::windows::ffi::OsStringExt, path::PathBuf, ptr};
 
-use windows::{
-  self as Windows,
-  Win32::{
-    Foundation::{self as win32f, HWND, POINTL, PWSTR},
-    System::{
-      Com::{IDataObject, DVASPECT_CONTENT, FORMATETC, TYMED_HGLOBAL},
-      Ole::{DROPEFFECT_COPY, DROPEFFECT_NONE},
-      SystemServices::CF_HDROP,
-    },
-    UI::Shell::{DragFinish, DragQueryFileW, HDROP},
+use windows::Win32::{
+  Foundation::{self as win32f, HWND, POINTL, PWSTR},
+  System::{
+    Com::{IDataObject, DVASPECT_CONTENT, FORMATETC, TYMED_HGLOBAL},
+    Ole::{IDropTarget, IDropTarget_Impl, DROPEFFECT_COPY, DROPEFFECT_NONE},
+    SystemServices::CF_HDROP,
   },
+  UI::Shell::{DragFinish, DragQueryFileW, HDROP},
 };
 
-use windows_macros::implement;
+use windows_implement::implement;
 
 use crate::platform_impl::platform::WindowId;
 
 use crate::{event::Event, window::WindowId as SuperWindowId};
 
-#[implement(Windows::Win32::System::Ole::IDropTarget)]
+#[implement(IDropTarget)]
 pub struct FileDropHandler {
   window: HWND,
   send_event: Box<dyn Fn(Event<'static, ()>)>,
@@ -30,7 +27,6 @@ pub struct FileDropHandler {
   hovered_is_valid: bool, /* If the currently hovered item is not valid there must not be any `HoveredFileCancelled` emitted */
 }
 
-#[allow(non_snake_case)]
 impl FileDropHandler {
   pub fn new(window: HWND, send_event: Box<dyn Fn(Event<'static, ()>)>) -> FileDropHandler {
     Self {
@@ -41,81 +37,16 @@ impl FileDropHandler {
     }
   }
 
-  unsafe fn DragEnter(
-    &mut self,
-    pDataObj: &Option<IDataObject>,
-    _grfKeyState: u32,
-    _pt: POINTL,
-    pdwEffect: *mut u32,
-  ) -> windows::core::Result<()> {
-    use crate::event::WindowEvent::HoveredFile;
-    let hdrop = Self::iterate_filenames(pDataObj, |filename| {
-      (self.send_event)(Event::WindowEvent {
-        window_id: SuperWindowId(WindowId(self.window.0)),
-        event: HoveredFile(filename),
-      });
-    });
-    self.hovered_is_valid = hdrop.is_some();
-    self.cursor_effect = if self.hovered_is_valid {
-      DROPEFFECT_COPY
-    } else {
-      DROPEFFECT_NONE
-    };
-    *pdwEffect = self.cursor_effect;
-    Ok(())
-  }
-
-  unsafe fn DragOver(
-    &self,
-    _grfKeyState: u32,
-    _pt: POINTL,
-    pdwEffect: *mut u32,
-  ) -> windows::core::Result<()> {
-    *pdwEffect = self.cursor_effect;
-    Ok(())
-  }
-
-  unsafe fn DragLeave(&self) -> windows::core::Result<()> {
-    use crate::event::WindowEvent::HoveredFileCancelled;
-    if self.hovered_is_valid {
-      (self.send_event)(Event::WindowEvent {
-        window_id: SuperWindowId(WindowId(self.window.0)),
-        event: HoveredFileCancelled,
-      });
-    }
-    Ok(())
-  }
-
-  unsafe fn Drop(
-    &self,
-    pDataObj: &Option<IDataObject>,
-    _grfKeyState: u32,
-    _pt: POINTL,
-    _pdwEffect: *mut u32,
-  ) -> windows::core::Result<()> {
-    use crate::event::WindowEvent::DroppedFile;
-    let hdrop = Self::iterate_filenames(pDataObj, |filename| {
-      (self.send_event)(Event::WindowEvent {
-        window_id: SuperWindowId(WindowId(self.window.0)),
-        event: DroppedFile(filename),
-      });
-    });
-    if let Some(hdrop) = hdrop {
-      DragFinish(hdrop);
-    }
-    Ok(())
-  }
-
   unsafe fn iterate_filenames<F>(data_obj: &Option<IDataObject>, callback: F) -> Option<HDROP>
   where
     F: Fn(PathBuf),
   {
     let drop_format = FORMATETC {
-      cfFormat: CF_HDROP as u16,
+      cfFormat: CF_HDROP.0 as u16,
       ptd: ptr::null_mut(),
-      dwAspect: DVASPECT_CONTENT as u32,
+      dwAspect: DVASPECT_CONTENT.0 as u32,
       lindex: -1,
-      tymed: TYMED_HGLOBAL as u32,
+      tymed: TYMED_HGLOBAL.0 as u32,
     };
 
     match data_obj
@@ -162,5 +93,77 @@ impl FileDropHandler {
         None
       }
     }
+  }
+}
+
+#[allow(non_snake_case)]
+impl IDropTarget_Impl for FileDropHandler {
+  fn DragEnter(
+    &mut self,
+    pDataObj: &Option<IDataObject>,
+    _grfKeyState: u32,
+    _pt: &POINTL,
+    pdwEffect: *mut u32,
+  ) -> windows::core::Result<()> {
+    use crate::event::WindowEvent::HoveredFile;
+    unsafe {
+      let hdrop = Self::iterate_filenames(pDataObj, |filename| {
+        (self.send_event)(Event::WindowEvent {
+          window_id: SuperWindowId(WindowId(self.window.0)),
+          event: HoveredFile(filename),
+        });
+      });
+      self.hovered_is_valid = hdrop.is_some();
+      self.cursor_effect = if self.hovered_is_valid {
+        DROPEFFECT_COPY
+      } else {
+        DROPEFFECT_NONE
+      };
+      *pdwEffect = self.cursor_effect;
+    }
+    Ok(())
+  }
+
+  fn DragOver(
+    &mut self,
+    _grfKeyState: u32,
+    _pt: &POINTL,
+    pdwEffect: *mut u32,
+  ) -> windows::core::Result<()> {
+    unsafe { *pdwEffect = self.cursor_effect };
+    Ok(())
+  }
+
+  fn DragLeave(&mut self) -> windows::core::Result<()> {
+    use crate::event::WindowEvent::HoveredFileCancelled;
+    if self.hovered_is_valid {
+      (self.send_event)(Event::WindowEvent {
+        window_id: SuperWindowId(WindowId(self.window.0)),
+        event: HoveredFileCancelled,
+      });
+    }
+    Ok(())
+  }
+
+  fn Drop(
+    &mut self,
+    pDataObj: &Option<IDataObject>,
+    _grfKeyState: u32,
+    _pt: &POINTL,
+    _pdwEffect: *mut u32,
+  ) -> windows::core::Result<()> {
+    use crate::event::WindowEvent::DroppedFile;
+    unsafe {
+      let hdrop = Self::iterate_filenames(pDataObj, |filename| {
+        (self.send_event)(Event::WindowEvent {
+          window_id: SuperWindowId(WindowId(self.window.0)),
+          event: DroppedFile(filename),
+        });
+      });
+      if let Some(hdrop) = hdrop {
+        DragFinish(hdrop);
+      }
+    }
+    Ok(())
   }
 }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1976,7 +1976,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
           i32::from(util::GET_Y_LPARAM(lparam)),
         );
 
-        result = ProcResult::Value(crate::platform_impl::hit_test(window, cx, cy));
+        result = ProcResult::Value(crate::platform_impl::hit_test(window.0 as _, cx, cy));
       } else {
         result = ProcResult::DefSubclassProc;
       }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -592,7 +592,7 @@ lazy_static! {
         RegisterWindowMessageA("Tao::SetRetainMaximized")
     };
     static ref THREAD_EVENT_TARGET_WINDOW_CLASS: Vec<u16> = unsafe {
-        let mut class_name= util::encode_wide("Tao Thread Event Target");
+        let class_name= util::encode_wide("Tao Thread Event Target");
 
         let class = WNDCLASSEXW {
             cbSize: mem::size_of::<WNDCLASSEXW>() as u32,

--- a/src/platform_impl/windows/global_shortcut.rs
+++ b/src/platform_impl/windows/global_shortcut.rs
@@ -24,7 +24,7 @@ impl ShortcutManager {
     accelerator: Accelerator,
   ) -> Result<RootGlobalShortcut, ShortcutManagerError> {
     unsafe {
-      let mut converted_modifiers = 0;
+      let mut converted_modifiers = Default::default();
       let modifiers: ModifiersState = accelerator.mods;
       if modifiers.shift_key() {
         converted_modifiers |= MOD_SHIFT;
@@ -46,7 +46,7 @@ impl ShortcutManager {
             HWND::default(),
             accelerator.clone().id().0 as i32,
             converted_modifiers,
-            u32::from(vk_code),
+            u32::from(vk_code.0),
           );
           if !result.as_bool() {
             return Err(ShortcutManagerError::InvalidAccelerator(

--- a/src/platform_impl/windows/icon.rs
+++ b/src/platform_impl/windows/icon.rs
@@ -41,12 +41,10 @@ impl RgbaIcon {
         (PIXEL_SIZE * 8) as u8,
         and_mask.as_ptr() as *const u8,
         rgba.as_ptr() as *const u8,
-      ) as HICON
+      )
     };
     Ok(WinIcon::from_handle(
-      handle
-        .ok()
-        .map_err(|_| BadIcon::OsError(io::Error::last_os_error()))?,
+      handle.map_err(|_| BadIcon::OsError(io::Error::last_os_error()))?,
     ))
   }
 }
@@ -89,44 +87,38 @@ impl WinIcon {
     // width / height of 0 along with LR_DEFAULTSIZE tells windows to load the default icon size
     let (width, height) = size.map(Into::into).unwrap_or((0, 0));
 
-    let handle = HICON(
-      unsafe {
-        LoadImageW(
-          HINSTANCE::default(),
-          PCWSTR(wide_path.as_ptr()),
-          IMAGE_ICON,
-          width as i32,
-          height as i32,
-          LR_DEFAULTSIZE | LR_LOADFROMFILE,
-        )
-      }
-      .0,
-    );
+    let handle = unsafe {
+      LoadImageW(
+        HINSTANCE::default(),
+        PCWSTR(wide_path.as_ptr()),
+        IMAGE_ICON,
+        width as i32,
+        height as i32,
+        LR_DEFAULTSIZE | LR_LOADFROMFILE,
+      )
+    }
+    .map(|handle| HICON(handle.0));
     Ok(WinIcon::from_handle(
-      handle
-        .ok()
-        .map_err(|_| BadIcon::OsError(io::Error::last_os_error()))?,
+      handle.map_err(|_| BadIcon::OsError(io::Error::last_os_error()))?,
     ))
   }
 
   pub fn from_resource(resource_id: u16, size: Option<PhysicalSize<u32>>) -> Result<Self, BadIcon> {
     // width / height of 0 along with LR_DEFAULTSIZE tells windows to load the default icon size
     let (width, height) = size.map(Into::into).unwrap_or((0, 0));
-    let handle = HICON(unsafe {
+    let handle = unsafe {
       LoadImageW(
-        GetModuleHandleW(PCWSTR::default()),
+        GetModuleHandleW(PCWSTR::default()).unwrap_or_default(),
         PCWSTR(resource_id as usize as *const u16),
         IMAGE_ICON,
         width as i32,
         height as i32,
         LR_DEFAULTSIZE,
       )
-      .0
-    });
+    }
+    .map(|handle| HICON(handle.0));
     Ok(WinIcon::from_handle(
-      handle
-        .ok()
-        .map_err(|_| BadIcon::OsError(io::Error::last_os_error()))?,
+      handle.map_err(|_| BadIcon::OsError(io::Error::last_os_error()))?,
     ))
   }
 

--- a/src/platform_impl/windows/icon.rs
+++ b/src/platform_impl/windows/icon.rs
@@ -3,10 +3,13 @@
 
 use std::{fmt, io, iter::once, mem, os::windows::ffi::OsStrExt, path::Path, sync::Arc};
 
-use windows::Win32::{
-  Foundation::{HINSTANCE, HWND, LPARAM, PWSTR, WPARAM},
-  System::LibraryLoader::*,
-  UI::WindowsAndMessaging::*,
+use windows::{
+  core::PCWSTR,
+  Win32::{
+    Foundation::{HINSTANCE, HWND, LPARAM, WPARAM},
+    System::LibraryLoader::*,
+    UI::WindowsAndMessaging::*,
+  },
 };
 
 use crate::{dpi::PhysicalSize, icon::*};
@@ -76,7 +79,7 @@ impl WinIcon {
     path: P,
     size: Option<PhysicalSize<u32>>,
   ) -> Result<Self, BadIcon> {
-    let mut wide_path: Vec<u16> = path
+    let wide_path: Vec<u16> = path
       .as_ref()
       .as_os_str()
       .encode_wide()
@@ -90,7 +93,7 @@ impl WinIcon {
       unsafe {
         LoadImageW(
           HINSTANCE::default(),
-          PWSTR(wide_path.as_mut_ptr()),
+          PCWSTR(wide_path.as_ptr()),
           IMAGE_ICON,
           width as i32,
           height as i32,
@@ -111,8 +114,8 @@ impl WinIcon {
     let (width, height) = size.map(Into::into).unwrap_or((0, 0));
     let handle = HICON(unsafe {
       LoadImageW(
-        GetModuleHandleW(PWSTR::default()),
-        PWSTR(resource_id as usize as *mut u16),
+        GetModuleHandleW(PCWSTR::default()),
+        PCWSTR(resource_id as usize as *const u16),
         IMAGE_ICON,
         width as i32,
         height as i32,

--- a/src/platform_impl/windows/keyboard.rs
+++ b/src/platform_impl/windows/keyboard.rs
@@ -699,7 +699,7 @@ fn ex_scancode_from_lparam(lparam: LPARAM) -> ExScancode {
 fn get_kbd_state() -> [u8; 256] {
   unsafe {
     let mut kbd_state: MaybeUninit<[u8; 256]> = MaybeUninit::uninit();
-    GetKeyboardState(kbd_state.as_mut_ptr() as *mut u8);
+    GetKeyboardState(&mut *kbd_state.as_mut_ptr());
     kbd_state.assume_init()
   }
 }

--- a/src/platform_impl/windows/keyboard.rs
+++ b/src/platform_impl/windows/keyboard.rs
@@ -91,7 +91,7 @@ impl KeyEventBuilder {
         }
       }
       win32wm::WM_KEYDOWN | win32wm::WM_SYSKEYDOWN => {
-        if msg_kind == WM_SYSKEYDOWN && wparam.0 == usize::from(VK_F4) {
+        if msg_kind == WM_SYSKEYDOWN && wparam.0 == usize::from(VK_F4.0) {
           // Don't dispatch Alt+F4 to the application.
           // This is handled in `event_loop.rs`
           return vec![];
@@ -242,7 +242,7 @@ impl KeyEventBuilder {
             event_info.text = PartialText::System(event_info.utf16parts.clone());
           } else {
             let mod_no_ctrl = mod_state.remove_only_ctrl();
-            let num_lock_on = kbd_state[usize::from(VK_NUMLOCK)] & 1 != 0;
+            let num_lock_on = kbd_state[usize::from(VK_NUMLOCK.0)] & 1 != 0;
             let vkey = event_info.vkey;
             let scancode = event_info.scancode;
             let keycode = event_info.code;
@@ -309,12 +309,12 @@ impl KeyEventBuilder {
     let mut layouts = LAYOUT_CACHE.lock().unwrap();
     let (locale_id, _) = layouts.get_current_layout();
 
-    let is_key_pressed = |vk: VIRTUAL_KEY| &kbd_state[usize::from(vk)] & 0x80 != 0;
+    let is_key_pressed = |vk: VIRTUAL_KEY| &kbd_state[usize::from(vk.0)] & 0x80 != 0;
 
     // Is caps-lock active? Note that this is different from caps-lock
     // being held down.
-    let caps_lock_on = kbd_state[usize::from(VK_CAPITAL)] & 1 != 0;
-    let num_lock_on = kbd_state[usize::from(VK_NUMLOCK)] & 1 != 0;
+    let caps_lock_on = kbd_state[usize::from(VK_CAPITAL.0)] & 1 != 0;
+    let num_lock_on = kbd_state[usize::from(VK_NUMLOCK.0)] & 1 != 0;
 
     // We are synthesizing the press event for caps-lock first for the following reasons:
     // 1. If caps-lock is *not* held down but *is* active, then we have to
@@ -342,21 +342,18 @@ impl KeyEventBuilder {
     }
     let do_non_modifier = |key_events: &mut Vec<_>, layouts: &mut _| {
       for vk in 0..256 {
-        let vk = vk as VIRTUAL_KEY;
+        let vk = VIRTUAL_KEY(vk);
         match vk {
-          _ if vk == VK_CONTROL
-            || vk == VK_LCONTROL
-            || vk == VK_RCONTROL
-            || vk == VK_SHIFT
-            || vk == VK_LSHIFT
-            || vk == VK_RSHIFT
-            || vk == VK_MENU
-            || vk == VK_LMENU
-            || vk == VK_RMENU
-            || vk == VK_CAPITAL =>
-          {
-            continue
-          }
+          win32km::VK_CONTROL
+          | win32km::VK_LCONTROL
+          | win32km::VK_RCONTROL
+          | win32km::VK_SHIFT
+          | win32km::VK_LSHIFT
+          | win32km::VK_RSHIFT
+          | win32km::VK_MENU
+          | win32km::VK_LMENU
+          | win32km::VK_RMENU
+          | win32km::VK_CAPITAL => continue,
           _ => (),
         }
         if !is_key_pressed(vk) {
@@ -427,7 +424,7 @@ impl KeyEventBuilder {
     locale_id: HKL,
     layouts: &mut MutexGuard<'_, LayoutCache>,
   ) -> Option<MessageAsKeyEvent> {
-    let scancode = unsafe { MapVirtualKeyExW(u32::from(vk), MAPVK_VK_TO_VSC_EX, locale_id) };
+    let scancode = unsafe { MapVirtualKeyExW(u32::from(vk.0), MAPVK_VK_TO_VSC_EX, locale_id) };
     if scancode == 0 {
       return None;
     }
@@ -518,12 +515,12 @@ impl PartialKeyEventInfo {
     let (_, layout) = layouts.get_current_layout();
     let lparam_struct = destructure_key_lparam(lparam);
     let scancode;
-    let vkey = wparam.0 as VIRTUAL_KEY;
+    let vkey = VIRTUAL_KEY(wparam.0 as u16);
     if lparam_struct.scancode == 0 {
       // In some cases (often with media keys) the device reports a scancode of 0 but a
       // valid virtual key. In these cases we obtain the scancode from the virtual key.
       scancode =
-        unsafe { MapVirtualKeyExW(u32::from(vkey), MAPVK_VK_TO_VSC_EX, layout.hkl) as u16 };
+        unsafe { MapVirtualKeyExW(u32::from(vkey.0), MAPVK_VK_TO_VSC_EX, layout.hkl) as u16 };
     } else {
       scancode = new_ex_scancode(lparam_struct.scancode, lparam_struct.extended);
     }
@@ -533,7 +530,7 @@ impl PartialKeyEventInfo {
     let kbd_state = get_kbd_state();
     let mods = WindowsModifiers::active_modifiers(&kbd_state);
     let mods_without_ctrl = mods.remove_only_ctrl();
-    let num_lock_on = kbd_state[VK_NUMLOCK as usize] & 1 != 0;
+    let num_lock_on = kbd_state[usize::from(VK_NUMLOCK.0)] & 1 != 0;
 
     // On Windows Ctrl+NumLock = Pause (and apparently Ctrl+Pause -> NumLock). In these cases
     // the KeyCode still stores the real key, so in the name of consistency across platforms, we
@@ -705,8 +702,8 @@ fn get_async_kbd_state() -> [u8; 256] {
   unsafe {
     let mut kbd_state: [u8; 256] = [0; 256];
     for (vk, state) in kbd_state.iter_mut().enumerate() {
-      let vk = vk as VIRTUAL_KEY;
-      let async_state = GetAsyncKeyState(i32::from(vk));
+      let vk = VIRTUAL_KEY(vk as u16);
+      let async_state = GetAsyncKeyState(i32::from(vk.0));
       let is_down = (async_state & (1 << 15)) != 0;
       if is_down {
         *state = 0x80;
@@ -717,7 +714,7 @@ fn get_async_kbd_state() -> [u8; 256] {
         win32km::VK_CAPITAL | win32km::VK_NUMLOCK | win32km::VK_SCROLL
       ) {
         // Toggle states aren't reported by `GetAsyncKeyState`
-        let toggle_state = GetKeyState(i32::from(vk));
+        let toggle_state = GetKeyState(i32::from(vk.0));
         let is_active = (toggle_state & 1) != 0;
         *state |= if is_active { 1 } else { 0 };
       }
@@ -745,11 +742,12 @@ fn is_current_fake(curr_info: &PartialKeyEventInfo, next_msg: MSG, layout: &Layo
 }
 
 fn get_location(scancode: ExScancode, hkl: HKL) -> KeyLocation {
-  const VK_ABNT_C2: VIRTUAL_KEY = win32km::VK_ABNT_C2 as VIRTUAL_KEY;
+  const VK_ABNT_C2: VIRTUAL_KEY = VIRTUAL_KEY(win32km::VK_ABNT_C2 as u16);
 
   let extension = 0xE000;
   let extended = (scancode & extension) == extension;
-  let vkey = unsafe { MapVirtualKeyExW(scancode as u32, MAPVK_VSC_TO_VK_EX, hkl) as u16 };
+  let vkey =
+    VIRTUAL_KEY(unsafe { MapVirtualKeyExW(scancode as u32, MAPVK_VSC_TO_VK_EX, hkl) } as u16);
 
   // Use the native VKEY and the extended flag to cover most cases
   // This is taken from the `druid` GUI library, specifically
@@ -802,53 +800,53 @@ fn get_location(scancode: ExScancode, hkl: HKL) -> KeyLocation {
 // used to build accelerators table from Key
 pub(crate) fn key_to_vk(key: &KeyCode) -> Option<VIRTUAL_KEY> {
   Some(match key {
-    KeyCode::KeyA => unsafe { VkKeyScanW('a' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyB => unsafe { VkKeyScanW('b' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyC => unsafe { VkKeyScanW('c' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyD => unsafe { VkKeyScanW('d' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyE => unsafe { VkKeyScanW('e' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyF => unsafe { VkKeyScanW('f' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyG => unsafe { VkKeyScanW('g' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyH => unsafe { VkKeyScanW('h' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyI => unsafe { VkKeyScanW('i' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyJ => unsafe { VkKeyScanW('j' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyK => unsafe { VkKeyScanW('k' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyL => unsafe { VkKeyScanW('l' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyM => unsafe { VkKeyScanW('m' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyN => unsafe { VkKeyScanW('n' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyO => unsafe { VkKeyScanW('o' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyP => unsafe { VkKeyScanW('p' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyQ => unsafe { VkKeyScanW('q' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyR => unsafe { VkKeyScanW('r' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyS => unsafe { VkKeyScanW('s' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyT => unsafe { VkKeyScanW('t' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyU => unsafe { VkKeyScanW('u' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyV => unsafe { VkKeyScanW('v' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyW => unsafe { VkKeyScanW('w' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyX => unsafe { VkKeyScanW('x' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyY => unsafe { VkKeyScanW('y' as u16) as VIRTUAL_KEY },
-    KeyCode::KeyZ => unsafe { VkKeyScanW('z' as u16) as VIRTUAL_KEY },
-    KeyCode::Digit0 => unsafe { VkKeyScanW('0' as u16) as VIRTUAL_KEY },
-    KeyCode::Digit1 => unsafe { VkKeyScanW('1' as u16) as VIRTUAL_KEY },
-    KeyCode::Digit2 => unsafe { VkKeyScanW('2' as u16) as VIRTUAL_KEY },
-    KeyCode::Digit3 => unsafe { VkKeyScanW('3' as u16) as VIRTUAL_KEY },
-    KeyCode::Digit4 => unsafe { VkKeyScanW('4' as u16) as VIRTUAL_KEY },
-    KeyCode::Digit5 => unsafe { VkKeyScanW('5' as u16) as VIRTUAL_KEY },
-    KeyCode::Digit6 => unsafe { VkKeyScanW('6' as u16) as VIRTUAL_KEY },
-    KeyCode::Digit7 => unsafe { VkKeyScanW('7' as u16) as VIRTUAL_KEY },
-    KeyCode::Digit8 => unsafe { VkKeyScanW('8' as u16) as VIRTUAL_KEY },
-    KeyCode::Digit9 => unsafe { VkKeyScanW('9' as u16) as VIRTUAL_KEY },
+    KeyCode::KeyA => unsafe { VIRTUAL_KEY(VkKeyScanW('a' as u16) as u16) },
+    KeyCode::KeyB => unsafe { VIRTUAL_KEY(VkKeyScanW('b' as u16) as u16) },
+    KeyCode::KeyC => unsafe { VIRTUAL_KEY(VkKeyScanW('c' as u16) as u16) },
+    KeyCode::KeyD => unsafe { VIRTUAL_KEY(VkKeyScanW('d' as u16) as u16) },
+    KeyCode::KeyE => unsafe { VIRTUAL_KEY(VkKeyScanW('e' as u16) as u16) },
+    KeyCode::KeyF => unsafe { VIRTUAL_KEY(VkKeyScanW('f' as u16) as u16) },
+    KeyCode::KeyG => unsafe { VIRTUAL_KEY(VkKeyScanW('g' as u16) as u16) },
+    KeyCode::KeyH => unsafe { VIRTUAL_KEY(VkKeyScanW('h' as u16) as u16) },
+    KeyCode::KeyI => unsafe { VIRTUAL_KEY(VkKeyScanW('i' as u16) as u16) },
+    KeyCode::KeyJ => unsafe { VIRTUAL_KEY(VkKeyScanW('j' as u16) as u16) },
+    KeyCode::KeyK => unsafe { VIRTUAL_KEY(VkKeyScanW('k' as u16) as u16) },
+    KeyCode::KeyL => unsafe { VIRTUAL_KEY(VkKeyScanW('l' as u16) as u16) },
+    KeyCode::KeyM => unsafe { VIRTUAL_KEY(VkKeyScanW('m' as u16) as u16) },
+    KeyCode::KeyN => unsafe { VIRTUAL_KEY(VkKeyScanW('n' as u16) as u16) },
+    KeyCode::KeyO => unsafe { VIRTUAL_KEY(VkKeyScanW('o' as u16) as u16) },
+    KeyCode::KeyP => unsafe { VIRTUAL_KEY(VkKeyScanW('p' as u16) as u16) },
+    KeyCode::KeyQ => unsafe { VIRTUAL_KEY(VkKeyScanW('q' as u16) as u16) },
+    KeyCode::KeyR => unsafe { VIRTUAL_KEY(VkKeyScanW('r' as u16) as u16) },
+    KeyCode::KeyS => unsafe { VIRTUAL_KEY(VkKeyScanW('s' as u16) as u16) },
+    KeyCode::KeyT => unsafe { VIRTUAL_KEY(VkKeyScanW('t' as u16) as u16) },
+    KeyCode::KeyU => unsafe { VIRTUAL_KEY(VkKeyScanW('u' as u16) as u16) },
+    KeyCode::KeyV => unsafe { VIRTUAL_KEY(VkKeyScanW('v' as u16) as u16) },
+    KeyCode::KeyW => unsafe { VIRTUAL_KEY(VkKeyScanW('w' as u16) as u16) },
+    KeyCode::KeyX => unsafe { VIRTUAL_KEY(VkKeyScanW('x' as u16) as u16) },
+    KeyCode::KeyY => unsafe { VIRTUAL_KEY(VkKeyScanW('y' as u16) as u16) },
+    KeyCode::KeyZ => unsafe { VIRTUAL_KEY(VkKeyScanW('z' as u16) as u16) },
+    KeyCode::Digit0 => unsafe { VIRTUAL_KEY(VkKeyScanW('0' as u16) as u16) },
+    KeyCode::Digit1 => unsafe { VIRTUAL_KEY(VkKeyScanW('1' as u16) as u16) },
+    KeyCode::Digit2 => unsafe { VIRTUAL_KEY(VkKeyScanW('2' as u16) as u16) },
+    KeyCode::Digit3 => unsafe { VIRTUAL_KEY(VkKeyScanW('3' as u16) as u16) },
+    KeyCode::Digit4 => unsafe { VIRTUAL_KEY(VkKeyScanW('4' as u16) as u16) },
+    KeyCode::Digit5 => unsafe { VIRTUAL_KEY(VkKeyScanW('5' as u16) as u16) },
+    KeyCode::Digit6 => unsafe { VIRTUAL_KEY(VkKeyScanW('6' as u16) as u16) },
+    KeyCode::Digit7 => unsafe { VIRTUAL_KEY(VkKeyScanW('7' as u16) as u16) },
+    KeyCode::Digit8 => unsafe { VIRTUAL_KEY(VkKeyScanW('8' as u16) as u16) },
+    KeyCode::Digit9 => unsafe { VIRTUAL_KEY(VkKeyScanW('9' as u16) as u16) },
     KeyCode::Comma => VK_OEM_COMMA,
     KeyCode::Minus => VK_OEM_MINUS,
     KeyCode::Period => VK_OEM_PERIOD,
-    KeyCode::Equal => unsafe { VkKeyScanW('=' as u16) as VIRTUAL_KEY },
-    KeyCode::Semicolon => unsafe { VkKeyScanW(';' as u16) as VIRTUAL_KEY },
-    KeyCode::Slash => unsafe { VkKeyScanW('/' as u16) as VIRTUAL_KEY },
-    KeyCode::Backslash => unsafe { VkKeyScanW('\\' as u16) as VIRTUAL_KEY },
-    KeyCode::Quote => unsafe { VkKeyScanW('\'' as u16) as VIRTUAL_KEY },
-    KeyCode::Backquote => unsafe { VkKeyScanW('`' as u16) as VIRTUAL_KEY },
-    KeyCode::BracketLeft => unsafe { VkKeyScanW('[' as u16) as VIRTUAL_KEY },
-    KeyCode::BracketRight => unsafe { VkKeyScanW(']' as u16) as VIRTUAL_KEY },
+    KeyCode::Equal => unsafe { VIRTUAL_KEY(VkKeyScanW('=' as u16) as u16) },
+    KeyCode::Semicolon => unsafe { VIRTUAL_KEY(VkKeyScanW(';' as u16) as u16) },
+    KeyCode::Slash => unsafe { VIRTUAL_KEY(VkKeyScanW('/' as u16) as u16) },
+    KeyCode::Backslash => unsafe { VIRTUAL_KEY(VkKeyScanW('\\' as u16) as u16) },
+    KeyCode::Quote => unsafe { VIRTUAL_KEY(VkKeyScanW('\'' as u16) as u16) },
+    KeyCode::Backquote => unsafe { VIRTUAL_KEY(VkKeyScanW('`' as u16) as u16) },
+    KeyCode::BracketLeft => unsafe { VIRTUAL_KEY(VkKeyScanW('[' as u16) as u16) },
+    KeyCode::BracketRight => unsafe { VIRTUAL_KEY(VkKeyScanW(']' as u16) as u16) },
     KeyCode::Backspace => VK_BACK,
     KeyCode::Tab => VK_TAB,
     KeyCode::Space => VK_SPACE,

--- a/src/platform_impl/windows/keyboard_layout.rs
+++ b/src/platform_impl/windows/keyboard_layout.rs
@@ -7,15 +7,12 @@ use std::{
 
 use lazy_static::lazy_static;
 
-use windows::{
-  core::PWSTR,
-  Win32::{
-    System::SystemServices::{LANG_JAPANESE, LANG_KOREAN},
-    UI::{
-      Input::KeyboardAndMouse::{self as win32km, *},
-      TextServices::HKL,
-      WindowsAndMessaging::*,
-    },
+use windows::Win32::{
+  System::SystemServices::{LANG_JAPANESE, LANG_KOREAN},
+  UI::{
+    Input::KeyboardAndMouse::{self as win32km, *},
+    TextServices::HKL,
+    WindowsAndMessaging::*,
   },
 };
 
@@ -441,9 +438,8 @@ impl LayoutCache {
       let mut wide_len = ToUnicodeEx(
         u32::from(vkey.0),
         scancode,
-        (&key_state[0]) as *const _,
-        PWSTR((&mut label_wide[0]) as *mut _),
-        label_wide.len() as i32,
+        &key_state,
+        &mut label_wide,
         0,
         locale_id,
       );
@@ -452,9 +448,8 @@ impl LayoutCache {
         wide_len = ToUnicodeEx(
           u32::from(vkey.0),
           scancode,
-          (&key_state[0]) as *const _,
-          PWSTR((&mut label_wide[0]) as *mut _),
-          label_wide.len() as i32,
+          &key_state,
+          &mut label_wide,
           0,
           locale_id,
         );

--- a/src/platform_impl/windows/keyboard_layout.rs
+++ b/src/platform_impl/windows/keyboard_layout.rs
@@ -438,7 +438,7 @@ impl LayoutCache {
       let mut wide_len = ToUnicodeEx(
         u32::from(vkey.0),
         scancode,
-        &key_state,
+        key_state,
         &mut label_wide,
         0,
         locale_id,
@@ -448,7 +448,7 @@ impl LayoutCache {
         wide_len = ToUnicodeEx(
           u32::from(vkey.0),
           scancode,
-          &key_state,
+          key_state,
           &mut label_wide,
           0,
           locale_id,

--- a/src/platform_impl/windows/keyboard_layout.rs
+++ b/src/platform_impl/windows/keyboard_layout.rs
@@ -7,13 +7,15 @@ use std::{
 
 use lazy_static::lazy_static;
 
-use windows::Win32::{
-  Foundation::PWSTR,
-  System::SystemServices::{LANG_JAPANESE, LANG_KOREAN},
-  UI::{
-    Input::KeyboardAndMouse::{self as win32km, *},
-    TextServices::HKL,
-    WindowsAndMessaging::*,
+use windows::{
+  core::PWSTR,
+  Win32::{
+    System::SystemServices::{LANG_JAPANESE, LANG_KOREAN},
+    UI::{
+      Input::KeyboardAndMouse::{self as win32km, *},
+      TextServices::HKL,
+      WindowsAndMessaging::*,
+    },
   },
 };
 

--- a/src/platform_impl/windows/keyboard_layout.rs
+++ b/src/platform_impl/windows/keyboard_layout.rs
@@ -28,7 +28,7 @@ lazy_static! {
 }
 
 fn key_pressed(vkey: VIRTUAL_KEY) -> bool {
-  unsafe { (GetKeyState(u32::from(vkey) as i32) & (1 << 15)) == (1 << 15) }
+  unsafe { (GetKeyState(u32::from(vkey.0) as i32) & (1 << 15)) == (1 << 15) }
 }
 
 const NUMPAD_VKEYS: [VIRTUAL_KEY; 16] = [
@@ -85,19 +85,19 @@ bitflags! {
 
 impl WindowsModifiers {
   pub fn active_modifiers(key_state: &[u8; 256]) -> WindowsModifiers {
-    let shift = key_state[usize::from(VK_SHIFT)] & 0x80 != 0;
-    let lshift = key_state[usize::from(VK_LSHIFT)] & 0x80 != 0;
-    let rshift = key_state[usize::from(VK_RSHIFT)] & 0x80 != 0;
+    let shift = key_state[usize::from(VK_SHIFT.0)] & 0x80 != 0;
+    let lshift = key_state[usize::from(VK_LSHIFT.0)] & 0x80 != 0;
+    let rshift = key_state[usize::from(VK_RSHIFT.0)] & 0x80 != 0;
 
-    let control = key_state[usize::from(VK_CONTROL)] & 0x80 != 0;
-    let lcontrol = key_state[usize::from(VK_LCONTROL)] & 0x80 != 0;
-    let rcontrol = key_state[usize::from(VK_RCONTROL)] & 0x80 != 0;
+    let control = key_state[usize::from(VK_CONTROL.0)] & 0x80 != 0;
+    let lcontrol = key_state[usize::from(VK_LCONTROL.0)] & 0x80 != 0;
+    let rcontrol = key_state[usize::from(VK_RCONTROL.0)] & 0x80 != 0;
 
-    let alt = key_state[usize::from(VK_MENU)] & 0x80 != 0;
-    let lalt = key_state[usize::from(VK_LMENU)] & 0x80 != 0;
-    let ralt = key_state[usize::from(VK_RMENU)] & 0x80 != 0;
+    let alt = key_state[usize::from(VK_MENU.0)] & 0x80 != 0;
+    let lalt = key_state[usize::from(VK_LMENU.0)] & 0x80 != 0;
+    let ralt = key_state[usize::from(VK_RMENU.0)] & 0x80 != 0;
 
-    let caps = key_state[usize::from(VK_CAPITAL)] & 0x01 != 0;
+    let caps = key_state[usize::from(VK_CAPITAL.0)] & 0x01 != 0;
 
     let mut result = WindowsModifiers::empty();
     if shift || lshift || rshift {
@@ -118,30 +118,30 @@ impl WindowsModifiers {
 
   pub fn apply_to_kbd_state(self, key_state: &mut [u8; 256]) {
     if self.intersects(Self::SHIFT) {
-      key_state[usize::from(VK_SHIFT)] |= 0x80;
+      key_state[usize::from(VK_SHIFT.0)] |= 0x80;
     } else {
-      key_state[usize::from(VK_SHIFT)] &= !0x80;
-      key_state[usize::from(VK_LSHIFT)] &= !0x80;
-      key_state[usize::from(VK_RSHIFT)] &= !0x80;
+      key_state[usize::from(VK_SHIFT.0)] &= !0x80;
+      key_state[usize::from(VK_LSHIFT.0)] &= !0x80;
+      key_state[usize::from(VK_RSHIFT.0)] &= !0x80;
     }
     if self.intersects(Self::CONTROL) {
-      key_state[usize::from(VK_CONTROL)] |= 0x80;
+      key_state[usize::from(VK_CONTROL.0)] |= 0x80;
     } else {
-      key_state[usize::from(VK_CONTROL)] &= !0x80;
-      key_state[usize::from(VK_LCONTROL)] &= !0x80;
-      key_state[usize::from(VK_RCONTROL)] &= !0x80;
+      key_state[usize::from(VK_CONTROL.0)] &= !0x80;
+      key_state[usize::from(VK_LCONTROL.0)] &= !0x80;
+      key_state[usize::from(VK_RCONTROL.0)] &= !0x80;
     }
     if self.intersects(Self::ALT) {
-      key_state[usize::from(VK_MENU)] |= 0x80;
+      key_state[usize::from(VK_MENU.0)] |= 0x80;
     } else {
-      key_state[usize::from(VK_MENU)] &= !0x80;
-      key_state[usize::from(VK_LMENU)] &= !0x80;
-      key_state[usize::from(VK_RMENU)] &= !0x80;
+      key_state[usize::from(VK_MENU.0)] &= !0x80;
+      key_state[usize::from(VK_LMENU.0)] &= !0x80;
+      key_state[usize::from(VK_RMENU.0)] &= !0x80;
     }
     if self.intersects(Self::CAPS_LOCK) {
-      key_state[usize::from(VK_CAPITAL)] |= 0x01;
+      key_state[usize::from(VK_CAPITAL.0)] |= 0x01;
     } else {
-      key_state[usize::from(VK_CAPITAL)] &= !0x01;
+      key_state[usize::from(VK_CAPITAL.0)] &= !0x01;
     }
   }
 
@@ -214,10 +214,10 @@ impl Layout {
       }
     }
     if num_lock_on {
-      if let Some(key) = self.numlock_on_keys.get(&vkey) {
+      if let Some(key) = self.numlock_on_keys.get(&vkey.0) {
         return key.clone();
       }
-    } else if let Some(key) = self.numlock_off_keys.get(&vkey) {
+    } else if let Some(key) = self.numlock_off_keys.get(&vkey.0) {
       return key.clone();
     }
 
@@ -305,31 +305,32 @@ impl LayoutCache {
       if scancode == 0 {
         continue;
       }
+      let vk = VIRTUAL_KEY(vk);
       let keycode = KeyCode::from_scancode(scancode);
       if !is_numpad_specific(vk) && NUMPAD_KEYCODES.contains(&keycode) {
         let native_code = NativeKeyCode::Windows(scancode as u16);
         let map_vkey = keycode_to_vkey(keycode, locale_id);
-        if map_vkey == 0 {
+        if map_vkey == Default::default() {
           continue;
         }
         let map_value = vkey_to_non_char_key(vk, native_code, locale_id, false);
         if matches!(map_value, Key::Unidentified(_)) {
           continue;
         }
-        layout.numlock_off_keys.insert(map_vkey, map_value);
+        layout.numlock_off_keys.insert(map_vkey.0, map_value);
       }
     }
 
     layout.numlock_on_keys.reserve(NUMPAD_VKEYS.len());
     for vk in NUMPAD_VKEYS.iter() {
       let scancode =
-        unsafe { MapVirtualKeyExW(u32::from(*vk), MAPVK_VK_TO_VSC_EX, locale_id as HKL) };
+        unsafe { MapVirtualKeyExW(u32::from(vk.0), MAPVK_VK_TO_VSC_EX, locale_id as HKL) };
       let unicode = Self::to_unicode_string(&key_state, *vk, scancode, locale_id);
       if let ToUnicodeResult::Str(s) = unicode {
         let static_str = get_or_insert_str(strings, s);
         layout
           .numlock_on_keys
-          .insert(*vk, Key::Character(static_str));
+          .insert(vk.0, Key::Character(static_str));
       }
     }
 
@@ -350,6 +351,7 @@ impl LayoutCache {
         if scancode == 0 {
           continue;
         }
+        let vk = VIRTUAL_KEY(vk);
         let native_code = NativeKeyCode::Windows(scancode as ExScancode);
         let key_code = KeyCode::from_scancode(scancode);
         // Let's try to get the key from just the scancode and vk
@@ -435,7 +437,7 @@ impl LayoutCache {
     unsafe {
       let mut label_wide = [0u16; 8];
       let mut wide_len = ToUnicodeEx(
-        u32::from(vkey),
+        u32::from(vkey.0),
         scancode,
         (&key_state[0]) as *const _,
         PWSTR((&mut label_wide[0]) as *mut _),
@@ -446,7 +448,7 @@ impl LayoutCache {
       if wide_len < 0 {
         // If it's dead, we run `ToUnicode` again to consume the dead-key
         wide_len = ToUnicodeEx(
-          u32::from(vkey),
+          u32::from(vkey.0),
           scancode,
           (&key_state[0]) as *const _,
           PWSTR((&mut label_wide[0]) as *mut _),

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -3,12 +3,15 @@
 
 use std::{collections::HashMap, fmt, sync::Mutex};
 
-use windows::Win32::{
-  Foundation::{HWND, LPARAM, LRESULT, PSTR, PWSTR, WPARAM},
-  UI::{
-    Input::KeyboardAndMouse::*,
-    Shell::*,
-    WindowsAndMessaging::{self as win32wm, *},
+use windows::{
+  core::{PCWSTR, PSTR},
+  Win32::{
+    Foundation::{HWND, LPARAM, LRESULT, WPARAM},
+    UI::{
+      Input::KeyboardAndMouse::*,
+      Shell::*,
+      WindowsAndMessaging::{self as win32wm, *},
+    },
   },
 };
 
@@ -26,7 +29,7 @@ use super::{accelerator::register_accel, keyboard::key_to_vk, util, WindowId};
 struct AccelWrapper(ACCEL);
 impl fmt::Debug for AccelWrapper {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-    f.pad(&format!(""))
+    f.pad("")
   }
 }
 
@@ -195,8 +198,8 @@ impl Menu {
         format_hotkey(accelerators, &mut anno_title);
       }
       // NOTE(amrbashir): The title must be a null-terminated string. Otherwise, it will display some gibberish characters at the end.
-      if !anno_title.ends_with("\0") {
-        anno_title.push_str("\0");
+      if !anno_title.ends_with('\0') {
+        anno_title.push('\0');
       }
 
       AppendMenuW(self.hmenu, flags, menu_id.0 as _, anno_title);
@@ -234,7 +237,7 @@ impl Menu {
     match item {
       MenuItem::Separator => {
         unsafe {
-          AppendMenuW(self.hmenu, MF_SEPARATOR, 0, PWSTR::default());
+          AppendMenuW(self.hmenu, MF_SEPARATOR, 0, PCWSTR::default());
         };
       }
       MenuItem::Cut => unsafe {

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -167,7 +167,7 @@ impl Default for Menu {
 impl Menu {
   pub fn new() -> Self {
     unsafe {
-      let hmenu = CreateMenu();
+      let hmenu = CreateMenu().unwrap_or_default();
       Menu {
         hmenu,
         accels: HashMap::default(),
@@ -177,7 +177,7 @@ impl Menu {
 
   pub fn new_popup_menu() -> Self {
     unsafe {
-      let hmenu = CreatePopupMenu();
+      let hmenu = CreatePopupMenu().unwrap_or_default();
       Menu {
         hmenu,
         accels: HashMap::default(),
@@ -410,11 +410,7 @@ fn execute_edit_command(command: EditCommand) {
     inputs[3].Anonymous.ki.wVk = VK_CONTROL;
     inputs[3].Anonymous.ki.dwFlags = KEYEVENTF_KEYUP;
 
-    SendInput(
-      inputs.len() as _,
-      inputs.as_mut_ptr(),
-      std::mem::size_of::<INPUT>() as _,
-    );
+    SendInput(&inputs, std::mem::size_of::<INPUT>() as _);
   }
 }
 

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2021 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, fmt, sync::Mutex};
+use std::{collections::HashMap, fmt, ptr, sync::Mutex};
 
 use windows::{
   core::{PCWSTR, PWSTR},
@@ -89,7 +89,7 @@ impl MenuItemAttributes {
       let mut mif = MENUITEMINFOW {
         cbSize: std::mem::size_of::<MENUITEMINFOW>() as _,
         fMask: MIIM_STRING,
-        dwTypeData: PWSTR(0 as *mut u16),
+        dwTypeData: PWSTR(ptr::null_mut()),
         ..Default::default()
       };
       GetMenuItemInfoW(self.1, self.0 as u32, false, &mut mif);
@@ -97,7 +97,7 @@ impl MenuItemAttributes {
       mif.dwTypeData = PWSTR(Vec::with_capacity(mif.cch as usize).as_mut_ptr());
       GetMenuItemInfoW(self.1, self.0 as u32, false, &mut mif);
       util::wchar_ptr_to_string(PCWSTR(mif.dwTypeData.0))
-        .split("\t")
+        .split('\t')
         .next()
         .unwrap_or_default()
         .to_string()
@@ -235,11 +235,7 @@ impl Menu {
         }
       }
       MENU_IDS.lock().unwrap().push(menu_id.0 as _);
-      CustomMenuItem(MenuItemAttributes(
-        menu_id.0,
-        self.hmenu,
-        accelerator.clone(),
-      ))
+      CustomMenuItem(MenuItemAttributes(menu_id.0, self.hmenu, accelerator))
     }
   }
 
@@ -452,84 +448,84 @@ impl Accelerator {
       cmd: menu_id,
     })
   }
+}
 
-  fn to_string(&self) -> String {
-    let mut s = String::new();
+impl fmt::Display for Accelerator {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     let key_mods: ModifiersState = self.mods;
     if key_mods.control_key() {
-      s.push_str("Ctrl+");
+      write!(f, "Ctrl+")?;
     }
     if key_mods.shift_key() {
-      s.push_str("Shift+");
+      write!(f, "Shift+")?;
     }
     if key_mods.alt_key() {
-      s.push_str("Alt+");
+      write!(f, "Alt+")?;
     }
     if key_mods.super_key() {
-      s.push_str("Windows+");
+      write!(f, "Windows+")?;
     }
     match &self.key {
-      KeyCode::KeyA => s.push('A'),
-      KeyCode::KeyB => s.push('B'),
-      KeyCode::KeyC => s.push('C'),
-      KeyCode::KeyD => s.push('D'),
-      KeyCode::KeyE => s.push('E'),
-      KeyCode::KeyF => s.push('F'),
-      KeyCode::KeyG => s.push('G'),
-      KeyCode::KeyH => s.push('H'),
-      KeyCode::KeyI => s.push('I'),
-      KeyCode::KeyJ => s.push('J'),
-      KeyCode::KeyK => s.push('K'),
-      KeyCode::KeyL => s.push('L'),
-      KeyCode::KeyM => s.push('M'),
-      KeyCode::KeyN => s.push('N'),
-      KeyCode::KeyO => s.push('O'),
-      KeyCode::KeyP => s.push('P'),
-      KeyCode::KeyQ => s.push('Q'),
-      KeyCode::KeyR => s.push('R'),
-      KeyCode::KeyS => s.push('S'),
-      KeyCode::KeyT => s.push('T'),
-      KeyCode::KeyU => s.push('U'),
-      KeyCode::KeyV => s.push('V'),
-      KeyCode::KeyW => s.push('W'),
-      KeyCode::KeyX => s.push('X'),
-      KeyCode::KeyY => s.push('Y'),
-      KeyCode::KeyZ => s.push('Z'),
-      KeyCode::Digit0 => s.push('0'),
-      KeyCode::Digit1 => s.push('1'),
-      KeyCode::Digit2 => s.push('2'),
-      KeyCode::Digit3 => s.push('3'),
-      KeyCode::Digit4 => s.push('4'),
-      KeyCode::Digit5 => s.push('5'),
-      KeyCode::Digit6 => s.push('6'),
-      KeyCode::Digit7 => s.push('7'),
-      KeyCode::Digit8 => s.push('8'),
-      KeyCode::Digit9 => s.push('9'),
-      KeyCode::Comma => s.push(','),
-      KeyCode::Minus => s.push('-'),
-      KeyCode::Period => s.push('.'),
-      KeyCode::Space => s.push_str("Space"),
-      KeyCode::Equal => s.push('='),
-      KeyCode::Semicolon => s.push(';'),
-      KeyCode::Slash => s.push('/'),
-      KeyCode::Backslash => s.push('\\'),
-      KeyCode::Quote => s.push('\''),
-      KeyCode::Backquote => s.push('`'),
-      KeyCode::BracketLeft => s.push('['),
-      KeyCode::BracketRight => s.push(']'),
-      KeyCode::Tab => s.push_str("Tab"),
-      KeyCode::Escape => s.push_str("Esc"),
-      KeyCode::Delete => s.push_str("Del"),
-      KeyCode::Insert => s.push_str("Ins"),
-      KeyCode::PageUp => s.push_str("PgUp"),
-      KeyCode::PageDown => s.push_str("PgDn"),
+      KeyCode::KeyA => write!(f, "A"),
+      KeyCode::KeyB => write!(f, "B"),
+      KeyCode::KeyC => write!(f, "C"),
+      KeyCode::KeyD => write!(f, "D"),
+      KeyCode::KeyE => write!(f, "E"),
+      KeyCode::KeyF => write!(f, "F"),
+      KeyCode::KeyG => write!(f, "G"),
+      KeyCode::KeyH => write!(f, "H"),
+      KeyCode::KeyI => write!(f, "I"),
+      KeyCode::KeyJ => write!(f, "J"),
+      KeyCode::KeyK => write!(f, "K"),
+      KeyCode::KeyL => write!(f, "L"),
+      KeyCode::KeyM => write!(f, "M"),
+      KeyCode::KeyN => write!(f, "N"),
+      KeyCode::KeyO => write!(f, "O"),
+      KeyCode::KeyP => write!(f, "P"),
+      KeyCode::KeyQ => write!(f, "Q"),
+      KeyCode::KeyR => write!(f, "R"),
+      KeyCode::KeyS => write!(f, "S"),
+      KeyCode::KeyT => write!(f, "T"),
+      KeyCode::KeyU => write!(f, "U"),
+      KeyCode::KeyV => write!(f, "V"),
+      KeyCode::KeyW => write!(f, "W"),
+      KeyCode::KeyX => write!(f, "X"),
+      KeyCode::KeyY => write!(f, "Y"),
+      KeyCode::KeyZ => write!(f, "Z"),
+      KeyCode::Digit0 => write!(f, "0"),
+      KeyCode::Digit1 => write!(f, "1"),
+      KeyCode::Digit2 => write!(f, "2"),
+      KeyCode::Digit3 => write!(f, "3"),
+      KeyCode::Digit4 => write!(f, "4"),
+      KeyCode::Digit5 => write!(f, "5"),
+      KeyCode::Digit6 => write!(f, "6"),
+      KeyCode::Digit7 => write!(f, "7"),
+      KeyCode::Digit8 => write!(f, "8"),
+      KeyCode::Digit9 => write!(f, "9"),
+      KeyCode::Comma => write!(f, ","),
+      KeyCode::Minus => write!(f, "-"),
+      KeyCode::Period => write!(f, "."),
+      KeyCode::Space => write!(f, "Space"),
+      KeyCode::Equal => write!(f, "="),
+      KeyCode::Semicolon => write!(f, ";"),
+      KeyCode::Slash => write!(f, "/"),
+      KeyCode::Backslash => write!(f, "\\"),
+      KeyCode::Quote => write!(f, "\'"),
+      KeyCode::Backquote => write!(f, "`"),
+      KeyCode::BracketLeft => write!(f, "["),
+      KeyCode::BracketRight => write!(f, "]"),
+      KeyCode::Tab => write!(f, "Tab"),
+      KeyCode::Escape => write!(f, "Esc"),
+      KeyCode::Delete => write!(f, "Del"),
+      KeyCode::Insert => write!(f, "Ins"),
+      KeyCode::PageUp => write!(f, "PgUp"),
+      KeyCode::PageDown => write!(f, "PgDn"),
       // These names match LibreOffice.
-      KeyCode::ArrowLeft => s.push_str("Left"),
-      KeyCode::ArrowRight => s.push_str("Right"),
-      KeyCode::ArrowUp => s.push_str("Up"),
-      KeyCode::ArrowDown => s.push_str("Down"),
-      _ => s.push_str(&format!("{:?}", self.key)),
+      KeyCode::ArrowLeft => write!(f, "Left"),
+      KeyCode::ArrowRight => write!(f, "Right"),
+      KeyCode::ArrowUp => write!(f, "Up"),
+      KeyCode::ArrowDown => write!(f, "Down"),
+      _ => write!(f, "{:?}", self.key),
     }
-    s
   }
 }

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -1,9 +1,12 @@
 // Copyright 2019-2021 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
-use windows::Win32::{
-  Foundation::{BOOL, HWND, LPARAM, POINT, PWSTR, RECT},
-  Graphics::Gdi::*,
+use windows::{
+  core::PCWSTR,
+  Win32::{
+    Foundation::{BOOL, HWND, LPARAM, POINT, RECT},
+    Graphics::Gdi::*,
+  },
 };
 
 use std::{
@@ -153,9 +156,9 @@ impl MonitorHandle {
 
   #[inline]
   pub fn name(&self) -> Option<String> {
-    let mut monitor_info = get_monitor_info(self.hmonitor()).unwrap();
-    Some(util::wchar_ptr_to_string(PWSTR(
-      monitor_info.szDevice.as_mut_ptr(),
+    let monitor_info = get_monitor_info(self.hmonitor()).unwrap();
+    Some(util::wchar_ptr_to_string(PCWSTR(
+      monitor_info.szDevice.as_ptr(),
     )))
   }
 
@@ -204,8 +207,8 @@ impl MonitorHandle {
 
     loop {
       unsafe {
-        let mut monitor_info = get_monitor_info(self.hmonitor()).unwrap();
-        let device_name = PWSTR(monitor_info.szDevice.as_mut_ptr());
+        let monitor_info = get_monitor_info(self.hmonitor()).unwrap();
+        let device_name = PCWSTR(monitor_info.szDevice.as_ptr());
         let mut mode: DEVMODEW = mem::zeroed();
         mode.dmSize = mem::size_of_val(&mode) as u16;
         if !EnumDisplaySettingsExW(device_name, ENUM_DISPLAY_SETTINGS_MODE(i), &mut mode, 0)

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -208,7 +208,7 @@ impl MonitorHandle {
         let device_name = PWSTR(monitor_info.szDevice.as_mut_ptr());
         let mut mode: DEVMODEW = mem::zeroed();
         mode.dmSize = mem::size_of_val(&mode) as u16;
-        if !EnumDisplaySettingsExW(device_name, i as ENUM_DISPLAY_SETTINGS_MODE, &mut mode, 0)
+        if !EnumDisplaySettingsExW(device_name, ENUM_DISPLAY_SETTINGS_MODE(i), &mut mode, 0)
           .as_bool()
         {
           break;

--- a/src/platform_impl/windows/raw_input.rs
+++ b/src/platform_impl/windows/raw_input.rs
@@ -125,8 +125,7 @@ pub fn get_raw_input_device_name(handle: HANDLE) -> Option<String> {
 pub fn register_raw_input_devices(devices: &[RAWINPUTDEVICE]) -> bool {
   let device_size = size_of::<RAWINPUTDEVICE>() as u32;
 
-  let success =
-    unsafe { RegisterRawInputDevices(devices.as_ptr() as _, devices.len() as _, device_size) };
+  let success = unsafe { RegisterRawInputDevices(&devices, device_size) };
 
   success.as_bool()
 }

--- a/src/platform_impl/windows/raw_input.rs
+++ b/src/platform_impl/windows/raw_input.rs
@@ -125,7 +125,7 @@ pub fn get_raw_input_device_name(handle: HANDLE) -> Option<String> {
 pub fn register_raw_input_devices(devices: &[RAWINPUTDEVICE]) -> bool {
   let device_size = size_of::<RAWINPUTDEVICE>() as u32;
 
-  let success = unsafe { RegisterRawInputDevices(&devices, device_size) };
+  let success = unsafe { RegisterRawInputDevices(devices, device_size) };
 
   success.as_bool()
 }

--- a/src/platform_impl/windows/raw_input.rs
+++ b/src/platform_impl/windows/raw_input.rs
@@ -134,7 +134,7 @@ pub fn register_raw_input_devices(devices: &[RAWINPUTDEVICE]) -> bool {
 pub fn register_all_mice_and_keyboards_for_raw_input(window_handle: HWND) -> bool {
   // RIDEV_DEVNOTIFY: receive hotplug events
   // RIDEV_INPUTSINK: receive events even if we're not in the foreground
-  let flags = RIDEV_DEVNOTIFY | RIDEV_INPUTSINK;
+  let flags = RAWINPUTDEVICE_FLAGS(RIDEV_DEVNOTIFY.0 | RIDEV_INPUTSINK.0);
 
   let devices: [RAWINPUTDEVICE; 2] = [
     RAWINPUTDEVICE {

--- a/src/platform_impl/windows/system_tray.rs
+++ b/src/platform_impl/windows/system_tray.rs
@@ -56,7 +56,7 @@ impl SystemTrayBuilder {
 
     let class_name = util::encode_wide("tao_system_tray_app");
     unsafe {
-      let hinstance = GetModuleHandleA(PCSTR::default());
+      let hinstance = GetModuleHandleA(PCSTR::default()).unwrap_or_default();
 
       let wnd_class = WNDCLASSW {
         lpfnWndProc: Some(util::call_default_window_proc),
@@ -82,7 +82,7 @@ impl SystemTrayBuilder {
         std::ptr::null_mut(),
       );
 
-      if hwnd.is_invalid() {
+      if !IsWindow(hwnd).as_bool() {
         return Err(os_error!(OsError::CreationError(
           "Unable to get valid mutable pointer for CreateWindowEx"
         )));

--- a/src/platform_impl/windows/system_tray.rs
+++ b/src/platform_impl/windows/system_tray.rs
@@ -13,12 +13,15 @@ use crate::{
   menu::MenuType,
   system_tray::SystemTray as RootSystemTray,
 };
-use windows::Win32::{
-  Foundation::{HWND, LPARAM, LRESULT, POINT, PSTR, PWSTR, WPARAM},
-  System::LibraryLoader::*,
-  UI::{
-    Shell::*,
-    WindowsAndMessaging::{self as win32wm, *},
+use windows::{
+  core::{PCSTR, PCWSTR},
+  Win32::{
+    Foundation::{HWND, LPARAM, LRESULT, POINT, WPARAM},
+    System::LibraryLoader::*,
+    UI::{
+      Shell::*,
+      WindowsAndMessaging::{self as win32wm, *},
+    },
   },
 };
 
@@ -51,13 +54,13 @@ impl SystemTrayBuilder {
   ) -> Result<RootSystemTray, RootOsError> {
     let hmenu: Option<HMENU> = self.tray_menu.map(|m| m.hmenu());
 
-    let mut class_name = util::to_wstring("tao_system_tray_app");
+    let class_name = util::to_wstring("tao_system_tray_app");
     unsafe {
-      let hinstance = GetModuleHandleA(PSTR::default());
+      let hinstance = GetModuleHandleA(PCSTR::default());
 
       let wnd_class = WNDCLASSW {
         lpfnWndProc: Some(util::call_default_window_proc),
-        lpszClassName: PWSTR(class_name.as_mut_ptr()),
+        lpszClassName: PCWSTR(class_name.as_ptr()),
         hInstance: hinstance,
         ..Default::default()
       };
@@ -66,7 +69,7 @@ impl SystemTrayBuilder {
 
       let hwnd = CreateWindowExW(
         Default::default(),
-        PWSTR(class_name.as_mut_ptr()),
+        PCWSTR(class_name.as_ptr()),
         "tao_system_tray_window",
         WS_OVERLAPPEDWINDOW,
         CW_USEDEFAULT,

--- a/src/platform_impl/windows/system_tray.rs
+++ b/src/platform_impl/windows/system_tray.rs
@@ -65,7 +65,7 @@ impl SystemTrayBuilder {
       RegisterClassW(&wnd_class);
 
       let hwnd = CreateWindowExW(
-        0,
+        Default::default(),
         PWSTR(class_name.as_mut_ptr()),
         "tao_system_tray_window",
         WS_OVERLAPPEDWINDOW,

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -12,9 +12,9 @@ use std::{
 use crate::{dpi::PhysicalSize, window::CursorIcon};
 
 use windows::{
-  core::HRESULT,
+  core::{HRESULT, PCWSTR},
   Win32::{
-    Foundation::{BOOL, FARPROC, HWND, LPARAM, LRESULT, POINT, PWSTR, RECT, WPARAM},
+    Foundation::{BOOL, FARPROC, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM},
     Globalization::lstrlenW,
     Graphics::Gdi::{ClientToScreen, InvalidateRgn, HMONITOR, HRGN},
     System::LibraryLoader::*,
@@ -38,7 +38,7 @@ pub fn wchar_to_string(wchar: &[u16]) -> String {
   String::from_utf16_lossy(wchar)
 }
 
-pub fn wchar_ptr_to_string(wchar: PWSTR) -> String {
+pub fn wchar_ptr_to_string(wchar: PCWSTR) -> String {
   let len = unsafe { lstrlenW(wchar) } as usize;
   let wchar_slice = unsafe { slice::from_raw_parts(wchar.0, len) };
   wchar_to_string(wchar_slice)
@@ -260,7 +260,7 @@ pub fn get_hicon_from_buffer(buffer: &[u8], width: i32, height: i32) -> Option<H
 }
 
 impl CursorIcon {
-  pub(crate) fn to_windows_cursor(self) -> PWSTR {
+  pub(crate) fn to_windows_cursor(self) -> PCWSTR {
     match self {
       CursorIcon::Arrow | CursorIcon::Default => IDC_ARROW,
       CursorIcon::Hand => IDC_HAND,

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -248,9 +248,7 @@ pub fn get_hicon_from_buffer(buffer: &[u8], width: i32, height: i32) -> Option<H
           0,
           0,
           LR_DEFAULTCOLOR,
-        )
-        .ok()
-        {
+        ) {
           // windows is really tough on icons
           // if a bad icon is provided it'll fail here or in
           // the LookupIconIdFromDirectoryEx if this is a bad format (example png's)
@@ -300,7 +298,7 @@ pub(super) fn get_function_impl(library: &str, function: &str) -> FARPROC {
   assert_eq!(function.chars().last(), Some('\0'));
 
   // Library names we will use are ASCII so we can use the A version to avoid string conversion.
-  let module = unsafe { LoadLibraryA(library) };
+  let module = unsafe { LoadLibraryA(library) }.unwrap_or_default();
   if module.is_invalid() {
     return None;
   }

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -131,8 +131,8 @@ pub(crate) fn set_inner_size_physical(window: HWND, x: u32, y: u32) {
 
 pub fn adjust_window_rect(hwnd: HWND, rect: RECT) -> Option<RECT> {
   unsafe {
-    let style = GetWindowLongW(hwnd, GWL_STYLE) as WINDOW_STYLE;
-    let style_ex = GetWindowLongW(hwnd, GWL_EXSTYLE) as WINDOW_EX_STYLE;
+    let style = WINDOW_STYLE(GetWindowLongW(hwnd, GWL_STYLE) as u32);
+    let style_ex = WINDOW_EX_STYLE(GetWindowLongW(hwnd, GWL_EXSTYLE) as u32);
     adjust_window_rect_with_styles(hwnd, style, style_ex, rect)
   }
 }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -16,17 +16,20 @@ use std::{
 };
 
 use crossbeam_channel as channel;
-use windows::Win32::{
-  Foundation::{self as win32f, HINSTANCE, HWND, LPARAM, LRESULT, POINT, PWSTR, RECT, WPARAM},
-  Graphics::{
-    Dwm::{DwmEnableBlurBehindWindow, DWM_BB_BLURREGION, DWM_BB_ENABLE, DWM_BLURBEHIND},
-    Gdi::*,
-  },
-  System::{Com::*, LibraryLoader::*, Ole::*},
-  UI::{
-    Input::{Ime::*, KeyboardAndMouse::*, Touch::*},
-    Shell::*,
-    WindowsAndMessaging::{self as win32wm, *},
+use windows::{
+  core::{PCWSTR, PWSTR},
+  Win32::{
+    Foundation::{self as win32f, HINSTANCE, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM},
+    Graphics::{
+      Dwm::{DwmEnableBlurBehindWindow, DWM_BB_BLURREGION, DWM_BB_ENABLE, DWM_BLURBEHIND},
+      Gdi::*,
+    },
+    System::{Com::*, LibraryLoader::*, Ole::*},
+    UI::{
+      Input::{Ime::*, KeyboardAndMouse::*, Touch::*},
+      Shell::*,
+      WindowsAndMessaging::{self as win32wm, *},
+    },
   },
 };
 
@@ -487,7 +490,7 @@ impl Window {
 
           let res = unsafe {
             ChangeDisplaySettingsExW(
-              PWSTR(display_name.as_mut_ptr()),
+              PCWSTR(display_name.as_ptr()),
               &native_video_mode,
               HWND::default(),
               CDS_FULLSCREEN,
@@ -505,7 +508,7 @@ impl Window {
         | (&Some(Fullscreen::Exclusive(_)), &Some(Fullscreen::Borderless(_))) => {
           let res = unsafe {
             ChangeDisplaySettingsExW(
-              PWSTR::default(),
+              PCWSTR::default(),
               std::ptr::null_mut(),
               HWND::default(),
               CDS_FULLSCREEN,
@@ -807,7 +810,7 @@ unsafe fn init<T: 'static>(
   event_loop: &EventLoopWindowTarget<T>,
 ) -> Result<Window, RootOsError> {
   // registering the window class
-  let mut class_name = register_window_class(&attributes.window_icon, &pl_attribs.taskbar_icon);
+  let class_name = register_window_class(&attributes.window_icon, &pl_attribs.taskbar_icon);
 
   let mut window_flags = WindowFlags::empty();
   window_flags.set(WindowFlags::DECORATIONS, attributes.decorations);
@@ -843,7 +846,7 @@ unsafe fn init<T: 'static>(
     let (style, ex_style) = window_flags.to_window_styles();
     let handle = CreateWindowExW(
       ex_style,
-      PWSTR(class_name.as_mut_ptr()),
+      PCWSTR(class_name.as_ptr()),
       attributes.title.as_str(),
       style,
       CW_USEDEFAULT,
@@ -852,7 +855,7 @@ unsafe fn init<T: 'static>(
       CW_USEDEFAULT,
       parent.unwrap_or_default(),
       pl_attribs.menu.unwrap_or_default(),
-      GetModuleHandleW(PWSTR::default()),
+      GetModuleHandleW(PCWSTR::default()),
       Box::into_raw(Box::new(window_flags)) as _,
     );
 
@@ -968,7 +971,7 @@ unsafe fn register_window_class(
   window_icon: &Option<Icon>,
   taskbar_icon: &Option<Icon>,
 ) -> Vec<u16> {
-  let mut class_name = util::to_wstring("Window Class");
+  let class_name = util::to_wstring("Window Class");
 
   let h_icon = taskbar_icon
     .as_ref()
@@ -985,12 +988,12 @@ unsafe fn register_window_class(
     lpfnWndProc: Some(window_proc),
     cbClsExtra: 0,
     cbWndExtra: 0,
-    hInstance: GetModuleHandleW(PWSTR::default()),
+    hInstance: GetModuleHandleW(PCWSTR::default()),
     hIcon: h_icon,
     hCursor: HCURSOR::default(), // must be null in order for cursor state to work properly
     hbrBackground: HBRUSH::default(),
-    lpszMenuName: PWSTR::default(),
-    lpszClassName: PWSTR(class_name.as_mut_ptr()),
+    lpszMenuName: PCWSTR::default(),
+    lpszClassName: PCWSTR(class_name.as_ptr()),
     hIconSm: h_icon_small,
   };
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -733,7 +733,7 @@ impl Window {
     // `ToUnicode` consumes the dead-key by default, so we are constructing a fake (but valid)
     // key input which we can call `ToUnicode` with.
     unsafe {
-      let vk = u32::from(VK_SPACE);
+      let vk = u32::from(VK_SPACE.0);
       let scancode = MapVirtualKeyW(vk, MAPVK_VK_TO_VSC);
       let kbd_state = [0; 256];
       let mut char_buff = [MaybeUninit::uninit(); 8];
@@ -1106,7 +1106,7 @@ unsafe fn force_window_active(handle: HWND) {
   // This is a little hack which can "steal" the foreground window permission
   // We only call this function in the window creation, so it should be fine.
   // See : https://stackoverflow.com/questions/10740346/setforegroundwindow-only-working-while-visual-studio-is-open
-  let alt_sc = MapVirtualKeyW(u32::from(VK_MENU), MAPVK_VK_TO_VSC);
+  let alt_sc = MapVirtualKeyW(u32::from(VK_MENU.0), MAPVK_VK_TO_VSC);
 
   let mut inputs: [INPUT; 2] = mem::zeroed();
   inputs[0].r#type = INPUT_KEYBOARD;

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1141,7 +1141,8 @@ unsafe fn force_window_active(handle: HWND) {
   SetForegroundWindow(handle);
 }
 
-pub fn hit_test(hwnd: HWND, cx: i32, cy: i32) -> LRESULT {
+pub fn hit_test(hwnd: *mut libc::c_void, cx: i32, cy: i32) -> LRESULT {
+  let hwnd = HWND(hwnd as _);
   let mut window_rect = RECT::default();
   unsafe {
     if GetWindowRect(hwnd, <*mut _>::cast(&mut window_rect)).as_bool() {

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -193,7 +193,7 @@ impl WindowFlags {
   }
 
   pub fn to_window_styles(self) -> (WINDOW_STYLE, WINDOW_EX_STYLE) {
-    let (mut style, mut style_ex) = (0, 0);
+    let (mut style, mut style_ex) = (Default::default(), Default::default());
     style |= WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_SYSMENU | WS_CAPTION | WS_MINIMIZEBOX;
     style_ex |= WS_EX_ACCEPTFILES;
 
@@ -314,8 +314,8 @@ impl WindowFlags {
 
         // This condition is necessary to avoid having an unrestorable window
         if !new.contains(WindowFlags::MINIMIZED) {
-          SetWindowLongW(window, GWL_STYLE, style as i32);
-          SetWindowLongW(window, GWL_EXSTYLE, style_ex as i32);
+          SetWindowLongW(window, GWL_STYLE, style.0 as i32);
+          SetWindowLongW(window, GWL_EXSTYLE, style_ex.0 as i32);
         }
 
         let mut flags = SWP_NOZORDER | SWP_NOMOVE | SWP_NOSIZE | SWP_FRAMECHANGED;

--- a/src/window.rs
+++ b/src/window.rs
@@ -1026,6 +1026,7 @@ impl Default for CursorIcon {
 
 /// Fullscreen modes.
 #[non_exhaustive]
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum Fullscreen {
   Exclusive(VideoMode),


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

The `windows-implement` macro which lets you implement COM interfaces with the `windows` crate depends on `const` generic support which was just stabilized in `rustc` 1.61. This effectively raises the MSRV for `tao` on Windows to 1.61.