### PR TITLE
feat(linux): Support tray icons in flatpak

### DIFF
--- a/.changes/linux-flatpak-icon-dir.md
+++ b/.changes/linux-flatpak-icon-dir.md
@@ -1,0 +1,7 @@
+---
+"tao": patch
+---
+
+On Linux, Support tray icons in flatpak
+For flatpak tray icons to work, the theme path we set with `set_icon_theme_path` should map 1:1 between the sandbox and the host machine.
+The ideal directory to use for this is `$XDG_RUNTIME_DIR/app/{app_id}/` where {app_id} is the reverse DNS name of the flatpak app.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ targets = [
 [features]
 default = [ ]
 dox = [ "gtk/dox" ]
-tray = [ "libappindicator", "dirs-next" ]
+tray = [ "libappindicator", "dirs-next", "serde", "serde_ini" ]
 
 [dependencies]
 instant = "0.1"
@@ -117,6 +117,7 @@ gdkx11-sys = "0.15"
 gdk-pixbuf = { version = "0.15", features = [ "v2_36_8" ] }
 libappindicator = { version = "0.7", optional = true }
 dirs-next = { version = "2.0.0", optional = true }
+serde_ini = { version = "0.2.0", optional = true }
 x11-dl = "2.18"
 uuid = { version = "0.8", features = [ "v4" ] }
 png = "0.17"


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

For flatpak tray icons to work, the theme path we set with `set_icon_theme_path` should map 1:1 between the sandbox and the host machine. The ideal directory to use for this is `$XDG_RUNTIME_DIR/app/{app_id}/` where {app_id} is the reverse DNS name of the flatpak app.

Some concerns about this approach may be as @amrbashir mentioned on Discord.
We may want to implement flatpak detection in Tauri, and expose a builder method.
```rs
SystemTrayBuilder::new(icon, Some(menu))
  .with_tmp_dir(flatpak_tmp_path) // only exposed for linux
  .build();
```

Test cases for this behavior are also tricky, as `/.flatpak-info` on the _host_ machine would need root to create.

Finally, Tauri might in the future have other reasons to read this file, as it's full of interesting data.

<details><summary>A complete example</summary>

```ini
$ cat /.flatpak-info 
[Application]
name=com.github.beanow.hi-flatpak
runtime=runtime/org.gnome.Platform/x86_64/42

[Instance]
instance-id=1859100691
instance-path=/home/beanow/.var/app/com.github.beanow.hi-flatpak
app-path=/home/beanow/.local/share/flatpak/app/com.github.beanow.hi-flatpak/x86_64/master/48284ae72231021513303324ed6fd8295e6838659dbe34e758ee4a5a96656354/files
app-commit=48284ae72231021513303324ed6fd8295e6838659dbe34e758ee4a5a96656354
runtime-path=/home/beanow/.local/share/flatpak/runtime/org.gnome.Platform/x86_64/42/e21d33a4f415cd14b03a148f757ebc2b4f86259fae14e3bd22c361b5b1d9b480/files
runtime-commit=e21d33a4f415cd14b03a148f757ebc2b4f86259fae14e3bd22c361b5b1d9b480
runtime-extensions=org.gnome.Platform.Locale=03a8cc993267dea9c9f16fd682134135493fe34289f680e0c344b5933dfed098;org.freedesktop.Platform.GL.default=c8f81b502d8a867a532896330988485f68e94a2cbb4c26ae98b1b2811b566f7e;org.gtk.Gtk3theme.Matcha-azul=e957a9e42886c2dcce03b32a949c8f2694880c5cc05b0a3278181a5faa70bb24;org.freedesktop.Platform.openh264=73f998362a6fc0d57e0c7e83e928d32b0ec14d10d0d94291033976bdcecc6b6b
branch=master
arch=x86_64
flatpak-version=1.12.7
session-bus-proxy=true
system-bus-proxy=true

[Context]
shared=ipc;
sockets=x11;wayland;pulseaudio;
devices=dri;

[Session Bus Policy]
org.kde.StatusNotifierWatcher=talk
org.freedesktop.Notifications=talk
com.canonical.AppMenu.Registrar=talk
com.canonical.indicator.application=talk
com.canonical.Unity.LauncherEntry=talk

[Environment]
ALSA_CONFIG_PATH=/usr/share/alsa/alsa-flatpak.conf
GI_TYPELIB_PATH=/app/lib/girepository-1.0
GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/usr/lib/extensions/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0
XDG_DATA_DIRS=/app/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share
LD_LIBRARY_PATH=/app/lib
ALSA_CONFIG_DIR=/usr/share/alsa
__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS=/etc/egl/egl_external_platform.d:/usr/lib/x86_64-linux-gnu/GL/egl/egl_external_platform.d:/usr/share/egl/egl_external_platform.d
```

</details>