### PR TITLE
feat: support theme on macOS

### DIFF
--- a/.changes/support-theme-on-macos.md
+++ b/.changes/support-theme-on-macos.md
@@ -1,5 +1,5 @@
 ---
-"tao": minor
+"tao": patch
 ---
 
 Support theme on macOS.

--- a/.changes/support-theme-on-macos.md
+++ b/.changes/support-theme-on-macos.md
@@ -1,0 +1,5 @@
+---
+"tao": minor
+---
+
+Support theme on macOS.

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -1,0 +1,60 @@
+// Copyright 2019-2021 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[allow(clippy::single_match)]
+fn main() {
+  use tao::{
+    event::{Event, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::WindowBuilder,
+  };
+
+  #[cfg(any(target_os = "macos"))]
+  use tao::platform::macos::WindowExtMacOS;
+  #[cfg(target_os = "windows")]
+  use tao::platform::windows::WindowExtWindows;
+
+  env_logger::init();
+  let event_loop = EventLoop::new();
+
+  let window = WindowBuilder::new()
+    .with_title("A fantastic window!")
+    // .with_theme(Some(Theme::Light))
+    .build(&event_loop)
+    .unwrap();
+
+  println!("Initial theme: {:?}", window.theme());
+
+  event_loop.run(move |event, _, control_flow| {
+    *control_flow = ControlFlow::Wait;
+
+    match event {
+      Event::WindowEvent {
+        event: WindowEvent::CloseRequested,
+        ..
+      } => *control_flow = ControlFlow::Exit,
+      Event::WindowEvent {
+        event: WindowEvent::ThemeChanged(theme),
+        window_id,
+        ..
+      } if window_id == window.id() => {
+        println!("Theme is changed: {:?}", theme)
+      }
+      _ => (),
+    }
+  });
+}
+
+#[cfg(any(
+  target_os = "ios",
+  target_os = "android",
+  target_os = "linux",
+  target_os = "dragonfly",
+  target_os = "freebsd",
+  target_os = "netbsd",
+  target_os = "openbsd"
+))]
+fn main() {
+  println!("This platform doesn't support theme.");
+}

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -11,7 +11,7 @@ use crate::{
   menu::CustomMenuItem,
   monitor::MonitorHandle,
   platform_impl::{get_aux_state_mut, Parent},
-  window::{Window, WindowBuilder},
+  window::{Theme, Window, WindowBuilder},
 };
 
 #[cfg(feature = "tray")]
@@ -54,6 +54,9 @@ pub trait WindowExtMacOS {
 
   /// Sets whether or not the window has shadow.
   fn set_has_shadow(&self, has_shadow: bool);
+
+  /// Returns the current window theme.
+  fn theme(&self) -> Theme;
 }
 
 impl WindowExtMacOS for Window {
@@ -85,6 +88,11 @@ impl WindowExtMacOS for Window {
   #[inline]
   fn set_has_shadow(&self, has_shadow: bool) {
     self.window.set_has_shadow(has_shadow)
+  }
+
+  #[inline]
+  fn theme(&self) -> Theme {
+    self.window.theme()
   }
 }
 
@@ -338,6 +346,8 @@ pub trait WindowBuilderExtMacOS {
   fn with_resize_increments(self, increments: LogicalSize<f64>) -> WindowBuilder;
   fn with_disallow_hidpi(self, disallow_hidpi: bool) -> WindowBuilder;
   fn with_has_shadow(self, has_shadow: bool) -> WindowBuilder;
+  /// Forces a theme or uses the system settings if `None` was provided.
+  fn with_theme(self, theme: Option<Theme>) -> WindowBuilder;
 }
 
 impl WindowBuilderExtMacOS for WindowBuilder {
@@ -401,6 +411,12 @@ impl WindowBuilderExtMacOS for WindowBuilder {
   #[inline]
   fn with_has_shadow(mut self, has_shadow: bool) -> WindowBuilder {
     self.platform_specific.has_shadow = has_shadow;
+    self
+  }
+
+  #[inline]
+  fn with_theme(mut self, theme: Option<Theme>) -> WindowBuilder {
+    self.platform_specific.preferred_theme = theme;
     self
   }
 }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -30,7 +30,9 @@ use crate::{
     window_delegate::new_delegate,
     OsError,
   },
-  window::{CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWindowId},
+  window::{
+    CursorIcon, Fullscreen, Theme, UserAttentionType, WindowAttributes, WindowId as RootWindowId,
+  },
 };
 use cocoa::{
   appkit::{
@@ -39,7 +41,9 @@ use cocoa::{
     NSWindowStyleMask,
   },
   base::{id, nil},
-  foundation::{NSAutoreleasePool, NSDictionary, NSPoint, NSRect, NSSize, NSUInteger},
+  foundation::{
+    NSArray, NSAutoreleasePool, NSDictionary, NSPoint, NSRect, NSSize, NSString, NSUInteger,
+  },
 };
 use core_graphics::display::{CGDisplay, CGDisplayMode};
 use objc::{
@@ -47,7 +51,7 @@ use objc::{
   runtime::{Class, Object, Sel, BOOL, NO, YES},
 };
 
-use super::Menu;
+use super::{util::ns_string_to_rust, Menu};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Id(pub usize);
@@ -83,6 +87,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
   pub resize_increments: Option<LogicalSize<f64>>,
   pub disallow_hidpi: bool,
   pub has_shadow: bool,
+  pub preferred_theme: Option<Theme>,
 }
 
 impl Default for PlatformSpecificWindowBuilderAttributes {
@@ -99,6 +104,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
       resize_increments: None,
       disallow_hidpi: false,
       has_shadow: true,
+      preferred_theme: None,
     }
   }
 }
@@ -253,10 +259,45 @@ fn create_window(
       if let Some(window_menu) = attrs.window_menu.clone() {
         menu::initialize(window_menu);
       }
+
       ns_window
     });
     pool.drain();
     res
+  }
+}
+
+pub(super) fn get_ns_theme() -> Theme {
+  unsafe {
+    let mut appearances: Vec<id> = Vec::new();
+    appearances.push(NSString::alloc(nil).init_str("NSAppearanceNameAqua"));
+    appearances.push(NSString::alloc(nil).init_str("NSAppearanceNameDarkAqua"));
+    let app_class = class!(NSApplication);
+    let app: id = msg_send![app_class, sharedApplication];
+    let appearance: id = msg_send![app, effectiveAppearance];
+    let name: id = msg_send![
+      appearance,
+      bestMatchFromAppearancesWithNames: NSArray::arrayWithObjects(nil, &appearances)
+    ];
+    let name = ns_string_to_rust(name);
+    match &name[..] {
+      "NSAppearanceNameDarkAqua" => Theme::Dark,
+      _ => Theme::Light,
+    }
+  }
+}
+
+pub(super) fn set_ns_theme(theme: Theme) {
+  let name = match theme {
+    Theme::Dark => "NSAppearanceNameDarkAqua",
+    Theme::Light => "NSAppearanceNameAqua",
+  };
+  unsafe {
+    let name = NSString::alloc(nil).init_str(name);
+    let appearance: id = msg_send![class!(NSAppearance), appearanceNamed: name];
+    let app_class = class!(NSApplication);
+    let app: id = msg_send![app_class, sharedApplication];
+    let _: () = msg_send![app, setAppearance: appearance];
   }
 }
 
@@ -325,6 +366,7 @@ pub struct SharedState {
   /// transitioning back to borderless fullscreen.
   save_presentation_opts: Option<NSApplicationPresentationOptions>,
   pub saved_desktop_display_mode: Option<(CGDisplay, CGDisplayMode)>,
+  current_theme: Theme,
 }
 
 impl SharedState {
@@ -415,7 +457,6 @@ impl UnownedWindow {
         set_max_inner_size(*ns_window, logical_dim)
       });
 
-      use cocoa::foundation::NSArray;
       // register for drag and drop operations.
       let () = msg_send![
         *ns_window,
@@ -445,6 +486,18 @@ impl UnownedWindow {
       cursor_state,
       inner_rect,
     });
+
+    match pl_attribs.preferred_theme {
+      Some(theme) => {
+        set_ns_theme(theme);
+        let mut state = window.shared_state.lock().unwrap();
+        state.current_theme = theme;
+      }
+      None => {
+        let mut state = window.shared_state.lock().unwrap();
+        state.current_theme = get_ns_theme();
+      }
+    }
 
     let delegate = new_delegate(&window, fullscreen.is_some());
 
@@ -1255,6 +1308,12 @@ impl WindowExtMacOS for UnownedWindow {
         .ns_window
         .setHasShadow_(if has_shadow { YES } else { NO })
     }
+  }
+
+  #[inline]
+  fn theme(&self) -> Theme {
+    let state = self.shared_state.lock().unwrap();
+    state.current_theme
   }
 }
 

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -10,7 +10,7 @@ use std::{
 use cocoa::{
   appkit::{self, NSApplicationPresentationOptions, NSView, NSWindow},
   base::{id, nil},
-  foundation::{NSAutoreleasePool, NSUInteger},
+  foundation::{NSAutoreleasePool, NSString, NSUInteger},
 };
 use objc::{
   declare::ClassDecl,
@@ -26,7 +26,7 @@ use crate::{
     event::{EventProxy, EventWrapper},
     util::{self, IdRef},
     view::ViewState,
-    window::{get_window_id, UnownedWindow},
+    window::{get_ns_theme, get_window_id, UnownedWindow},
   },
   window::{Fullscreen, WindowId},
 };
@@ -243,6 +243,14 @@ lazy_static! {
       sel!(windowDidFailToEnterFullScreen:),
       window_did_fail_to_enter_fullscreen as extern "C" fn(&Object, Sel, id),
     );
+    decl.add_method(
+      sel!(effectiveAppearanceDidChange:),
+      effective_appearance_did_change as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+      sel!(effectiveAppearanceDidChangedOnMainThread:),
+      effective_appearance_did_changed_on_main_thread as extern "C" fn(&Object, Sel, id),
+    );
 
     decl.add_ivar::<*mut c_void>("taoState");
     WindowDelegateClass(decl.register())
@@ -274,6 +282,18 @@ extern "C" fn init_with_tao(this: &Object, _sel: Sel, state: *mut c_void) -> id 
         let () = msg_send![*state.ns_window, setDelegate: this];
       });
     }
+
+    let notification_center: &Object =
+      msg_send![class!(NSDistributedNotificationCenter), defaultCenter];
+    let notification_name = NSString::alloc(nil).init_str("AppleInterfaceThemeChangedNotification");
+    let _: () = msg_send![
+        notification_center,
+        addObserver: this
+        selector: sel!(effectiveAppearanceDidChange:)
+        name: notification_name
+        object: nil
+    ];
+
     this
   }
 }
@@ -391,7 +411,6 @@ extern "C" fn dragging_entered(this: &Object, _: Sel, sender: id) -> BOOL {
   let filenames = unsafe { NSPasteboard::propertyListForType(pb, appkit::NSFilenamesPboardType) };
 
   for file in unsafe { filenames.iter() } {
-    use cocoa::foundation::NSString;
     use std::ffi::CStr;
 
     unsafe {
@@ -426,7 +445,6 @@ extern "C" fn perform_drag_operation(this: &Object, _: Sel, sender: id) -> BOOL 
   let filenames = unsafe { NSPasteboard::propertyListForType(pb, appkit::NSFilenamesPboardType) };
 
   for file in unsafe { filenames.iter() } {
-    use cocoa::foundation::NSString;
     use std::ffi::CStr;
 
     unsafe {
@@ -624,4 +642,18 @@ extern "C" fn window_did_fail_to_enter_fullscreen(this: &Object, _: Sel, _: id) 
     }
   });
   trace!("Completed `windowDidFailToEnterFullscreen:`");
+}
+
+// Observe theme change
+extern "C" fn effective_appearance_did_change(this: &Object, _: Sel, _: id) {
+  trace!("Triggered `effectiveAppearDidChange:`");
+  unsafe {
+    let _: () = msg_send![this, performSelectorOnMainThread: sel!(effectiveAppearanceDidChangedOnMainThread:) withObject:nil waitUntilDone:false];
+  }
+}
+extern "C" fn effective_appearance_did_changed_on_main_thread(this: &Object, _: Sel, _: id) {
+  with_state(this, |state| {
+    state.emit_event(WindowEvent::ThemeChanged(get_ns_theme()));
+  });
+  trace!("Completed `effectiveAppearDidChange:`");
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1042,6 +1042,12 @@ pub enum Theme {
   Dark,
 }
 
+impl Default for Theme {
+  fn default() -> Self {
+    Theme::Light
+  }
+}
+
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum UserAttentionType {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

I added support for macOS theme get/set function.
Theme change events are now also supported.

Also I will implement same method on Linux in another PR.

related issue: https://github.com/tauri-apps/tao/issues/387

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
