### PR TITLE
Remove most RedrawWindow to event target window

### DIFF
--- a/.changes/wmpaint.md
+++ b/.changes/wmpaint.md
@@ -1,0 +1,5 @@
+---
+tao: "patch"
+---
+
+Reduce `WM_PAINT` singal on event target window to prevent from webview2 delay.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2018,9 +2018,11 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
 ) -> LRESULT {
   let subclass_input = Box::from_raw(subclass_input_ptr as *mut ThreadMsgTargetSubclassInput<T>);
 
-  // if msg != WM_PAINT {
-  //   RedrawWindow(window, ptr::null(), HRGN::default(), RDW_INTERNALPAINT);
-  // }
+  // Calling RedrawWindow will cause other window busy waiting. So we handle clear event directly
+  // as long as there's a thread event target message.
+  if msg != WM_PAINT {
+    handle_clear_event(&subclass_input.event_loop_runner, window);
+  }
 
   let mut subclass_removed = false;
 
@@ -2037,25 +2039,8 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
     // when the event queue has been emptied. See `process_event` for more details.
     win32wm::WM_PAINT => {
       ValidateRect(window, ptr::null());
-      // If the WM_PAINT handler in `public_window_callback` has already flushed the redraw
-      // events, `handling_events` will return false and we won't emit a second
-      // `RedrawEventsCleared` event.
-      if subclass_input.event_loop_runner.handling_events() {
-        if subclass_input.event_loop_runner.should_buffer() {
-          // This branch can be triggered when a nested win32 event loop is triggered
-          // inside of the `event_handler` callback.
-          RedrawWindow(window, ptr::null(), HRGN::default(), RDW_INTERNALPAINT);
-        } else {
-          // This WM_PAINT handler will never be re-entrant because `flush_paint_messages`
-          // doesn't call WM_PAINT for the thread event target (i.e. this window).
-          assert!(flush_paint_messages(
-            None,
-            &subclass_input.event_loop_runner
-          ));
-          subclass_input.event_loop_runner.redraw_events_cleared();
-          process_control_flow(&subclass_input.event_loop_runner);
-        }
-      }
+
+      handle_clear_event(&subclass_input.event_loop_runner, window);
 
       // Default WM_PAINT behaviour. This makes sure modals and popups are shown immediatly when opening them.
       DefSubclassProc(window, msg, wparam, lparam)
@@ -2321,5 +2306,24 @@ unsafe fn handle_raw_input<T: 'static>(
         state,
       }),
     });
+  }
+}
+
+unsafe fn handle_clear_event<T: 'static>(event_loop_runner: &EventLoopRunner<T>, window: HWND) {
+  // If the WM_PAINT handler in `public_window_callback` has already flushed the redraw
+  // events, `handling_events` will return false and we won't emit a second
+  // `RedrawEventsCleared` event.
+  if event_loop_runner.handling_events() {
+    if event_loop_runner.should_buffer() {
+      // This branch can be triggered when a nested win32 event loop is triggered
+      // inside of the `event_handler` callback.
+      RedrawWindow(window, ptr::null(), HRGN::default(), RDW_INTERNALPAINT);
+    } else {
+      // This WM_PAINT handler will never be re-entrant because `flush_paint_messages`
+      // doesn't call WM_PAINT for the thread event target (i.e. this window).
+      assert!(flush_paint_messages(None, &event_loop_runner));
+      event_loop_runner.redraw_events_cleared();
+      process_control_flow(&event_loop_runner);
+    }
   }
 }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2018,9 +2018,9 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
 ) -> LRESULT {
   let subclass_input = Box::from_raw(subclass_input_ptr as *mut ThreadMsgTargetSubclassInput<T>);
 
-  if msg != WM_PAINT {
-    RedrawWindow(window, ptr::null(), HRGN::default(), RDW_INTERNALPAINT);
-  }
+  // if msg != WM_PAINT {
+  //   RedrawWindow(window, ptr::null(), HRGN::default(), RDW_INTERNALPAINT);
+  // }
 
   let mut subclass_removed = false;
 

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -196,6 +196,13 @@ impl<T> EventLoopRunner<T> {
     owned_windows.extend(&new_owned_windows);
     self.owned_windows.set(owned_windows);
   }
+
+  pub fn no_owned_windows(&self) -> bool {
+    let owned_windows = self.owned_windows.take();
+    let result = owned_windows.is_empty();
+    self.owned_windows.set(owned_windows);
+    result
+  }
 }
 
 /// Event dispatch functions.
@@ -394,12 +401,16 @@ impl<T> EventLoopRunner<T> {
     };
     self.call_event_handler(Event::NewEvents(start_cause));
     self.dispatch_buffered_events();
-    // RedrawWindow(
-    //   self.thread_msg_target,
-    //   ptr::null(),
-    //   HRGN::default(),
-    //   RDW_INTERNALPAINT,
-    // );
+    // Calling RedrawWindow will cause other window busy waiting. So we only call it when
+    // there's no window.
+    if self.no_owned_windows() {
+      RedrawWindow(
+        self.thread_msg_target,
+        ptr::null(),
+        HRGN::default(),
+        RDW_INTERNALPAINT,
+      );
+    }
   }
 
   unsafe fn call_redraw_events_cleared(&self) {

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -394,12 +394,12 @@ impl<T> EventLoopRunner<T> {
     };
     self.call_event_handler(Event::NewEvents(start_cause));
     self.dispatch_buffered_events();
-    RedrawWindow(
-      self.thread_msg_target,
-      ptr::null(),
-      HRGN::default(),
-      RDW_INTERNALPAINT,
-    );
+    // RedrawWindow(
+    //   self.thread_msg_target,
+    //   ptr::null(),
+    //   HRGN::default(),
+    //   RDW_INTERNALPAINT,
+    // );
   }
 
   unsafe fn call_redraw_events_cleared(&self) {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
There are two places will call lots of `RedrawWindow` to event target window on Windows.
This causes https://github.com/tauri-apps/wry/issues/616
Do we really need to draw them despite it's always hidden?