### PR TITLE
fix(macos): guard theme APIs to not crash when running on 10.13 or older

### DIFF
--- a/.changes/theme-macos-guard.md
+++ b/.changes/theme-macos-guard.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+The `theme` function now `Theme::Light` on macOS older than 10.14 and the initial theme setter has no effect instead of crashing the application.

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -274,6 +274,10 @@ pub(super) fn get_ns_theme() -> Theme {
     appearances.push(NSString::alloc(nil).init_str("NSAppearanceNameDarkAqua"));
     let app_class = class!(NSApplication);
     let app: id = msg_send![app_class, sharedApplication];
+    let has_theme: BOOL = msg_send![app, respondsToSelector: sel!(effectiveAppearance)];
+    if has_theme == NO {
+      return Theme::Light;
+    }
     let appearance: id = msg_send![app, effectiveAppearance];
     let name: id = msg_send![
       appearance,
@@ -293,11 +297,14 @@ pub(super) fn set_ns_theme(theme: Theme) {
     Theme::Light => "NSAppearanceNameAqua",
   };
   unsafe {
-    let name = NSString::alloc(nil).init_str(name);
-    let appearance: id = msg_send![class!(NSAppearance), appearanceNamed: name];
     let app_class = class!(NSApplication);
     let app: id = msg_send![app_class, sharedApplication];
-    let _: () = msg_send![app, setAppearance: appearance];
+    let has_theme: BOOL = msg_send![app, respondsToSelector: sel!(effectiveAppearance)];
+    if has_theme == YES {
+      let name = NSString::alloc(nil).init_str(name);
+      let appearance: id = msg_send![class!(NSAppearance), appearanceNamed: name];
+      let _: () = msg_send![app, setAppearance: appearance];
+    }
   }
 }
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
