### PR TITLE
fix: fix assigning the wrong monitor when receiving Windows move events

### DIFF
--- a/.changes/fix-fullscreen-monitor.md
+++ b/.changes/fix-fullscreen-monitor.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+On Windows, fix wrong fullscreen monitors being recognized when handling `WM_WINDOWPOSCHANGING` messages

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1036,35 +1036,68 @@ unsafe fn public_window_callback_inner<T: 'static>(
           right: window_pos.x + window_pos.cx,
           bottom: window_pos.y + window_pos.cy,
         };
-        let new_monitor = MonitorFromRect(&new_rect, MONITOR_DEFAULTTONULL);
-        match fullscreen {
-          Fullscreen::Borderless(ref mut fullscreen_monitor) => {
-            if !new_monitor.is_invalid()
-              && fullscreen_monitor
-                .as_ref()
-                .map(|monitor| new_monitor != monitor.inner.hmonitor())
-                .unwrap_or(true)
-            {
-              if let Ok(new_monitor_info) = monitor::get_monitor_info(new_monitor) {
-                let new_monitor_rect = new_monitor_info.monitorInfo.rcMonitor;
-                window_pos.x = new_monitor_rect.left;
-                window_pos.y = new_monitor_rect.top;
-                window_pos.cx = new_monitor_rect.right - new_monitor_rect.left;
-                window_pos.cy = new_monitor_rect.bottom - new_monitor_rect.top;
-              }
-              *fullscreen_monitor = Some(crate::monitor::MonitorHandle {
-                inner: MonitorHandle::new(new_monitor),
-              });
-            }
+
+        const NOMOVE_OR_NOSIZE: SET_WINDOW_POS_FLAGS =
+          SET_WINDOW_POS_FLAGS(SWP_NOMOVE.0 | SWP_NOSIZE.0);
+
+        let new_rect = if (window_pos.flags & NOMOVE_OR_NOSIZE).0 != 0 {
+          let cur_rect = util::get_window_rect(window)
+                        .expect("Unexpected GetWindowRect failure; please report this error to https://github.com/rust-windowing/tao");
+
+          match window_pos.flags & NOMOVE_OR_NOSIZE {
+            NOMOVE_OR_NOSIZE => None,
+
+            SWP_NOMOVE => Some(RECT {
+              left: cur_rect.left,
+              top: cur_rect.top,
+              right: cur_rect.left + window_pos.cx,
+              bottom: cur_rect.top + window_pos.cy,
+            }),
+
+            SWP_NOSIZE => Some(RECT {
+              left: window_pos.x,
+              top: window_pos.y,
+              right: window_pos.x - cur_rect.left + cur_rect.right,
+              bottom: window_pos.y - cur_rect.top + cur_rect.bottom,
+            }),
+
+            _ => unreachable!(),
           }
-          Fullscreen::Exclusive(ref video_mode) => {
-            let old_monitor = video_mode.video_mode.monitor.hmonitor();
-            if let Ok(old_monitor_info) = monitor::get_monitor_info(old_monitor) {
-              let old_monitor_rect = old_monitor_info.monitorInfo.rcMonitor;
-              window_pos.x = old_monitor_rect.left;
-              window_pos.y = old_monitor_rect.top;
-              window_pos.cx = old_monitor_rect.right - old_monitor_rect.left;
-              window_pos.cy = old_monitor_rect.bottom - old_monitor_rect.top;
+        } else {
+          Some(new_rect)
+        };
+
+        if let Some(new_rect) = new_rect {
+          let new_monitor = MonitorFromRect(&new_rect, MONITOR_DEFAULTTONULL);
+          match fullscreen {
+            Fullscreen::Borderless(ref mut fullscreen_monitor) => {
+              if !new_monitor.is_invalid()
+                && fullscreen_monitor
+                  .as_ref()
+                  .map(|monitor| new_monitor != monitor.inner.hmonitor())
+                  .unwrap_or(true)
+              {
+                if let Ok(new_monitor_info) = monitor::get_monitor_info(new_monitor) {
+                  let new_monitor_rect = new_monitor_info.monitorInfo.rcMonitor;
+                  window_pos.x = new_monitor_rect.left;
+                  window_pos.y = new_monitor_rect.top;
+                  window_pos.cx = new_monitor_rect.right - new_monitor_rect.left;
+                  window_pos.cy = new_monitor_rect.bottom - new_monitor_rect.top;
+                }
+                *fullscreen_monitor = Some(crate::monitor::MonitorHandle {
+                  inner: MonitorHandle::new(new_monitor),
+                });
+              }
+            }
+            Fullscreen::Exclusive(ref video_mode) => {
+              let old_monitor = video_mode.video_mode.monitor.hmonitor();
+              if let Ok(old_monitor_info) = monitor::get_monitor_info(old_monitor) {
+                let old_monitor_rect = old_monitor_info.monitorInfo.rcMonitor;
+                window_pos.x = old_monitor_rect.left;
+                window_pos.y = old_monitor_rect.top;
+                window_pos.cx = old_monitor_rect.right - old_monitor_rect.left;
+                window_pos.cy = old_monitor_rect.bottom - old_monitor_rect.top;
+              }
             }
           }
         }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1040,7 +1040,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         const NOMOVE_OR_NOSIZE: SET_WINDOW_POS_FLAGS =
           SET_WINDOW_POS_FLAGS(SWP_NOMOVE.0 | SWP_NOSIZE.0);
 
-        let new_rect = if (window_pos.flags & NOMOVE_OR_NOSIZE).0 != 0 {
+        let new_rect = if (window_pos.flags & NOMOVE_OR_NOSIZE) != SET_WINDOW_POS_FLAGS::default() {
           let cur_rect = util::get_window_rect(window)
                         .expect("Unexpected GetWindowRect failure; please report this error to https://github.com/rust-windowing/tao");
 


### PR DESCRIPTION
Co-authored-by: kas <exactly-one-kas@users.noreply.github.com>

ref: https://github.com/rust-windowing/winit/commit/e7f88588bf1d164b96b010755d4958c2875eb723

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
