### PR TITLE
feat(macOS): create native image from file path

### DIFF
--- a/examples/system_tray.rs
+++ b/examples/system_tray.rs
@@ -7,11 +7,11 @@
 #[cfg(any(feature = "tray", all(target_os = "linux", feature = "ayatana")))]
 fn main() {
   #[cfg(target_os = "macos")]
+  use tao::platform::macos::{CustomMenuItemExtMacOS, NativeImage, SystemTrayBuilderExtMacOS};
   use tao::{
     event::Event,
     event_loop::{ControlFlow, EventLoop},
     menu::{ContextMenu as Menu, MenuItemAttributes, MenuType},
-    platform::macos::{CustomMenuItemExtMacOS, NativeImage, SystemTrayBuilderExtMacOS},
     system_tray::SystemTrayBuilder,
   };
 

--- a/examples/system_tray.rs
+++ b/examples/system_tray.rs
@@ -7,19 +7,16 @@
 #[cfg(any(feature = "tray", all(target_os = "linux", feature = "ayatana")))]
 fn main() {
   #[cfg(target_os = "macos")]
-  use tao::platform::macos::{CustomMenuItemExtMacOS, NativeImage, SystemTrayBuilderExtMacOS};
   use tao::{
     event::Event,
     event_loop::{ControlFlow, EventLoop},
     menu::{ContextMenu as Menu, MenuItemAttributes, MenuType},
+    platform::macos::{CustomMenuItemExtMacOS, NativeImage, SystemTrayBuilderExtMacOS},
     system_tray::SystemTrayBuilder,
   };
 
   env_logger::init();
   let event_loop = EventLoop::new();
-
-  let mut tray_menu = Menu::new();
-  let quit = tray_menu.add_item(MenuItemAttributes::new("Quit"));
 
   // You'll have to choose an icon size at your own discretion. On Linux, the icon should be
   // provided in whatever size it was naturally drawn; that is, don’t scale the image before passing
@@ -27,6 +24,17 @@ fn main() {
   // since it seems to work well enough in most cases. Be careful about going too high, or
   // you'll be bitten by the low-quality downscaling built into the WM.
   let path = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/icon.png");
+
+  let mut tray_menu = Menu::new();
+
+  #[cfg(target_os = "macos")]
+  {
+    let item = tray_menu
+      .add_item(MenuItemAttributes::new("Item 1"))
+      .set_native_image(NativeImage::FromFile(path.to_string()));
+  }
+
+  let quit = tray_menu.add_item(MenuItemAttributes::new("Quit"));
 
   let icon = load_icon(std::path::Path::new(path));
 

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -87,10 +87,7 @@ impl MenuItemAttributes {
     unsafe {
       let image_ref: id = match icon {
         NativeImage::FromFile(..) => icon.get_ns_image(),
-        _ => {
-          let ns_image: id = icon.get_ns_image();
-          msg_send![class!(NSImage), imageNamed: ns_image]
-        }
+        _ => msg_send![class!(NSImage), imageNamed: icon.get_ns_image()],
       };
       let () = msg_send![self.1, setImage: image_ref];
     }

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -85,8 +85,13 @@ impl MenuItemAttributes {
   // Available only with CustomMenuItemExtMacOS
   pub fn set_native_image(&mut self, icon: NativeImage) {
     unsafe {
-      let ns_image: id = icon.get_ns_image();
-      let image_ref: id = msg_send![class!(NSImage), imageNamed: ns_image];
+      let image_ref: id = match icon {
+        NativeImage::FromFile(..) => icon.get_ns_image(),
+        _ => {
+          let ns_image: id = icon.get_ns_image();
+          msg_send![class!(NSImage), imageNamed: ns_image]
+        }
+      };
       let () = msg_send![self.1, setImage: image_ref];
     }
   }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
Add support to create `NativeImage` from a given file path.

It enables devs to use an image from a file path as native image for their menu items.


- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
