### PR TITLE
feat(linux) add `with_temp_icon_dir` builder extension

### DIFF
--- a/.changes/linux-custom-temp-icon-dir.md
+++ b/.changes/linux-custom-temp-icon-dir.md
@@ -1,0 +1,6 @@
+---
+"tao": minor
+---
+
+On Linux, adds `SystemTrayBuilderExtLinux::with_temp_icon_dir` which sets a custom temp icon dir to store generated icon files.
+This may be useful when the application requires icons to be stored in a specific location, such as when running in a Flatpak sandbox.

--- a/examples/system_tray.rs
+++ b/examples/system_tray.rs
@@ -6,6 +6,8 @@
 #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
 #[cfg(any(feature = "tray", all(target_os = "linux", feature = "ayatana")))]
 fn main() {
+  #[cfg(target_os = "linux")]
+  use tao::platform::linux::SystemTrayBuilderExtLinux;
   #[cfg(target_os = "macos")]
   use tao::platform::macos::{CustomMenuItemExtMacOS, NativeImage, SystemTrayBuilderExtMacOS};
   use tao::{
@@ -30,6 +32,13 @@ fn main() {
 
   let icon = load_icon(std::path::Path::new(path));
 
+  #[cfg(target_os = "linux")]
+  let system_tray = SystemTrayBuilder::new(icon, Some(tray_menu))
+    .with_temp_icon_dir(std::path::Path::new("/tmp/tao-examples"))
+    .build(&event_loop)
+    .unwrap();
+
+  #[cfg(not(target_os = "linux"))]
   let system_tray = SystemTrayBuilder::new(icon, Some(tray_menu))
     .build(&event_loop)
     .unwrap();

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1,0 +1,23 @@
+// Copyright 2019-2021 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(target_os = "linux")]
+
+#[cfg(feature = "tray")]
+use crate::system_tray::SystemTrayBuilder;
+#[cfg(feature = "tray")]
+use std::path::Path;
+
+#[cfg(feature = "tray")]
+pub trait SystemTrayBuilderExtLinux {
+  /// Sets a custom temp icon dir to store generated icon files.
+  fn with_temp_icon_dir<P: AsRef<Path>>(self, p: P) -> Self;
+}
+
+#[cfg(feature = "tray")]
+impl SystemTrayBuilderExtLinux for SystemTrayBuilder {
+  fn with_temp_icon_dir<P: AsRef<Path>>(mut self, p: P) -> Self {
+    self.0.temp_icon_dir = Some(p.as_ref().to_path_buf());
+    self
+  }
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -21,8 +21,8 @@
 
 pub mod android;
 pub mod ios;
+pub mod linux;
 pub mod macos;
 pub mod run_return;
 pub mod unix;
-pub mod linux;
 pub mod windows;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -9,6 +9,7 @@
 //!  - `ios`
 //!  - `macos`
 //!  - `unix`
+//!  - `linux`
 //!  - `windows`
 //!
 //! And the following platform-specific module:
@@ -23,4 +24,5 @@ pub mod ios;
 pub mod macos;
 pub mod run_return;
 pub mod unix;
+pub mod linux;
 pub mod windows;

--- a/src/platform_impl/linux/system_tray.rs
+++ b/src/platform_impl/linux/system_tray.rs
@@ -38,8 +38,8 @@ impl SystemTrayBuilder {
   ) -> Result<RootSystemTray, OsError> {
     let mut app_indicator = AppIndicator::new("tao application", "");
 
-    let (parent_path, icon_path) = temp_icon_path(self.temp_icon_dir.as_ref())
-      .expect("Failed to create a temp folder for icon");
+    let (parent_path, icon_path) =
+      temp_icon_path(self.temp_icon_dir.as_ref()).expect("Failed to create a temp folder for icon");
 
     self.icon.inner.write_to_png(&icon_path);
 
@@ -75,8 +75,8 @@ pub struct SystemTray {
 
 impl SystemTray {
   pub fn set_icon(&mut self, icon: Icon) {
-    let (parent_path, icon_path) = temp_icon_path(self.temp_icon_dir.as_ref())
-      .expect("Failed to create a temp folder for icon");
+    let (parent_path, icon_path) =
+      temp_icon_path(self.temp_icon_dir.as_ref()).expect("Failed to create a temp folder for icon");
     icon.inner.write_to_png(&icon_path);
 
     self

--- a/src/platform_impl/linux/system_tray.rs
+++ b/src/platform_impl/linux/system_tray.rs
@@ -34,7 +34,7 @@ impl SystemTrayBuilder {
     let mut app_indicator = AppIndicator::new("tao application", "");
 
     let (parent_path, icon_path) =
-      temp_icon_path().expect("Failed to create a temp folder for icon");
+      temp_icon_path(None).expect("Failed to create a temp folder for icon");
 
     self.icon.inner.write_to_png(&icon_path);
 
@@ -69,7 +69,7 @@ pub struct SystemTray {
 impl SystemTray {
   pub fn set_icon(&mut self, icon: Icon) {
     let (parent_path, icon_path) =
-      temp_icon_path().expect("Failed to create a temp folder for icon");
+      temp_icon_path(None).expect("Failed to create a temp folder for icon");
     icon.inner.write_to_png(&icon_path);
 
     self
@@ -98,28 +98,38 @@ impl Drop for SystemTray {
   }
 }
 
-fn temp_icon_path() -> std::io::Result<(PathBuf, PathBuf)> {
-  let mut parent_path = dirs_next::runtime_dir().unwrap_or_else(|| std::env::temp_dir());
+/// Generates an icon path in one of the following dirs:
+/// 1. If `temp_icon_dir` is `Some` use that.
+/// 2. `$XDG_RUNTIME_DIR/tao`
+/// 3. `/tmp/tao`
+fn temp_icon_path(temp_icon_dir: Option<&PathBuf>) -> std::io::Result<(PathBuf, PathBuf)> {
+  let parent_path = match temp_icon_dir.as_ref() {
+    Some(path) => path.to_path_buf(),
+    None => dirs_next::runtime_dir()
+      .unwrap_or_else(|| std::env::temp_dir())
+      .join("tao"),
+  };
 
-  parent_path.push("tao");
   std::fs::create_dir_all(&parent_path)?;
-  let mut icon_path = parent_path.clone();
-  icon_path.push(format!("tray-icon-{}.png", uuid::Uuid::new_v4()));
+  let icon_path = parent_path.join(format!("tray-icon-{}.png", uuid::Uuid::new_v4()));
   Ok((parent_path, icon_path))
 }
 
 #[test]
-fn temp_icon_path_prefers_runtime() {
+fn temp_icon_path_preference_order() {
   let runtime_dir = option_env!("XDG_RUNTIME_DIR");
+  let override_dir = PathBuf::from("/tmp/tao-tests");
 
-  let (dir1, _file1) = temp_icon_path().unwrap();
+  let (dir1, _file1) = temp_icon_path(Some(&override_dir)).unwrap();
+  let (dir2, _file1) = temp_icon_path(None).unwrap();
   std::env::remove_var("XDG_RUNTIME_DIR");
-  let (dir2, _file2) = temp_icon_path().unwrap();
+  let (dir3, _file2) = temp_icon_path(None).unwrap();
 
+  assert_eq!(dir1, override_dir);
   if let Some(runtime_dir) = runtime_dir {
     std::env::set_var("XDG_RUNTIME_DIR", runtime_dir);
-    assert_eq!(dir1, PathBuf::from(format!("{}/tao", runtime_dir)));
+    assert_eq!(dir2, PathBuf::from(format!("{}/tao", runtime_dir)));
   }
 
-  assert_eq!(dir2, PathBuf::from("/tmp/tao"));
+  assert_eq!(dir3, PathBuf::from("/tmp/tao"));
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

This is the replacement approach for #450.
Rather than detecting Flatpaks with Tao, we'll allow setting a `temp_icon_dir` to override default behavior.

Note, some refactoring was involved so I've made several commits for easier review.

Also as this adds a new (non breaking) feature, I assumed this is a minor version increment.

Testing:
- The unit test is updated.
  1. Run with `cargo test --features=tray`.
- The example is updated.
  1. Run with `cargo run --features=tray --example=system_tray`.
  2. Verify that the example created an icon at path `/tmp/tao-examples/*.png`