### PR TITLE
Update libappindicator dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ gdk = { version = "0.15", features = [ "v3_22" ] }
 gdk-sys = "0.15"
 gdkx11-sys = "0.15"
 gdk-pixbuf = { version = "0.15", features = [ "v2_36_8" ] }
-libappindicator = { version = "0.7", optional = true }
+libappindicator = { version = "0.7.1", optional = true }
 dirs-next = { version = "2.0.0", optional = true }
 x11-dl = "2.19"
 uuid = { version = "1.1", features = [ "v4" ] }


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

This addresses my comment https://github.com/tauri-apps/tao/pull/411#issuecomment-1192208890, in that PR `ayatana` support was removed as "unnecessary", but it is only the case with `libappindicator >= 0.7.1`, which wasn't bumped, so in our project old version was used even after Tauri upgrade.