### PR TITLE
Changed to activate before opening window on macos.

### DIFF
--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -91,12 +91,14 @@ extern "C" fn dealloc(this: &Object, _: Sel) {
 }
 
 extern "C" fn will_finish_launching(this: &Object, _: Sel, _: id) {
+  trace!("Triggered `applicationWillFinishLaunching`");
   AppState::will_launch(this);
+  trace!("Completed `applicationWillFinishLaunching`");
 }
 
-extern "C" fn did_finish_launching(_: &Object, _: Sel, _: id) {
+extern "C" fn did_finish_launching(this: &Object, _: Sel, _: id) {
   trace!("Triggered `applicationDidFinishLaunching`");
-  AppState::launched();
+  AppState::launched(this);
   trace!("Completed `applicationDidFinishLaunching`");
 }
 

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -40,6 +40,11 @@ lazy_static! {
     decl.add_method(sel!(dealloc), dealloc as extern "C" fn(&Object, Sel));
 
     decl.add_method(
+      sel!(applicationWillFinishLaunching:),
+      will_finish_launching as extern "C" fn(&Object, Sel, id),
+    );
+
+    decl.add_method(
       sel!(applicationDidFinishLaunching:),
       did_finish_launching as extern "C" fn(&Object, Sel, id),
     );
@@ -85,9 +90,13 @@ extern "C" fn dealloc(this: &Object, _: Sel) {
   }
 }
 
-extern "C" fn did_finish_launching(this: &Object, _: Sel, _: id) {
+extern "C" fn will_finish_launching(this: &Object, _: Sel, _: id) {
+  AppState::will_launch(this);
+}
+
+extern "C" fn did_finish_launching(_: &Object, _: Sel, _: id) {
   trace!("Triggered `applicationDidFinishLaunching`");
-  AppState::launched(this);
+  AppState::launched();
   trace!("Completed `applicationDidFinishLaunching`");
 }
 

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -281,8 +281,11 @@ impl AppState {
     }
   }
 
-  pub fn launched(app_delegate: &Object) {
+  pub fn will_launch(app_delegate: &Object) {
     apply_activation_policy(app_delegate);
+  }
+
+  pub fn launched() {
     unsafe {
       let ns_app = NSApp();
       window_activation_hack(ns_app);
@@ -439,7 +442,7 @@ unsafe fn window_activation_hack(ns_app: id) {
     }
   }
 }
-fn apply_activation_policy(app_delegate: &Object) {
+pub fn apply_activation_policy(app_delegate: &Object) {
   unsafe {
     use cocoa::appkit::NSApplicationActivationPolicy::*;
     let ns_app = NSApp();

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -286,7 +286,7 @@ impl AppState {
   }
 
   pub fn launched(app_delegate: &Object) {
-    // In catalina, if I set the activation policy before the app is launched,
+    // In catalina, if we set the activation policy before the app is launched,
     // We get a bug where the menu is not clickable.
     // We have solved this problem by setting the activation policy to prohibited
     // with `set_policy_to_prohibited` and then running `apply_activation_policy` again. 

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -289,7 +289,7 @@ impl AppState {
     // In catalina, if we set the activation policy before the app is launched,
     // We get a bug where the menu is not clickable.
     // We have solved this problem by setting the activation policy to prohibited
-    // with `set_policy_to_prohibited` and then running `apply_activation_policy` again. 
+    // with `set_policy_to_prohibited` and then running `apply_activation_policy` again.
     set_policy_to_prohibited();
     apply_activation_policy(app_delegate);
     unsafe {
@@ -461,7 +461,7 @@ fn apply_activation_policy(app_delegate: &Object) {
   }
 }
 
-fn set_policy_to_prohibited(){
+fn set_policy_to_prohibited() {
   unsafe {
     let ns_app = NSApp();
     ns_app.setActivationPolicy_(cocoa::appkit::NSApplicationActivationPolicyProhibited);

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -285,7 +285,13 @@ impl AppState {
     apply_activation_policy(app_delegate);
   }
 
-  pub fn launched() {
+  pub fn launched(app_delegate: &Object) {
+    // In catalina, if I set the activation policy before the app is launched,
+    // We get a bug where the menu is not clickable.
+    // We have solved this problem by setting the activation policy to prohibited
+    // with `set_policy_to_prohibited` and then running `apply_activation_policy` again. 
+    set_policy_to_prohibited();
+    apply_activation_policy(app_delegate);
     unsafe {
       let ns_app = NSApp();
       window_activation_hack(ns_app);
@@ -442,18 +448,22 @@ unsafe fn window_activation_hack(ns_app: id) {
     }
   }
 }
-pub fn apply_activation_policy(app_delegate: &Object) {
+fn apply_activation_policy(app_delegate: &Object) {
   unsafe {
     use cocoa::appkit::NSApplicationActivationPolicy::*;
     let ns_app = NSApp();
-    // We need to delay setting the activation policy and activating the app
-    // until `applicationDidFinishLaunching` has been called. Otherwise the
-    // menu bar won't be interactable.
     let act_pol = get_aux_state_mut(app_delegate).activation_policy;
     ns_app.setActivationPolicy_(match act_pol {
       ActivationPolicy::Regular => NSApplicationActivationPolicyRegular,
       ActivationPolicy::Accessory => NSApplicationActivationPolicyAccessory,
       ActivationPolicy::Prohibited => NSApplicationActivationPolicyProhibited,
     });
+  }
+}
+
+fn set_policy_to_prohibited(){
+  unsafe {
+    let ns_app = NSApp();
+    ns_app.setActivationPolicy_(cocoa::appkit::NSApplicationActivationPolicyProhibited);
   }
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
fix https://github.com/tauri-apps/tauri/issues/4310

Fixed a bug that when starting tao with cargo run on macos, it was activated after the window was opened.

#### before fixed

https://user-images.githubusercontent.com/65934663/175223299-9a5e9107-59e8-4220-8546-962b9bc96289.mov

#### after fixed

https://user-images.githubusercontent.com/65934663/175223480-0aaee509-2cd1-4170-8f11-1980b840be3b.mov


