### PR TITLE
fix: emit resize event on frame_did_change on macOS, closes #436

### DIFF
--- a/.changes/frame-did-change.md
+++ b/.changes/frame-did-change.md
@@ -1,0 +1,6 @@
+---
+"tao": patch
+---
+
+On macOS, `WindowEvent::Resized` is now emitted in `frameDidChange` instead of `windowDidResize`.
+

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -17,11 +17,12 @@ use gio::{prelude::*, Cancellable};
 use glib::{source::Priority, Continue, MainContext};
 use gtk::{builders::AboutDialogBuilder, prelude::*, Inhibit};
 
-use crate::event::{MouseScrollDelta, TouchPhase};
 use crate::{
   accelerator::AcceleratorId,
   dpi::{LogicalPosition, LogicalSize},
-  event::{ElementState, Event, MouseButton, StartCause, WindowEvent},
+  event::{
+    ElementState, Event, MouseButton, MouseScrollDelta, StartCause, TouchPhase, WindowEvent,
+  },
   event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootELW},
   keyboard::ModifiersState,
   menu::{MenuItem, MenuType},

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -380,8 +380,8 @@ extern "C" fn frame_did_change(this: &Object, _sel: Sel, _event: id) {
     let logical_size = LogicalSize::new(rect.size.width as f64, rect.size.height as f64);
     let size = logical_size.to_physical::<u32>(state.get_scale_factor());
     AppState::queue_event(EventWrapper::StaticEvent(Event::WindowEvent {
-        window_id: WindowId(get_window_id(state.ns_window)),
-        event: WindowEvent::Resized(size),
+      window_id: WindowId(get_window_id(state.ns_window)),
+      event: WindowEvent::Resized(size),
     }));
 
     state.tracking_rect = Some(tracking_rect);

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -20,7 +20,7 @@ use objc::{
 };
 
 use crate::{
-  dpi::LogicalPosition,
+  dpi::{LogicalPosition, LogicalSize},
   event::{
     DeviceEvent, ElementState, Event, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent,
   },
@@ -373,6 +373,16 @@ extern "C" fn frame_did_change(this: &Object, _sel: Sel, _event: id) {
         userData:ptr::null_mut::<c_void>()
         assumeInside:NO
     ];
+
+    // Emit resize event here rather than from windowDidResize because:
+    // 1. When a new window is created as a tab, the frame size may change without a window resize occurring.
+    // 2. Even when a window resize does occur on a new tabbed window, it contains the wrong size (includes tab height).
+    let logical_size = LogicalSize::new(rect.size.width as f64, rect.size.height as f64);
+    let size = logical_size.to_physical::<u32>(state.get_scale_factor());
+    AppState::queue_event(EventWrapper::StaticEvent(Event::WindowEvent {
+        window_id: WindowId(get_window_id(state.ns_window)),
+        event: WindowEvent::Resized(size),
+    }));
 
     state.tracking_rect = Some(tracking_rect);
   }

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -104,14 +104,6 @@ impl WindowDelegateState {
     AppState::queue_event(wrapper);
   }
 
-  pub fn emit_resize_event(&mut self) {
-    let rect = unsafe { NSView::frame(*self.ns_view) };
-    let scale_factor = self.get_scale_factor();
-    let logical_size = LogicalSize::new(rect.size.width as f64, rect.size.height as f64);
-    let size = logical_size.to_physical(scale_factor);
-    self.emit_event(WindowEvent::Resized(size));
-  }
-
   fn emit_move_event(&mut self) {
     let rect = unsafe { NSWindow::frame(*self.ns_window) };
     let x = rect.origin.x as f64;
@@ -335,7 +327,7 @@ extern "C" fn window_did_resize(this: &Object, _: Sel, _: id) {
   trace!("Triggered `windowDidResize:`");
   with_state(this, |state| {
     if !state.is_checking_zoomed_in {
-      state.emit_resize_event();
+      // NOTE: WindowEvent::Resized is reported in frameDidChange.
       state.emit_move_event();
     }
   });


### PR DESCRIPTION
When the window switches mode from normal to tabbed one, it doesn't
get resized, however the frame gets resized. This commit makes
winit to track resizes when frame changes instead of window.

Co-authored-by: Phillip Hellewell <sshock@users.noreply.github.com>

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
