### PR TITLE
fix(windows): get correct monitor in `WM_NCCALCSIZE`, closes #471

### DIFF
--- a/.changes/correct-monitor.md
+++ b/.changes/correct-monitor.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On Windows, fix assigning the wrong mintor rect to undecorated maximized window. This caused a blank window downstream in wry and tauri.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1982,9 +1982,10 @@ unsafe fn public_window_callback_inner<T: 'static>(
       if !win_flags.contains(WindowFlags::DECORATIONS) {
         // adjust the maximized borderless window so it doesn't cover the taskbar
         if util::is_maximized(window) {
-          let monitor = monitor::current_monitor(window);
-          if let Ok(monitor_info) = monitor::get_monitor_info(monitor.hmonitor()) {
-            let params = &mut *(lparam.0 as *mut NCCALCSIZE_PARAMS);
+          let params = &mut *(lparam.0 as *mut NCCALCSIZE_PARAMS);
+          if let Ok(monitor_info) =
+            monitor::get_monitor_info(MonitorFromRect(&params.rgrc[0], MONITOR_DEFAULTTONULL))
+          {
             params.rgrc[0] = monitor_info.monitorInfo.rcWork;
           }
         }


### PR DESCRIPTION
`MonitorFromWindow` is unreliable with maximized Window, it either can't
find a monitor for the window and will default to nearest monitor or it
will find a wrong monitor, see
https://github.com/MicrosoftEdge/WebView2Feedback/issues/2549#issuecomment-1180843867.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [X] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information
