### PR TITLE
fix(macos): retain tray to prevent segfault when event loop is running

### DIFF
--- a/.changes/fix-macos-tray-creation.md
+++ b/.changes/fix-macos-tray-creation.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix system tray creation after event loop starts on macOS.

--- a/src/platform_impl/macos/system_tray.rs
+++ b/src/platform_impl/macos/system_tray.rs
@@ -21,7 +21,7 @@ use cocoa::{
     NSStatusBar, NSStatusItem, NSWindow,
   },
   base::{id, nil, NO, YES},
-  foundation::{NSAutoreleasePool, NSData, NSPoint, NSSize, NSString},
+  foundation::{NSData, NSPoint, NSSize, NSString},
 };
 use objc::{
   declare::ClassDecl,
@@ -38,9 +38,9 @@ impl SystemTrayBuilder {
   #[inline]
   pub fn new(icon: Icon, tray_menu: Option<Menu>) -> Self {
     unsafe {
-      let ns_status_bar = NSStatusBar::systemStatusBar(nil)
-        .statusItemWithLength_(NSSquareStatusItemLength)
-        .autorelease();
+      let ns_status_bar =
+        NSStatusBar::systemStatusBar(nil).statusItemWithLength_(NSSquareStatusItemLength);
+      let _: () = msg_send![ns_status_bar, retain];
 
       Self {
         system_tray: SystemTray {
@@ -119,6 +119,7 @@ impl Drop for SystemTray {
   fn drop(&mut self) {
     unsafe {
       NSStatusBar::systemStatusBar(nil).removeStatusItem_(self.ns_status_bar);
+      let _: () = msg_send![self.ns_status_bar, release];
     }
   }
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

I learned this from the [electron implementation](https://github.com/electron/electron/blob/19baea4bc2be42ac0568bacab9e7365bb3f8ce26/shell/browser/ui/tray_icon_cocoa.mm#L53).