### PR TITLE
fix(linux/globalShortcut): disable on wayland

### DIFF
--- a/.changes/linux-wayland.md
+++ b/.changes/linux-wayland.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+Disables the global shortcut manager on wayland as its X11-specific.

--- a/src/platform_impl/linux/global_shortcut.rs
+++ b/src/platform_impl/linux/global_shortcut.rs
@@ -40,126 +40,130 @@ impl ShortcutManager {
     let (method_sender, thread_receiver) = channel::unbounded();
     let (thread_sender, method_receiver) = channel::unbounded();
 
-    std::thread::spawn(move || {
-      let event_loop_channel = event_loop_channel.clone();
-      let xlib = xlib::Xlib::open().unwrap();
-      unsafe {
-        let display = (xlib.XOpenDisplay)(ptr::null());
-        let root = (xlib.XDefaultRootWindow)(display);
+    if !_window_target.p.is_wayland() {
+      std::thread::spawn(move || {
+        let event_loop_channel = event_loop_channel.clone();
+        let xlib = xlib::Xlib::open().unwrap();
+        unsafe {
+          let display = (xlib.XOpenDisplay)(ptr::null());
+          let root = (xlib.XDefaultRootWindow)(display);
 
-        // Only trigger key release at end of repeated keys
-        #[allow(clippy::uninit_assumed_init)]
-        let mut supported_rtrn: i32 = std::mem::MaybeUninit::uninit().assume_init();
-        (xlib.XkbSetDetectableAutoRepeat)(display, 1, &mut supported_rtrn);
+          // Only trigger key release at end of repeated keys
+          #[allow(clippy::uninit_assumed_init)]
+          let mut supported_rtrn: i32 = std::mem::MaybeUninit::uninit().assume_init();
+          (xlib.XkbSetDetectableAutoRepeat)(display, 1, &mut supported_rtrn);
 
-        (xlib.XSelectInput)(display, root, xlib::KeyReleaseMask);
-        #[allow(clippy::uninit_assumed_init)]
-        let mut event: xlib::XEvent = std::mem::MaybeUninit::uninit().assume_init();
+          (xlib.XSelectInput)(display, root, xlib::KeyReleaseMask);
+          #[allow(clippy::uninit_assumed_init)]
+          let mut event: xlib::XEvent = std::mem::MaybeUninit::uninit().assume_init();
 
-        loop {
-          let event_loop_channel = event_loop_channel.clone();
-          if (xlib.XPending)(display) > 0 {
-            (xlib.XNextEvent)(display, &mut event);
-            if let xlib::KeyRelease = event.get_type() {
-              let keycode = event.key.keycode;
-              // X11 sends masks for Lock keys also and we only care about the 4 below
-              let modifiers = event.key.state
-                & (xlib::ControlMask | xlib::ShiftMask | xlib::Mod4Mask | xlib::Mod1Mask);
-              if let Some(hotkey_id) = hotkey_map.lock().unwrap().get(&(keycode as i32, modifiers))
-              {
-                event_loop_channel
-                  .send((window_id, WindowRequest::GlobalHotKey(*hotkey_id as u16)))
-                  .unwrap();
+          loop {
+            let event_loop_channel = event_loop_channel.clone();
+            if (xlib.XPending)(display) > 0 {
+              (xlib.XNextEvent)(display, &mut event);
+              if let xlib::KeyRelease = event.get_type() {
+                let keycode = event.key.keycode;
+                // X11 sends masks for Lock keys also and we only care about the 4 below
+                let modifiers = event.key.state
+                  & (xlib::ControlMask | xlib::ShiftMask | xlib::Mod4Mask | xlib::Mod1Mask);
+                if let Some(hotkey_id) =
+                  hotkey_map.lock().unwrap().get(&(keycode as i32, modifiers))
+                {
+                  event_loop_channel
+                    .send((window_id, WindowRequest::GlobalHotKey(*hotkey_id as u16)))
+                    .unwrap();
+                }
               }
             }
+
+            // XGrabKey works only with the exact state (modifiers)
+            // and since X11 considers NumLock, ScrollLock and CapsLock a modifier when it is ON,
+            // we also need to register our shortcut combined with these extra modifiers as well
+            const IGNORED_MODS: [u32; 4] = [
+              0,              // modifier only
+              xlib::Mod2Mask, // NumLock
+              xlib::LockMask, // CapsLock
+              xlib::Mod2Mask | xlib::LockMask,
+            ];
+
+            match thread_receiver.try_recv() {
+              Ok(HotkeyMessage::RegisterHotkey(_, modifiers, key)) => {
+                let keycode = (xlib.XKeysymToKeycode)(display, key.into()) as i32;
+
+                let mut result = 0;
+                for m in IGNORED_MODS {
+                  result = (xlib.XGrabKey)(
+                    display,
+                    keycode,
+                    modifiers | m,
+                    root,
+                    0,
+                    xlib::GrabModeAsync,
+                    xlib::GrabModeAsync,
+                  );
+                }
+                if result == 0 {
+                  if let Err(err) = thread_sender
+                    .clone()
+                    .send(HotkeyMessage::RegisterHotkeyResult(Err(
+                      ShortcutManagerError::InvalidAccelerator(
+                        "Unable to register accelerator".into(),
+                      ),
+                    )))
+                  {
+                    #[cfg(debug_assertions)]
+                    eprintln!("hotkey: thread_sender.send error {}", err);
+                  }
+                } else if let Err(err) = thread_sender.send(HotkeyMessage::RegisterHotkeyResult(
+                  Ok((keycode, modifiers)),
+                )) {
+                  #[cfg(debug_assertions)]
+                  eprintln!("hotkey: thread_sender.send error {}", err);
+                }
+              }
+              Ok(HotkeyMessage::UnregisterHotkey(id)) => {
+                let mut result = 0;
+                for m in IGNORED_MODS {
+                  result = (xlib.XUngrabKey)(display, id.0, id.1 | m, root);
+                }
+                if result == 0 {
+                  if let Err(err) =
+                    thread_sender
+                      .clone()
+                      .send(HotkeyMessage::UnregisterHotkeyResult(Err(
+                        ShortcutManagerError::InvalidAccelerator(
+                          "Unable to unregister accelerator".into(),
+                        ),
+                      )))
+                  {
+                    #[cfg(debug_assertions)]
+                    eprintln!("hotkey: thread_sender.send error {}", err);
+                  }
+                } else if let Err(err) =
+                  thread_sender.send(HotkeyMessage::UnregisterHotkeyResult(Ok(())))
+                {
+                  #[cfg(debug_assertions)]
+                  eprintln!("hotkey: thread_sender.send error {}", err);
+                }
+              }
+              Ok(HotkeyMessage::DropThread) => {
+                (xlib.XCloseDisplay)(display);
+                return;
+              }
+              Err(err) => {
+                if let TryRecvError::Disconnected = err {
+                  #[cfg(debug_assertions)]
+                  eprintln!("hotkey: try_recv error {}", err);
+                }
+              }
+              _ => unreachable!("other message should not arrive"),
+            };
+
+            std::thread::sleep(std::time::Duration::from_millis(50));
           }
-
-          // XGrabKey works only with the exact state (modifiers)
-          // and since X11 considers NumLock, ScrollLock and CapsLock a modifier when it is ON,
-          // we also need to register our shortcut combined with these extra modifiers as well
-          const IGNORED_MODS: [u32; 4] = [
-            0,              // modifier only
-            xlib::Mod2Mask, // NumLock
-            xlib::LockMask, // CapsLock
-            xlib::Mod2Mask | xlib::LockMask,
-          ];
-
-          match thread_receiver.try_recv() {
-            Ok(HotkeyMessage::RegisterHotkey(_, modifiers, key)) => {
-              let keycode = (xlib.XKeysymToKeycode)(display, key.into()) as i32;
-
-              let mut result = 0;
-              for m in IGNORED_MODS {
-                result = (xlib.XGrabKey)(
-                  display,
-                  keycode,
-                  modifiers | m,
-                  root,
-                  0,
-                  xlib::GrabModeAsync,
-                  xlib::GrabModeAsync,
-                );
-              }
-              if result == 0 {
-                if let Err(err) = thread_sender
-                  .clone()
-                  .send(HotkeyMessage::RegisterHotkeyResult(Err(
-                    ShortcutManagerError::InvalidAccelerator(
-                      "Unable to register accelerator".into(),
-                    ),
-                  )))
-                {
-                  #[cfg(debug_assertions)]
-                  eprintln!("hotkey: thread_sender.send error {}", err);
-                }
-              } else if let Err(err) = thread_sender.send(HotkeyMessage::RegisterHotkeyResult(Ok(
-                (keycode, modifiers),
-              ))) {
-                #[cfg(debug_assertions)]
-                eprintln!("hotkey: thread_sender.send error {}", err);
-              }
-            }
-            Ok(HotkeyMessage::UnregisterHotkey(id)) => {
-              let mut result = 0;
-              for m in IGNORED_MODS {
-                result = (xlib.XUngrabKey)(display, id.0, id.1 | m, root);
-              }
-              if result == 0 {
-                if let Err(err) = thread_sender
-                  .clone()
-                  .send(HotkeyMessage::UnregisterHotkeyResult(Err(
-                    ShortcutManagerError::InvalidAccelerator(
-                      "Unable to unregister accelerator".into(),
-                    ),
-                  )))
-                {
-                  #[cfg(debug_assertions)]
-                  eprintln!("hotkey: thread_sender.send error {}", err);
-                }
-              } else if let Err(err) =
-                thread_sender.send(HotkeyMessage::UnregisterHotkeyResult(Ok(())))
-              {
-                #[cfg(debug_assertions)]
-                eprintln!("hotkey: thread_sender.send error {}", err);
-              }
-            }
-            Ok(HotkeyMessage::DropThread) => {
-              (xlib.XCloseDisplay)(display);
-              return;
-            }
-            Err(err) => {
-              if let TryRecvError::Disconnected = err {
-                #[cfg(debug_assertions)]
-                eprintln!("hotkey: try_recv error {}", err);
-              }
-            }
-            _ => unreachable!("other message should not arrive"),
-          };
-
-          std::thread::sleep(std::time::Duration::from_millis(50));
         }
-      }
-    });
+      });
+    }
 
     ShortcutManager {
       shortcuts: hotkeys,


### PR DESCRIPTION
Don't start the global shortcut thread on wayland, as its highly x11
specific and otherwise results in a segfault in libX11.

Disabling the thread allows for example Cinny to start with the envvar DISPLAY unset and GDK_BACKEND=wayland. 

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
