### PR TITLE
feat: `Window::set_ignore_cursor_events`, closes #184

### DIFF
--- a/.changes/window_ignore_cursor_events.md
+++ b/.changes/window_ignore_cursor_events.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Add `Window::set_ignore_cursor_events`

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -664,6 +664,12 @@ impl Window {
     ))
   }
 
+  pub fn set_ignore_cursor_events(&self, _ignore: bool) -> Result<(), error::ExternalError> {
+    Err(error::ExternalError::NotSupported(
+      error::NotSupportedError::new(),
+    ))
+  }
+
   pub fn raw_window_handle(&self) -> RawWindowHandle {
     // TODO: Use main activity instead?
     let mut handle = AndroidNdkHandle::empty();

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -196,6 +196,10 @@ impl Inner {
     Err(ExternalError::NotSupported(NotSupportedError::new()))
   }
 
+  pub fn set_ignore_cursor_events(&self, _ignore: bool) -> Result<(), ExternalError> {
+    Err(ExternalError::NotSupported(NotSupportedError::new()))
+  }
+
   pub fn set_minimized(&self, _minimized: bool) {
     warn!("`Window::set_minimized` is ignored on iOS")
   }

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -11,6 +11,7 @@ use std::{
   time::Instant,
 };
 
+use cairo::{RectangleInt, Region};
 use gdk::{Cursor, CursorType, EventKey, EventMask, ScrollDirection, WindowEdge, WindowState};
 use gio::{prelude::*, Cancellable};
 use glib::{source::Priority, Continue, MainContext};
@@ -310,8 +311,18 @@ impl<T: 'static> EventLoop<T> {
               }
             }
           }
-          WindowRequest::CursorIgnoreEvents => {
-            // TODO
+          WindowRequest::CursorIgnoreEvents(_ignore) => {
+            // if ignore {
+            //   let empty_region = Region::create_rectangle(&RectangleInt {
+            //     x: 0,
+            //     y: 0,
+            //     width: 0,
+            //     height: 0,
+            //   });
+            //   window.input_shape_combine_region(Some(&empty_region));
+            // } else {
+            //   window.input_shape_combine_region(None)
+            // };
           }
           WindowRequest::WireUpEvents => {
             window.add_events(

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -311,18 +311,21 @@ impl<T: 'static> EventLoop<T> {
               }
             }
           }
-          WindowRequest::CursorIgnoreEvents(_ignore) => {
-            // if ignore {
-            //   let empty_region = Region::create_rectangle(&RectangleInt {
-            //     x: 0,
-            //     y: 0,
-            //     width: 0,
-            //     height: 0,
-            //   });
-            //   window.input_shape_combine_region(Some(&empty_region));
-            // } else {
-            //   window.input_shape_combine_region(None)
-            // };
+          WindowRequest::CursorIgnoreEvents(ignore) => {
+            if ignore {
+              let empty_region = Region::create_rectangle(&RectangleInt {
+                x: 0,
+                y: 0,
+                width: 1,
+                height: 1,
+              });
+              window
+                .window()
+                .unwrap()
+                .input_shape_combine_region(&empty_region, 0, 0);
+            } else {
+              window.input_shape_combine_region(None)
+            };
           }
           WindowRequest::WireUpEvents => {
             window.add_events(

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -310,6 +310,9 @@ impl<T: 'static> EventLoop<T> {
               }
             }
           }
+          WindowRequest::CursorIgnoreEvents => {
+            // TODO
+          }
           WindowRequest::WireUpEvents => {
             window.add_events(
               EventMask::POINTER_MOTION_MASK

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -555,6 +555,17 @@ impl Window {
     Ok(())
   }
 
+  pub fn set_ignore_cursor_events(&self, ignore: bool) -> Result<(), ExternalError> {
+    if let Err(e) = self
+      .window_requests_tx
+      .send((self.window_id, WindowRequest::CursorIgnoreEvents(ignore)))
+    {
+      log::warn!("Fail to send cursor position request: {}", e);
+    }
+
+    Ok(())
+  }
+
   pub fn set_cursor_visible(&self, visible: bool) {
     let cursor = if visible {
       Some(CursorIcon::Default)
@@ -660,6 +671,7 @@ pub enum WindowRequest {
   SetSkipTaskbar(bool),
   CursorIcon(Option<CursorIcon>),
   CursorPosition((i32, i32)),
+  CursorIgnoreEvents(bool),
   WireUpEvents,
   Redraw,
   Menu((Option<MenuItem>, Option<MenuId>)),

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -247,3 +247,11 @@ pub unsafe fn close_async(ns_window: IdRef) {
     });
   });
 }
+
+// `setIgnoresMouseEvents_:` isn't thread-safe, and fails silently.
+pub unsafe fn set_ignore_mouse_events(ns_window: id, ignore: bool) {
+  let ns_window = MainThreadSafe(ns_window);
+  Queue::main().exec_async(move || {
+    ns_window.setIgnoresMouseEvents_(if ignore { YES } else { NO });
+  });
+}

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -735,6 +735,15 @@ impl UnownedWindow {
     Ok(())
   }
 
+  #[inline]
+  pub fn set_ignore_cursor_events(&self, ignore: bool) -> Result<(), ExternalError> {
+    unsafe {
+      util::set_ignore_mouse_events(*self.ns_window, ignore);
+    }
+
+    Ok(())
+  }
+
   pub(crate) fn is_zoomed(&self) -> bool {
     // because `isZoomed` doesn't work if the window's borderless,
     // we make it resizable temporalily.

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -406,6 +406,19 @@ impl Window {
   }
 
   #[inline]
+  pub fn set_ignore_cursor_events(&self, ignore: bool) -> Result<(), ExternalError> {
+    let window = self.window.clone();
+    let window_state = Arc::clone(&self.window_state);
+    self.thread_executor.execute_in_thread(move || {
+      WindowState::set_window_flags(window_state.lock(), window.0, |f| {
+        f.set(WindowFlags::IGNORE_CURSOR_EVENT, ignore)
+      });
+    });
+
+    Ok(())
+  }
+
+  #[inline]
   pub fn id(&self) -> WindowId {
     WindowId(self.window.0 .0)
   }

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -90,6 +90,8 @@ bitflags! {
 
         const MINIMIZED = 1 << 12;
 
+        const IGNORE_CURSOR_EVENT = 1 << 15;
+
         const EXCLUSIVE_FULLSCREEN_OR_MASK = WindowFlags::ALWAYS_ON_TOP.bits;
         const INVISIBLE_AND_MASK = !WindowFlags::MAXIMIZED.bits;
     }
@@ -224,6 +226,9 @@ impl WindowFlags {
     }
     if self.contains(WindowFlags::MAXIMIZED) {
       style |= WS_MAXIMIZE;
+    }
+    if self.contains(WindowFlags::IGNORE_CURSOR_EVENT) {
+      style_ex |= WS_EX_TRANSPARENT | WS_EX_LAYERED;
     }
     if self.intersects(
       WindowFlags::MARKER_EXCLUSIVE_FULLSCREEN | WindowFlags::MARKER_BORDERLESS_FULLSCREEN,

--- a/src/window.rs
+++ b/src/window.rs
@@ -906,7 +906,7 @@ impl Window {
   ///
   /// ## Platform-specific
   ///
-  /// - **iOS / Android / Web:** Always returns an [`ExternalError::NotSupported`]
+  /// - **iOS / Android:** Always returns an [`ExternalError::NotSupported`]
   #[inline]
   pub fn set_ignore_cursor_events(&self, ignore: bool) -> Result<(), ExternalError> {
     self.window.set_ignore_cursor_events(ignore)

--- a/src/window.rs
+++ b/src/window.rs
@@ -898,6 +898,19 @@ impl Window {
   pub fn drag_window(&self) -> Result<(), ExternalError> {
     self.window.drag_window()
   }
+
+  /// Modifies whether the window catches cursor events.
+  ///
+  /// If `true`, the events are passed through the window such that any other window behind it receives them.
+  /// If `false` the window will catch the cursor events. By default cursor events are not ignored.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **iOS / Android / Web:** Always returns an [`ExternalError::NotSupported`]
+  #[inline]
+  pub fn set_ignore_cursor_events(&self, ignore: bool) -> Result<(), ExternalError> {
+    self.window.set_ignore_cursor_events(ignore)
+  }
 }
 
 /// Monitor info functions.


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [X] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information

Co-authored-by: Markus Siglreithmaier <m.siglreith@gmail.com>
Co-authored-by: z4122 <412213484@qq.com>
Co-authored-by: Kirill Chibisov <contact@kchibisov.com>