### PR TITLE
feat(linux): Store tray icons in XDG_RUNTIME_DIR

### DIFF
--- a/.changes/linux-runtime-dir.md
+++ b/.changes/linux-runtime-dir.md
@@ -1,0 +1,7 @@
+---
+"tao": patch
+---
+
+On Linux, store tray icons in `$XDG_RUNTIME_DIR`.
+This is preferred over `/tmp`, because this directory (typically `/run/user/{uid}`)
+is only readable for the current user. While `/tmp` is shared with all users.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ targets = [
 
 [features]
 default = [ ]
-tray = [ "libappindicator" ]
 dox = [ "gtk/dox" ]
+tray = [ "libappindicator", "dirs-next" ]
 
 [dependencies]
 instant = "0.1"
@@ -116,6 +116,7 @@ gdk-sys = "0.15"
 gdkx11-sys = "0.15"
 gdk-pixbuf = { version = "0.15", features = [ "v2_36_8" ] }
 libappindicator = { version = "0.7", optional = true }
+dirs-next = { version = "2.0.0", optional = true }
 x11-dl = "2.18"
 uuid = { version = "0.8", features = [ "v4" ] }
 png = "0.17"

--- a/src/platform_impl/linux/system_tray.rs
+++ b/src/platform_impl/linux/system_tray.rs
@@ -102,10 +102,24 @@ impl Drop for SystemTray {
 }
 
 fn temp_icon_path() -> std::io::Result<(PathBuf, PathBuf)> {
-  let mut parent_path = std::env::temp_dir();
+  let mut parent_path = dirs_next::runtime_dir().unwrap_or_else(|| std::env::temp_dir());
+
   parent_path.push("tao");
   std::fs::create_dir_all(&parent_path)?;
   let mut icon_path = parent_path.clone();
   icon_path.push(format!("tray-icon-{}.png", uuid::Uuid::new_v4()));
   Ok((parent_path, icon_path))
+}
+
+#[test]
+fn temp_icon_path_prefers_runtime() {
+  let runtime_dir = env!("XDG_RUNTIME_DIR");
+
+  let (dir1, _file1) = temp_icon_path().unwrap();
+  std::env::remove_var("XDG_RUNTIME_DIR");
+  let (dir2, _file2) = temp_icon_path().unwrap();
+  std::env::set_var("XDG_RUNTIME_DIR", runtime_dir);
+
+  assert_eq!(dir1, PathBuf::from(format!("{}/tao", runtime_dir)));
+  assert_eq!(dir2, PathBuf::from("/tmp/tao"));
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

This is preferred over `/tmp`, because this directory (typically `/run/user/{uid}`) is only readable for the current user. While `/tmp` is shared with all users.

Comparing mount options:
```
tmpfs on /tmp type tmpfs (rw,noatime,inode64)
tmpfs on /run/user/1000 type tmpfs (rw,nosuid,nodev,relatime,size=3281440k,nr_inodes=820360,mode=700,uid=1000,gid=1000,inode64)
```

Note the `mode=700,uid=1000,gid=1000`.

---

Also added a test case to show fallback behavior, using `/tmp` when the runtime dir is not set.