### PR TITLE
fix(window): `is_decorated` wrong return value, closes #518

### DIFF
--- a/.changes/fix-macos-is-decorated.md
+++ b/.changes/fix-macos-is-decorated.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fixes `Window::is_decorated` always returning `true` on macOS.

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -861,13 +861,7 @@ impl UnownedWindow {
 
   #[inline]
   pub fn is_decorated(&self) -> bool {
-    let current_mask = unsafe { self.ns_window.styleMask() };
-    if current_mask
-      == NSWindowStyleMask::NSMiniaturizableWindowMask | NSWindowStyleMask::NSResizableWindowMask
-    {
-      return false;
-    }
-    true
+    self.decorations.load(Ordering::Acquire)
   }
 
   #[inline]


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
