### PR TITLE
fix(windows): respect min/max sizes when creating window, closes #498

### DIFF
--- a/.changes/windows-initial-window-min-max-size.md
+++ b/.changes/windows-initial-window-min-max-size.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+On Windows, respect min/max inner sizes when creating the window.

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -433,6 +433,29 @@ impl Size {
       Size::Logical(size) => size.to_physical(scale_factor),
     }
   }
+
+  pub fn clamp<S: Into<Size>>(input: S, min: S, max: S, scale_factor: f64) -> Size {
+    let (input, min, max) = (
+      input.into().to_physical::<f64>(scale_factor),
+      min.into().to_physical::<f64>(scale_factor),
+      max.into().to_physical::<f64>(scale_factor),
+    );
+
+    let clamp = |input: f64, min: f64, max: f64| {
+      if input < min {
+        min
+      } else if input > max {
+        max
+      } else {
+        input
+      }
+    };
+
+    let width = clamp(input.width, min.width, max.width);
+    let height = clamp(input.height, min.height, max.height);
+
+    PhysicalSize::new(width, height).into()
+  }
 }
 
 impl<P: Pixel> From<PhysicalSize<P>> for Size {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -941,21 +941,30 @@ unsafe fn init<T: 'static>(
 
   win.set_skip_taskbar(pl_attribs.skip_taskbar);
 
-  let dimensions = attributes
-    .inner_size
-    .unwrap_or_else(|| PhysicalSize::new(800, 600).into());
-  win.set_inner_size(dimensions);
-  if attributes.maximized {
-    // Need to set MAXIMIZED after setting `inner_size` as
-    // `Window::set_inner_size` changes MAXIMIZED to false.
-    win.set_maximized(true);
-  }
-  win.set_visible(attributes.visible);
-
   if attributes.fullscreen.is_some() {
     win.set_fullscreen(attributes.fullscreen);
     force_window_active(win.window.0);
+  } else {
+    let size = attributes
+      .inner_size
+      .unwrap_or_else(|| PhysicalSize::new(800, 600).into());
+    let max_size = attributes
+      .max_inner_size
+      .unwrap_or_else(|| PhysicalSize::new(f64::MAX, f64::MAX).into());
+    let min_size = attributes
+      .min_inner_size
+      .unwrap_or_else(|| PhysicalSize::new(0, 0).into());
+    let clamped_size = Size::clamp(size, min_size, max_size, win.scale_factor());
+    win.set_inner_size(clamped_size);
+
+    if attributes.maximized {
+      // Need to set MAXIMIZED after setting `inner_size` as
+      // `Window::set_inner_size` changes MAXIMIZED to false.
+      win.set_maximized(true);
+    }
   }
+
+  win.set_visible(attributes.visible);
 
   if let Some(position) = attributes.position {
     win.set_outer_position(position);


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
