### PR TITLE
feat(macos): add ApplicationShouldHandleReopen event.

### DIFF
--- a/.changes/ApplicationShouldHandleReopen-event.md
+++ b/.changes/ApplicationShouldHandleReopen-event.md
@@ -1,0 +1,5 @@
+---
+"tao": minor
+---
+
+Add `event::ApplicationShouldHandleReopen` for handle click on dock icon on macOS. 

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,3 +34,4 @@ Run the `cargo run --example <file_name>` to see how each example works.
 - `window`: example that makes a window.
 - `system_tray`: add icon to your system tray, click icon to start. 
 - `system_tray_no_menu`: like system_tray, but no menu when right click icon. 
+- `activate_event`: example of how to handle click on dock icon.

--- a/examples/activate_event.rs
+++ b/examples/activate_event.rs
@@ -1,0 +1,65 @@
+// Copyright 2019-2021 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+
+use tao::{
+  event::{Event, WindowEvent},
+  event_loop::{ControlFlow, EventLoop},
+  window::WindowBuilder,
+};
+
+#[allow(clippy::single_match)]
+fn main() {
+  let event_loop = EventLoop::new();
+
+  let window = Some(
+    WindowBuilder::new()
+      .with_title("A fantastic window!")
+      .with_inner_size(tao::dpi::LogicalSize::new(128.0, 128.0))
+      .build(&event_loop)
+      .unwrap(),
+  );
+
+  event_loop.run(move |event, _, control_flow| {
+    *control_flow = ControlFlow::Wait;
+    println!("{:?}", event);
+
+    match event {
+      Event::WindowEvent {
+        event: WindowEvent::CloseRequested,
+        window_id: _,
+        ..
+      } => {
+        // drop the window to fire the `Destroyed` event
+        if let Some(window) = &window{
+          window.set_visible(false)
+        }
+      }
+      Event::WindowEvent {
+        event: WindowEvent::Destroyed,
+        window_id: _,
+        ..
+      } => {
+        // *control_flow = ControlFlow::Exit;
+      }
+      Event::MainEventsCleared => {
+        if let Some(w) = &window {
+          w.request_redraw();
+        }
+      }
+      // handle click on dock icon
+      Event::ApplicationShouldHandleReopen { has_visible_windows, should_handle } => {
+        if !has_visible_windows {
+          if let Some(window) = &window{
+            window.set_visible(true)
+          }
+        } else {
+          if let Some(window) = &window{
+            window.set_visible(false)
+          }
+        }
+        *should_handle = false
+      }
+      _ => {}
+    }
+  });
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -100,6 +100,16 @@ pub enum Event<'a, T: 'static> {
     position: PhysicalPosition<f64>,
   },
 
+  /// Emitted when dock icon has been clicked.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **iOS / Android / Linux / Windows:** Unsupported.
+  ApplicationShouldHandleReopen {
+    has_visible_windows: bool,
+    should_handle: &'a mut bool,
+  },
+
   /// Emitted when a global shortcut is triggered.
   ///
   /// ## Platform-specific
@@ -203,6 +213,9 @@ impl<T: Clone> Clone for Event<'static, T> {
         position: *position,
       },
       GlobalShortcutEvent(accelerator_id) => GlobalShortcutEvent(*accelerator_id),
+      ApplicationShouldHandleReopen { .. } => {
+        unreachable!("ApplicationShouldHandleReopen cannot clone")
+      },
     }
   }
 }
@@ -240,6 +253,13 @@ impl<'a, T> Event<'a, T> {
         position,
       }),
       GlobalShortcutEvent(accelerator_id) => Ok(GlobalShortcutEvent(accelerator_id)),
+      ApplicationShouldHandleReopen {
+        has_visible_windows,
+        should_handle
+      } => Ok(ApplicationShouldHandleReopen {
+        has_visible_windows,
+        should_handle,
+      }),
     }
   }
 
@@ -279,6 +299,7 @@ impl<'a, T> Event<'a, T> {
         position,
       }),
       GlobalShortcutEvent(accelerator_id) => Some(GlobalShortcutEvent(accelerator_id)),
+      ApplicationShouldHandleReopen { .. } => None,
     }
   }
 }

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -211,6 +211,12 @@ impl Handler {
     }
   }
 
+  fn handle_nonuser_event_without_wrapper(&self, event: Event<'_, Never>) {
+    if let Some(ref mut callback) = *self.callback.lock().unwrap() {
+      callback.handle_nonuser_event(event, &mut *self.control_flow.lock().unwrap())
+    }
+  }
+
   fn handle_user_events(&self) {
     if let Some(ref mut callback) = *self.callback.lock().unwrap() {
       callback.handle_user_events(&mut *self.control_flow.lock().unwrap());
@@ -295,6 +301,17 @@ impl AppState {
       StartCause::Init,
     )));
     HANDLER.set_in_callback(false);
+  }
+
+  pub fn should_handle_reopen(has_visible_windows: bool) -> bool {
+    let mut should_handle = true;
+
+    HANDLER.handle_nonuser_event_without_wrapper(Event::ApplicationShouldHandleReopen {
+      has_visible_windows,
+      should_handle: &mut should_handle,
+    });
+
+    should_handle
   }
 
   pub fn wakeup(panic_info: Weak<PanicInfo>) {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
in macOS the app usually doesn't exit when all window closed, and will use click on dock icon for reopen window.