### PR TITLE
fix(windows): fix focus events being sent to inactive windows.

### DIFF
--- a/.changes/window-focus-inactive.md
+++ b/.changes/window-focus-inactive.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On Windows, fix focus events being sent to inactive windows.

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -40,7 +40,6 @@ pub struct WindowState {
 
   pub window_flags: WindowFlags,
 
-
   // Used by WM_NCACTIVATE, WM_SETFOCUS and WM_KILLFOCUS
   pub is_active: bool,
   pub is_focused: bool,
@@ -133,7 +132,8 @@ impl WindowState {
       preferred_theme,
       high_surrogate: None,
       ime_handler: MinimalIme::default(),
-      window_flags: WindowFlags::empty(),is_active: false,
+      window_flags: WindowFlags::empty(),
+      is_active: false,
       is_focused: false,
     }
   }
@@ -163,21 +163,21 @@ impl WindowState {
 
   pub fn has_active_focus(&self) -> bool {
     self.is_active && self.is_focused
-}
+  }
 
-// Updates is_active and returns whether active-focus state has changed
-pub fn set_active(&mut self, is_active: bool) -> bool {
+  // Updates is_active and returns whether active-focus state has changed
+  pub fn set_active(&mut self, is_active: bool) -> bool {
     let old = self.has_active_focus();
     self.is_active = is_active;
     old != self.has_active_focus()
-}
+  }
 
-// Updates is_focused and returns whether active-focus state has changed
-pub fn set_focused(&mut self, is_focused: bool) -> bool {
+  // Updates is_focused and returns whether active-focus state has changed
+  pub fn set_focused(&mut self, is_focused: bool) -> bool {
     let old = self.has_active_focus();
     self.is_focused = is_focused;
     old != self.has_active_focus()
-}
+  }
 }
 
 impl MouseProperties {

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -39,6 +39,11 @@ pub struct WindowState {
   pub ime_handler: MinimalIme,
 
   pub window_flags: WindowFlags,
+
+
+  // Used by WM_NCACTIVATE, WM_SETFOCUS and WM_KILLFOCUS
+  pub is_active: bool,
+  pub is_focused: bool,
 }
 
 #[derive(Clone)]
@@ -128,7 +133,8 @@ impl WindowState {
       preferred_theme,
       high_surrogate: None,
       ime_handler: MinimalIme::default(),
-      window_flags: WindowFlags::empty(),
+      window_flags: WindowFlags::empty(),is_active: false,
+      is_focused: false,
     }
   }
 
@@ -154,6 +160,24 @@ impl WindowState {
   {
     f(&mut self.window_flags);
   }
+
+  pub fn has_active_focus(&self) -> bool {
+    self.is_active && self.is_focused
+}
+
+// Updates is_active and returns whether active-focus state has changed
+pub fn set_active(&mut self, is_active: bool) -> bool {
+    let old = self.has_active_focus();
+    self.is_active = is_active;
+    old != self.has_active_focus()
+}
+
+// Updates is_focused and returns whether active-focus state has changed
+pub fn set_focused(&mut self, is_focused: bool) -> bool {
+    let old = self.has_active_focus();
+    self.is_focused = is_focused;
+    old != self.has_active_focus()
+}
 }
 
 impl MouseProperties {


### PR DESCRIPTION
Co-authored-by: Steve Wooster <swooster@users.noreply.github.com>
ref: https://github.com/rust-windowing/winit/commit/1091a8ba1adb6533cb3747d49cf4c08303cdb92a

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [X] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information
