### PR TITLE
fix(macos): do not emit ThemeChanged event if window theme didn't change

### DIFF
--- a/.changes/macos-theme-changed-event.md
+++ b/.changes/macos-theme-changed-event.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Do not emit the `ThemeChanged` event when the window theme is set and the system theme changes (the window keeps its theme in this scenario).

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -11,16 +11,16 @@ fn main() {
   };
 
   #[cfg(any(target_os = "macos"))]
-  use tao::platform::macos::WindowExtMacOS;
+  use tao::platform::macos::{WindowBuilderExtMacOS, WindowExtMacOS};
   #[cfg(target_os = "windows")]
-  use tao::platform::windows::WindowExtWindows;
+  use tao::platform::windows::{WindowBuilderExtWindows, WindowExtWindows};
 
   env_logger::init();
   let event_loop = EventLoop::new();
 
   let window = WindowBuilder::new()
     .with_title("A fantastic window!")
-    // .with_theme(Some(Theme::Light))
+    // .with_theme(Some(tao::window::Theme::Light))
     .build(&event_loop)
     .unwrap();
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -366,7 +366,7 @@ pub struct SharedState {
   /// transitioning back to borderless fullscreen.
   save_presentation_opts: Option<NSApplicationPresentationOptions>,
   pub saved_desktop_display_mode: Option<(CGDisplay, CGDisplayMode)>,
-  current_theme: Theme,
+  pub current_theme: Theme,
 }
 
 impl SharedState {

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -653,7 +653,16 @@ extern "C" fn effective_appearance_did_change(this: &Object, _: Sel, _: id) {
 }
 extern "C" fn effective_appearance_did_changed_on_main_thread(this: &Object, _: Sel, _: id) {
   with_state(this, |state| {
-    state.emit_event(WindowEvent::ThemeChanged(get_ns_theme()));
+    let theme = get_ns_theme();
+    let current_theme = state.window.upgrade().map(|w| {
+      let mut state = w.shared_state.lock().unwrap();
+      let current_theme = state.current_theme;
+      state.current_theme = theme;
+      current_theme
+    });
+    if current_theme != Some(theme) {
+      state.emit_event(WindowEvent::ThemeChanged(theme));
+    }
   });
   trace!("Completed `effectiveAppearDidChange:`");
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
