### PR TITLE
feat(macos): add Reopen event, closes #218

### DIFF
--- a/.changes/macos_reopen_event.md
+++ b/.changes/macos_reopen_event.md
@@ -1,0 +1,5 @@
+---
+"tao": minor
+---
+
+Add `event::Reopen` for handle click on dock icon on macOS.

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,7 @@ Run the `cargo run --example <file_name>` to see how each example works.
 - `multithreaded`: same as multiwindow but multithreaded.
 - `multiwindow`: create multiple windows
 - `parentwindow`: a window inside another window.
+- `reopen_event`: handle click on dock icon on macOS
 - `resizable`: allow resizing window or not.
 - `set_ime_position`: set IME (input method editor) position when click.
 - `transparent`: make a transparent window.

--- a/examples/reopen_event.rs
+++ b/examples/reopen_event.rs
@@ -1,0 +1,43 @@
+// Copyright 2014-2021 The winit contributors
+// Copyright 2021-2023 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+
+use tao::{
+  event::{Event, WindowEvent},
+  event_loop::{ControlFlow, EventLoop},
+  window::Window,
+};
+
+#[allow(clippy::single_match)]
+fn main() {
+  let event_loop = EventLoop::new();
+
+  let mut window = Some(Window::new(&event_loop).unwrap());
+
+  event_loop.run(move |event, event_loop, control_flow| {
+    *control_flow = ControlFlow::Wait;
+
+    match event {
+      Event::WindowEvent {
+        event: WindowEvent::CloseRequested,
+        ..
+      } => {
+        // drop the window
+        window = None;
+      }
+      Event::Reopen {
+        has_visible_windows,
+        ..
+      } => {
+        println!("on reopen, has visible windows: {has_visible_windows}");
+        window = Some(Window::new(&event_loop).unwrap())
+      }
+      Event::MainEventsCleared => {
+        if let Some(w) = &window {
+          w.request_redraw();
+        }
+      }
+      _ => (),
+    }
+  });
+}

--- a/examples/reopen_event.rs
+++ b/examples/reopen_event.rs
@@ -30,7 +30,9 @@ fn main() {
         ..
       } => {
         println!("on reopen, has visible windows: {has_visible_windows}");
-        window = Some(Window::new(&event_loop).unwrap())
+        if !has_visible_windows {
+          window = Some(Window::new(&event_loop).unwrap())
+        }
       }
       Event::MainEventsCleared => {
         if let Some(w) = &window {

--- a/src/event.rs
+++ b/src/event.rs
@@ -136,6 +136,13 @@ pub enum Event<'a, T: 'static> {
 
   /// Emitted when the app is open by external resources, like opening a file or deeplink.
   Opened { urls: Vec<url::Url> },
+
+  /// ## Platform-specific
+  ///
+  /// - **macOS**: https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428638-applicationshouldhandlereopen with return value same as hasVisibleWindows
+  /// - **Other**: Unsupported.
+  #[non_exhaustive]
+  Reopen { has_visible_windows: bool },
 }
 
 impl<T: Clone> Clone for Event<'static, T> {
@@ -159,6 +166,11 @@ impl<T: Clone> Clone for Event<'static, T> {
       Suspended => Suspended,
       Resumed => Resumed,
       Opened { urls } => Opened { urls: urls.clone() },
+      Reopen {
+        has_visible_windows,
+      } => Reopen {
+        has_visible_windows: *has_visible_windows,
+      },
     }
   }
 }
@@ -178,6 +190,11 @@ impl<'a, T> Event<'a, T> {
       Suspended => Ok(Suspended),
       Resumed => Ok(Resumed),
       Opened { urls } => Ok(Opened { urls }),
+      Reopen {
+        has_visible_windows,
+      } => Ok(Reopen {
+        has_visible_windows,
+      }),
     }
   }
 
@@ -199,6 +216,11 @@ impl<'a, T> Event<'a, T> {
       Suspended => Some(Suspended),
       Resumed => Some(Resumed),
       Opened { urls } => Some(Opened { urls }),
+      Reopen {
+        has_visible_windows,
+      } => Some(Reopen {
+        has_visible_windows,
+      }),
     }
   }
 }
@@ -692,7 +714,6 @@ pub struct KeyEvent {
   /// ## Platform-specific
   /// - **Web:** Dead keys might be reported as the real key instead
   /// of `Dead` depending on the browser/OS.
-  ///
   pub logical_key: keyboard::Key<'static>,
 
   /// Contains the text produced by this keypress.

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -4,8 +4,7 @@
 
 use crate::{platform::macos::ActivationPolicy, platform_impl::platform::app_state::AppState};
 
-use cocoa::base::id;
-use cocoa::foundation::NSString;
+use cocoa::{base::id, foundation::NSString};
 use objc::{
   declare::ClassDecl,
   runtime::{Class, Object, Sel, BOOL},
@@ -15,8 +14,7 @@ use std::{
   os::raw::c_void,
 };
 
-use cocoa::foundation::NSArray;
-use cocoa::foundation::NSURL;
+use cocoa::foundation::{NSArray, NSURL};
 use std::ffi::CStr;
 
 static AUX_DELEGATE_STATE_NAME: &str = "auxState";
@@ -53,6 +51,10 @@ lazy_static! {
     decl.add_method(
       sel!(application:openURLs:),
       application_open_urls as extern "C" fn(&Object, Sel, id, id),
+    );
+    decl.add_method(
+      sel!(applicationShouldHandleReopen:hasVisibleWindows:),
+      application_should_handle_reopen as extern "C" fn(&Object, Sel, id, BOOL) -> BOOL,
     );
     decl.add_method(
       sel!(applicationSupportsSecureRestorableState:),
@@ -123,6 +125,18 @@ extern "C" fn application_open_urls(_: &Object, _: Sel, _: id, urls: id) -> () {
   trace!("Get `application:openURLs:` URLs: {:?}", urls);
   AppState::open_urls(urls);
   trace!("Completed `application:openURLs:`");
+}
+
+extern "C" fn application_should_handle_reopen(
+  _: &Object,
+  _: Sel,
+  _: id,
+  has_visible_windows: BOOL,
+) -> BOOL {
+  trace!("Triggered `applicationShouldHandleReopen`");
+  AppState::reopen(has_visible_windows);
+  trace!("Completed `applicationShouldHandleReopen`");
+  has_visible_windows
 }
 
 extern "C" fn application_supports_secure_restorable_state(_: &Object, _: Sel, _: id) -> BOOL {

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -4,7 +4,10 @@
 
 use crate::{platform::macos::ActivationPolicy, platform_impl::platform::app_state::AppState};
 
-use cocoa::{base::id, foundation::NSString};
+use cocoa::{
+  base::{id, NO},
+  foundation::NSString,
+};
 use objc::{
   declare::ClassDecl,
   runtime::{Class, Object, Sel, BOOL},
@@ -134,7 +137,7 @@ extern "C" fn application_should_handle_reopen(
   has_visible_windows: BOOL,
 ) -> BOOL {
   trace!("Triggered `applicationShouldHandleReopen`");
-  AppState::reopen(has_visible_windows);
+  AppState::reopen(has_visible_windows != NO);
   trace!("Completed `applicationShouldHandleReopen`");
   has_visible_windows
 }

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -306,6 +306,12 @@ impl AppState {
     HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::Opened { urls }));
   }
 
+  pub fn reopen(has_visible_windows: bool) {
+    HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::Reopen {
+      has_visible_windows,
+    }));
+  }
+
   pub fn wakeup(panic_info: Weak<PanicInfo>) {
     let panic_info = panic_info
       .upgrade()


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
in macOS the app usually doesn't exit when all window closed, and will use click on dock icon for reopen window.
https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428638-applicationshouldhandlereopen?language=objc

---

this is a recreate of pr #515, due to it's not signed because misconfiguration in git