### PR TITLE
Update windows to 0.39.0

### DIFF
--- a/.changes/windows-0.39.0.md
+++ b/.changes/windows-0.39.0.md
@@ -6,4 +6,4 @@ Update `windows-rs` to the latest 0.39.0 release.
 
 The `alloc` feature has been removed, which means it no longer accepts Rust `String` or `&str` parameters and implicitly converts them to `PWSTR` or `PSTR`.
 
-For string literals, that feature was replaced with `s!()` and `w!()` macros which null terminate the string literal at compile time and convert to UTF-16 if necessary.
+For string literals, that feature was replaced with `s!()` and `w!()` macros which null terminate the string literal at compile time and convert to UTF-16 if necessary. The `s!()` macro is fine, however the `w!()` macro uses `HSTRING` types from WinRT for maximum compatibility with WinRT types. Since Tao only uses Win32 APIs, this change relies on `util::encode_wide` to convert to a `Vec<u16>` instead.

--- a/.changes/windows-0.39.0.md
+++ b/.changes/windows-0.39.0.md
@@ -1,0 +1,9 @@
+---
+"tao": "patch"
+---
+
+Update `windows-rs` to the latest 0.39.0 release.
+
+The `alloc` feature has been removed, which means it no longer accepts Rust `String` or `&str` parameters and implicitly converts them to `PWSTR` or `PSTR`.
+
+For string literals, that feature was replaced with `s!()` and `w!()` macros which null terminate the string literal at compile time and convert to UTF-16 if necessary.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,12 +71,11 @@ cc = "1"
 parking_lot = "0.12"
 unicode-segmentation = "1.9.0"
 image = { version = "0.24", default-features = false }
-windows-implement = "0.37.0"
+windows-implement = "0.39.0"
 
   [target."cfg(target_os = \"windows\")".dependencies.windows]
-  version = "0.37.0"
+  version = "0.39.0"
   features = [
-  "alloc",
   "implement",
   "Win32_Devices_HumanInterfaceDevice",
   "Win32_Foundation",

--- a/src/platform_impl/windows/clipboard.rs
+++ b/src/platform_impl/windows/clipboard.rs
@@ -36,7 +36,7 @@ impl Clipboard {
       if handle.is_invalid() {
         None
       } else {
-        let unic_str = PWSTR(GlobalLock(handle.0) as *mut _);
+        let unic_str = PWSTR::from_raw(GlobalLock(handle.0) as *mut _);
         let mut len = 0;
         while *unic_str.0.offset(len) != 0 {
           len += 1;
@@ -94,7 +94,7 @@ fn register_identifier(ident: &str) -> Option<u32> {
   unsafe {
     let clipboard_format = util::encode_wide(ident);
 
-    let pb_format = RegisterClipboardFormatW(PCWSTR(clipboard_format.as_ptr()));
+    let pb_format = RegisterClipboardFormatW(PCWSTR::from_raw(clipboard_format.as_ptr()));
     if pb_format == 0 {
       #[cfg(debug_assertions)]
       println!(

--- a/src/platform_impl/windows/clipboard.rs
+++ b/src/platform_impl/windows/clipboard.rs
@@ -2,15 +2,16 @@
 // Copyright 2021-2022 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
+use super::util;
 use crate::clipboard::{ClipboardFormat, FormatId};
 use std::{ffi::OsStr, os::windows::ffi::OsStrExt, ptr};
 use windows::{
-  core::PWSTR,
+  core::{PCWSTR, PWSTR},
   Win32::{
     Foundation::{HANDLE, HWND},
     System::{
       DataExchange::{
-        CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, RegisterClipboardFormatA,
+        CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, RegisterClipboardFormatW,
         SetClipboardData,
       },
       Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE},
@@ -91,7 +92,9 @@ fn get_format_id(format: FormatId) -> Option<u32> {
 
 fn register_identifier(ident: &str) -> Option<u32> {
   unsafe {
-    let pb_format = RegisterClipboardFormatA(ident);
+    let clipboard_format = util::encode_wide(ident);
+
+    let pb_format = RegisterClipboardFormatW(PCWSTR(clipboard_format.as_ptr()));
     if pb_format == 0 {
       #[cfg(debug_assertions)]
       println!(

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -87,7 +87,7 @@ pub fn try_theme(hwnd: HWND, preferred_theme: Option<Theme>) -> Theme {
     } else {
       Theme::Light
     };
-    let theme_name = PCWSTR(
+    let theme_name = PCWSTR::from_raw(
       match theme {
         Theme::Dark => DARK_THEME_NAME.clone(),
         Theme::Light => LIGHT_THEME_NAME.clone(),
@@ -168,7 +168,7 @@ fn should_apps_use_dark_mode() -> bool {
 
         let handle = GetProcAddress(
           module,
-          PCSTR(UXTHEME_SHOULDAPPSUSEDARKMODE_ORDINAL as usize as *mut _),
+          PCSTR::from_raw(UXTHEME_SHOULDAPPSUSEDARKMODE_ORDINAL as usize as *mut _),
         );
 
         handle.map(|handle| std::mem::transmute(handle))

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -13,7 +13,7 @@ use windows::{
   },
 };
 
-use std::{ffi::c_void, ptr};
+use std::ffi::c_void;
 
 use crate::{platform_impl::platform::util, window::Theme};
 
@@ -95,7 +95,7 @@ pub fn try_theme(hwnd: HWND, preferred_theme: Option<Theme>) -> Theme {
       .as_ptr(),
     );
 
-    let status = unsafe { SetWindowTheme(hwnd, theme_name, PCWSTR(ptr::null())) };
+    let status = unsafe { SetWindowTheme(hwnd, theme_name, PCWSTR::null()) };
 
     if status.is_ok() && set_dark_mode_for_window(hwnd, is_dark_mode) {
       return theme;
@@ -187,7 +187,7 @@ fn is_high_contrast() -> bool {
   let mut hc = HIGHCONTRASTA {
     cbSize: 0,
     dwFlags: Default::default(),
-    lpszDefaultScheme: PSTR(ptr::null_mut()),
+    lpszDefaultScheme: PSTR::null(),
   };
 
   let ok = unsafe {

--- a/src/platform_impl/windows/drop_handler.rs
+++ b/src/platform_impl/windows/drop_handler.rs
@@ -33,7 +33,7 @@ impl FileDropHandler {
     Self {
       window,
       send_event,
-      cursor_effect: DROPEFFECT_NONE.into(),
+      cursor_effect: DROPEFFECT_NONE.0.into(),
       hovered_is_valid: false.into(),
     }
   }
@@ -122,8 +122,8 @@ impl IDropTarget_Impl for FileDropHandler {
         DROPEFFECT_NONE
       };
       *self.hovered_is_valid.get() = hovered_is_valid;
-      *self.cursor_effect.get() = cursor_effect;
-      *pdwEffect = cursor_effect;
+      *self.cursor_effect.get() = cursor_effect.0;
+      *pdwEffect = cursor_effect.0;
     }
     Ok(())
   }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -615,11 +615,11 @@ lazy_static! {
             lpfnWndProc: Some(util::call_default_window_proc),
             cbClsExtra: 0,
             cbWndExtra: 0,
-            hInstance: GetModuleHandleW(PCWSTR(ptr::null())).unwrap_or_default(),
+            hInstance: GetModuleHandleW(PCWSTR::null()).unwrap_or_default(),
             hIcon: HICON::default(),
             hCursor: HCURSOR::default(), // must be null in order for cursor state to work properly
             hbrBackground: HBRUSH::default(),
-            lpszMenuName: PCWSTR(ptr::null()),
+            lpszMenuName: PCWSTR::null(),
             lpszClassName: PCWSTR(class_name.as_ptr()),
             hIconSm: HICON::default(),
         };
@@ -643,7 +643,7 @@ fn create_event_target_window() -> HWND {
       // It is unclear why the bug is triggered by waiting for several hours.
       WS_EX_TOOLWINDOW,
       PCWSTR(THREAD_EVENT_TARGET_WINDOW_CLASS.clone().as_ptr()),
-      PCWSTR(ptr::null()),
+      PCWSTR::null(),
       WS_OVERLAPPED,
       0,
       0,
@@ -651,7 +651,7 @@ fn create_event_target_window() -> HWND {
       0,
       HWND::default(),
       HMENU::default(),
-      GetModuleHandleW(PCWSTR(ptr::null())).unwrap_or_default(),
+      GetModuleHandleW(PCWSTR::null()).unwrap_or_default(),
       ptr::null_mut(),
     )
   };

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -20,7 +20,7 @@ use std::{
   time::{Duration, Instant},
 };
 use windows::{
-  core::PCWSTR,
+  core::{s, PCWSTR},
   Win32::{
     Devices::HumanInterfaceDevice::*,
     Foundation::{
@@ -555,7 +555,7 @@ lazy_static! {
     /// WPARAM and LPARAM are unused.
     static ref USER_EVENT_MSG_ID: u32 = {
         unsafe {
-            RegisterWindowMessageA("Tao::WakeupMsg")
+            RegisterWindowMessageA(s!("Tao::WakeupMsg"))
         }
     };
     /// Message sent when we want to execute a closure in the thread.
@@ -563,48 +563,48 @@ lazy_static! {
     /// and LPARAM is unused.
     static ref EXEC_MSG_ID: u32 = {
         unsafe {
-            RegisterWindowMessageA("Tao::ExecMsg")
+            RegisterWindowMessageA(s!("Tao::ExecMsg"))
         }
     };
     static ref PROCESS_NEW_EVENTS_MSG_ID: u32 = {
         unsafe {
-            RegisterWindowMessageA("Tao::ProcessNewEvents")
+            RegisterWindowMessageA(s!("Tao::ProcessNewEvents"))
         }
     };
     /// lparam is the wait thread's message id.
     static ref SEND_WAIT_THREAD_ID_MSG_ID: u32 = {
         unsafe {
-            RegisterWindowMessageA("Tao::SendWaitThreadId")
+            RegisterWindowMessageA(s!("Tao::SendWaitThreadId"))
         }
     };
     /// lparam points to a `Box<Instant>` signifying the time `PROCESS_NEW_EVENTS_MSG_ID` should
     /// be sent.
     static ref WAIT_UNTIL_MSG_ID: u32 = {
         unsafe {
-            RegisterWindowMessageA("Tao::WaitUntil")
+            RegisterWindowMessageA(s!("Tao::WaitUntil"))
         }
     };
     static ref CANCEL_WAIT_UNTIL_MSG_ID: u32 = {
         unsafe {
-            RegisterWindowMessageA("Tao::CancelWaitUntil")
+            RegisterWindowMessageA(s!("Tao::CancelWaitUntil"))
         }
     };
     /// Message sent by a `Window` when it wants to be destroyed by the main thread.
     /// WPARAM and LPARAM are unused.
     pub static ref DESTROY_MSG_ID: u32 = {
         unsafe {
-            RegisterWindowMessageA("Tao::DestroyMsg")
+            RegisterWindowMessageA(s!("Tao::DestroyMsg"))
         }
     };
     /// WPARAM is a bool specifying the `WindowFlags::MARKER_RETAIN_STATE_ON_SIZE` flag. See the
     /// documentation in the `window_state` module for more information.
     pub static ref SET_RETAIN_STATE_ON_SIZE_MSG_ID: u32 = unsafe {
-        RegisterWindowMessageA("Tao::SetRetainMaximized")
+        RegisterWindowMessageA(s!("Tao::SetRetainMaximized"))
     };
     /// When the taskbar is created, it registers a message with the "TaskbarCreated" string and then broadcasts this message to all top-level windows
     /// When the application receives this message, it should assume that any taskbar icons it added have been removed and add them again.
     pub static ref S_U_TASKBAR_RESTART: u32 = unsafe {
-      RegisterWindowMessageA("TaskbarCreated")
+      RegisterWindowMessageA(s!("TaskbarCreated"))
     };
     static ref THREAD_EVENT_TARGET_WINDOW_CLASS: Vec<u16> = unsafe {
         let class_name= util::encode_wide("Tao Thread Event Target");
@@ -615,11 +615,11 @@ lazy_static! {
             lpfnWndProc: Some(util::call_default_window_proc),
             cbClsExtra: 0,
             cbWndExtra: 0,
-            hInstance: GetModuleHandleW(PCWSTR::default()).unwrap_or_default(),
+            hInstance: GetModuleHandleW(PCWSTR(ptr::null())).unwrap_or_default(),
             hIcon: HICON::default(),
             hCursor: HCURSOR::default(), // must be null in order for cursor state to work properly
             hbrBackground: HBRUSH::default(),
-            lpszMenuName: Default::default(),
+            lpszMenuName: PCWSTR(ptr::null()),
             lpszClassName: PCWSTR(class_name.as_ptr()),
             hIconSm: HICON::default(),
         };
@@ -643,7 +643,7 @@ fn create_event_target_window() -> HWND {
       // It is unclear why the bug is triggered by waiting for several hours.
       WS_EX_TOOLWINDOW,
       PCWSTR(THREAD_EVENT_TARGET_WINDOW_CLASS.clone().as_ptr()),
-      PCWSTR::default(),
+      PCWSTR(ptr::null()),
       WS_OVERLAPPED,
       0,
       0,
@@ -651,7 +651,7 @@ fn create_event_target_window() -> HWND {
       0,
       HWND::default(),
       HMENU::default(),
-      GetModuleHandleW(PCWSTR::default()).unwrap_or_default(),
+      GetModuleHandleW(PCWSTR(ptr::null())).unwrap_or_default(),
       ptr::null_mut(),
     )
   };

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -620,7 +620,7 @@ lazy_static! {
             hCursor: HCURSOR::default(), // must be null in order for cursor state to work properly
             hbrBackground: HBRUSH::default(),
             lpszMenuName: PCWSTR::null(),
-            lpszClassName: PCWSTR(class_name.as_ptr()),
+            lpszClassName: PCWSTR::from_raw(class_name.as_ptr()),
             hIconSm: HICON::default(),
         };
 
@@ -642,7 +642,7 @@ fn create_event_target_window() -> HWND {
       // `explorer.exe` and then starting the process back up.
       // It is unclear why the bug is triggered by waiting for several hours.
       WS_EX_TOOLWINDOW,
-      PCWSTR(THREAD_EVENT_TARGET_WINDOW_CLASS.clone().as_ptr()),
+      PCWSTR::from_raw(THREAD_EVENT_TARGET_WINDOW_CLASS.clone().as_ptr()),
       PCWSTR::null(),
       WS_OVERLAPPED,
       0,

--- a/src/platform_impl/windows/icon.rs
+++ b/src/platform_impl/windows/icon.rs
@@ -2,7 +2,7 @@
 // Copyright 2021-2022 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fmt, io, iter::once, mem, os::windows::ffi::OsStrExt, path::Path, ptr, sync::Arc};
+use std::{fmt, io, iter::once, mem, os::windows::ffi::OsStrExt, path::Path, sync::Arc};
 
 use windows::{
   core::PCWSTR,
@@ -109,7 +109,7 @@ impl WinIcon {
     let (width, height) = size.map(Into::into).unwrap_or((0, 0));
     let handle = unsafe {
       LoadImageW(
-        GetModuleHandleW(PCWSTR(ptr::null())).unwrap_or_default(),
+        GetModuleHandleW(PCWSTR::null()).unwrap_or_default(),
         PCWSTR(resource_id as usize as *const u16),
         IMAGE_ICON,
         width as i32,

--- a/src/platform_impl/windows/icon.rs
+++ b/src/platform_impl/windows/icon.rs
@@ -91,7 +91,7 @@ impl WinIcon {
     let handle = unsafe {
       LoadImageW(
         HINSTANCE::default(),
-        PCWSTR(wide_path.as_ptr()),
+        PCWSTR::from_raw(wide_path.as_ptr()),
         IMAGE_ICON,
         width as i32,
         height as i32,
@@ -110,7 +110,7 @@ impl WinIcon {
     let handle = unsafe {
       LoadImageW(
         GetModuleHandleW(PCWSTR::null()).unwrap_or_default(),
-        PCWSTR(resource_id as usize as *const u16),
+        PCWSTR::from_raw(resource_id as usize as *const u16),
         IMAGE_ICON,
         width as i32,
         height as i32,

--- a/src/platform_impl/windows/icon.rs
+++ b/src/platform_impl/windows/icon.rs
@@ -2,7 +2,7 @@
 // Copyright 2021-2022 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fmt, io, iter::once, mem, os::windows::ffi::OsStrExt, path::Path, sync::Arc};
+use std::{fmt, io, iter::once, mem, os::windows::ffi::OsStrExt, path::Path, ptr, sync::Arc};
 
 use windows::{
   core::PCWSTR,
@@ -109,7 +109,7 @@ impl WinIcon {
     let (width, height) = size.map(Into::into).unwrap_or((0, 0));
     let handle = unsafe {
       LoadImageW(
-        GetModuleHandleW(PCWSTR::default()).unwrap_or_default(),
+        GetModuleHandleW(PCWSTR(ptr::null())).unwrap_or_default(),
         PCWSTR(resource_id as usize as *const u16),
         IMAGE_ICON,
         width as i32,

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -96,9 +96,9 @@ impl MenuItemAttributes {
       };
       GetMenuItemInfoW(self.1, self.0 as u32, false, &mut mif);
       mif.cch += 1;
-      mif.dwTypeData = PWSTR(Vec::with_capacity(mif.cch as usize).as_mut_ptr());
+      mif.dwTypeData = PWSTR::from_raw(Vec::with_capacity(mif.cch as usize).as_mut_ptr());
       GetMenuItemInfoW(self.1, self.0 as u32, false, &mut mif);
-      util::wchar_ptr_to_string(PCWSTR(mif.dwTypeData.0))
+      util::wchar_ptr_to_string(PCWSTR::from_raw(mif.dwTypeData.0))
         .split('\t')
         .next()
         .unwrap_or_default()
@@ -127,7 +127,7 @@ impl MenuItemAttributes {
       let info = MENUITEMINFOW {
         cbSize: std::mem::size_of::<MENUITEMINFOW>() as _,
         fMask: MIIM_STRING,
-        dwTypeData: PWSTR(util::encode_wide(title).as_mut_ptr()),
+        dwTypeData: PWSTR::from_raw(util::encode_wide(title).as_mut_ptr()),
         ..Default::default()
       };
 
@@ -227,7 +227,7 @@ impl Menu {
         self.hmenu,
         flags,
         menu_id.0 as _,
-        PCWSTR(util::encode_wide(title).as_ptr()),
+        PCWSTR::from_raw(util::encode_wide(title).as_ptr()),
       );
 
       // add our accels
@@ -256,7 +256,7 @@ impl Menu {
         self.hmenu,
         flags,
         submenu.hmenu().0 as usize,
-        PCWSTR(title.as_ptr()),
+        PCWSTR::from_raw(title.as_ptr()),
       );
     }
   }
@@ -277,7 +277,7 @@ impl Menu {
           self.hmenu,
           MF_STRING,
           CUT_ID,
-          PCWSTR(util::encode_wide("&Cut\tCtrl+X").as_ptr()),
+          PCWSTR::from_raw(util::encode_wide("&Cut\tCtrl+X").as_ptr()),
         );
       },
       MenuItem::Copy => unsafe {
@@ -285,7 +285,7 @@ impl Menu {
           self.hmenu,
           MF_STRING,
           COPY_ID,
-          PCWSTR(util::encode_wide("&Copy\tCtrl+C").as_ptr()),
+          PCWSTR::from_raw(util::encode_wide("&Copy\tCtrl+C").as_ptr()),
         );
       },
       MenuItem::Paste => unsafe {
@@ -293,7 +293,7 @@ impl Menu {
           self.hmenu,
           MF_STRING,
           PASTE_ID,
-          PCWSTR(util::encode_wide("&Paste\tCtrl+V").as_ptr()),
+          PCWSTR::from_raw(util::encode_wide("&Paste\tCtrl+V").as_ptr()),
         );
       },
       MenuItem::SelectAll => unsafe {
@@ -301,7 +301,7 @@ impl Menu {
           self.hmenu,
           MF_STRING,
           SELECT_ALL_ID,
-          PCWSTR(util::encode_wide("&Select all\tCtrl+A").as_ptr()),
+          PCWSTR::from_raw(util::encode_wide("&Select all\tCtrl+A").as_ptr()),
         );
       },
       MenuItem::Hide => unsafe {
@@ -309,7 +309,7 @@ impl Menu {
           self.hmenu,
           MF_STRING,
           HIDE_ID,
-          PCWSTR(util::encode_wide("&Hide\tCtrl+H").as_ptr()),
+          PCWSTR::from_raw(util::encode_wide("&Hide\tCtrl+H").as_ptr()),
         );
       },
       MenuItem::CloseWindow => unsafe {
@@ -317,7 +317,7 @@ impl Menu {
           self.hmenu,
           MF_STRING,
           CLOSE_ID,
-          PCWSTR(util::encode_wide("&Close\tAlt+F4").as_ptr()),
+          PCWSTR::from_raw(util::encode_wide("&Close\tAlt+F4").as_ptr()),
         );
       },
       MenuItem::Quit => unsafe {
@@ -325,7 +325,7 @@ impl Menu {
           self.hmenu,
           MF_STRING,
           QUIT_ID,
-          PCWSTR(util::encode_wide("&Quit").as_ptr()),
+          PCWSTR::from_raw(util::encode_wide("&Quit").as_ptr()),
         );
       },
       MenuItem::Minimize => unsafe {
@@ -333,7 +333,7 @@ impl Menu {
           self.hmenu,
           MF_STRING,
           MINIMIZE_ID,
-          PCWSTR(util::encode_wide("&Minimize").as_ptr()),
+          PCWSTR::from_raw(util::encode_wide("&Minimize").as_ptr()),
         );
       },
       // FIXME: create all shortcuts of MenuItem if possible...

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -5,7 +5,7 @@
 use std::{collections::HashMap, fmt, ptr, sync::Mutex};
 
 use windows::{
-  core::{w, PCWSTR, PWSTR},
+  core::{PCWSTR, PWSTR},
   Win32::{
     Foundation::{HWND, LPARAM, LRESULT, WPARAM},
     UI::{
@@ -273,33 +273,68 @@ impl Menu {
         };
       }
       MenuItem::Cut => unsafe {
-        AppendMenuW(self.hmenu, MF_STRING, CUT_ID, w!("&Cut\tCtrl+X"));
+        AppendMenuW(
+          self.hmenu,
+          MF_STRING,
+          CUT_ID,
+          PCWSTR(util::encode_wide("&Cut\tCtrl+X").as_ptr()),
+        );
       },
       MenuItem::Copy => unsafe {
-        AppendMenuW(self.hmenu, MF_STRING, COPY_ID, w!("&Copy\tCtrl+C"));
+        AppendMenuW(
+          self.hmenu,
+          MF_STRING,
+          COPY_ID,
+          PCWSTR(util::encode_wide("&Copy\tCtrl+C").as_ptr()),
+        );
       },
       MenuItem::Paste => unsafe {
-        AppendMenuW(self.hmenu, MF_STRING, PASTE_ID, w!("&Paste\tCtrl+V"));
+        AppendMenuW(
+          self.hmenu,
+          MF_STRING,
+          PASTE_ID,
+          PCWSTR(util::encode_wide("&Paste\tCtrl+V").as_ptr()),
+        );
       },
       MenuItem::SelectAll => unsafe {
         AppendMenuW(
           self.hmenu,
           MF_STRING,
           SELECT_ALL_ID,
-          w!("&Select all\tCtrl+A"),
+          PCWSTR(util::encode_wide("&Select all\tCtrl+A").as_ptr()),
         );
       },
       MenuItem::Hide => unsafe {
-        AppendMenuW(self.hmenu, MF_STRING, HIDE_ID, w!("&Hide\tCtrl+H"));
+        AppendMenuW(
+          self.hmenu,
+          MF_STRING,
+          HIDE_ID,
+          PCWSTR(util::encode_wide("&Hide\tCtrl+H").as_ptr()),
+        );
       },
       MenuItem::CloseWindow => unsafe {
-        AppendMenuW(self.hmenu, MF_STRING, CLOSE_ID, w!("&Close\tAlt+F4"));
+        AppendMenuW(
+          self.hmenu,
+          MF_STRING,
+          CLOSE_ID,
+          PCWSTR(util::encode_wide("&Close\tAlt+F4").as_ptr()),
+        );
       },
       MenuItem::Quit => unsafe {
-        AppendMenuW(self.hmenu, MF_STRING, QUIT_ID, w!("&Quit"));
+        AppendMenuW(
+          self.hmenu,
+          MF_STRING,
+          QUIT_ID,
+          PCWSTR(util::encode_wide("&Quit").as_ptr()),
+        );
       },
       MenuItem::Minimize => unsafe {
-        AppendMenuW(self.hmenu, MF_STRING, MINIMIZE_ID, w!("&Minimize"));
+        AppendMenuW(
+          self.hmenu,
+          MF_STRING,
+          MINIMIZE_ID,
+          PCWSTR(util::encode_wide("&Minimize").as_ptr()),
+        );
       },
       // FIXME: create all shortcuts of MenuItem if possible...
       // like linux?

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -5,7 +5,7 @@
 use std::{collections::HashMap, fmt, ptr, sync::Mutex};
 
 use windows::{
-  core::{PCWSTR, PWSTR},
+  core::{w, PCWSTR, PWSTR},
   Win32::{
     Foundation::{HWND, LPARAM, LRESULT, WPARAM},
     UI::{
@@ -251,7 +251,13 @@ impl Menu {
         flags |= MF_DISABLED;
       }
 
-      AppendMenuW(self.hmenu, flags, submenu.hmenu().0 as usize, title);
+      let title = util::encode_wide(title);
+      AppendMenuW(
+        self.hmenu,
+        flags,
+        submenu.hmenu().0 as usize,
+        PCWSTR(title.as_ptr()),
+      );
     }
   }
 
@@ -263,32 +269,37 @@ impl Menu {
     match item {
       MenuItem::Separator => {
         unsafe {
-          AppendMenuW(self.hmenu, MF_SEPARATOR, 0, PCWSTR::default());
+          AppendMenuW(self.hmenu, MF_SEPARATOR, 0, PCWSTR(ptr::null()));
         };
       }
       MenuItem::Cut => unsafe {
-        AppendMenuW(self.hmenu, MF_STRING, CUT_ID, "&Cut\tCtrl+X");
+        AppendMenuW(self.hmenu, MF_STRING, CUT_ID, w!("&Cut\tCtrl+X"));
       },
       MenuItem::Copy => unsafe {
-        AppendMenuW(self.hmenu, MF_STRING, COPY_ID, "&Copy\tCtrl+C");
+        AppendMenuW(self.hmenu, MF_STRING, COPY_ID, w!("&Copy\tCtrl+C"));
       },
       MenuItem::Paste => unsafe {
-        AppendMenuW(self.hmenu, MF_STRING, PASTE_ID, "&Paste\tCtrl+V");
+        AppendMenuW(self.hmenu, MF_STRING, PASTE_ID, w!("&Paste\tCtrl+V"));
       },
       MenuItem::SelectAll => unsafe {
-        AppendMenuW(self.hmenu, MF_STRING, SELECT_ALL_ID, "&Select all\tCtrl+A");
+        AppendMenuW(
+          self.hmenu,
+          MF_STRING,
+          SELECT_ALL_ID,
+          w!("&Select all\tCtrl+A"),
+        );
       },
       MenuItem::Hide => unsafe {
-        AppendMenuW(self.hmenu, MF_STRING, HIDE_ID, "&Hide\tCtrl+H");
+        AppendMenuW(self.hmenu, MF_STRING, HIDE_ID, w!("&Hide\tCtrl+H"));
       },
       MenuItem::CloseWindow => unsafe {
-        AppendMenuW(self.hmenu, MF_STRING, CLOSE_ID, "&Close\tAlt+F4");
+        AppendMenuW(self.hmenu, MF_STRING, CLOSE_ID, w!("&Close\tAlt+F4"));
       },
       MenuItem::Quit => unsafe {
-        AppendMenuW(self.hmenu, MF_STRING, QUIT_ID, "&Quit");
+        AppendMenuW(self.hmenu, MF_STRING, QUIT_ID, w!("&Quit"));
       },
       MenuItem::Minimize => unsafe {
-        AppendMenuW(self.hmenu, MF_STRING, MINIMIZE_ID, "&Minimize");
+        AppendMenuW(self.hmenu, MF_STRING, MINIMIZE_ID, w!("&Minimize"));
       },
       // FIXME: create all shortcuts of MenuItem if possible...
       // like linux?

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -2,7 +2,7 @@
 // Copyright 2021-2022 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, fmt, ptr, sync::Mutex};
+use std::{collections::HashMap, fmt, sync::Mutex};
 
 use windows::{
   core::{PCWSTR, PWSTR},
@@ -91,7 +91,7 @@ impl MenuItemAttributes {
       let mut mif = MENUITEMINFOW {
         cbSize: std::mem::size_of::<MENUITEMINFOW>() as _,
         fMask: MIIM_STRING,
-        dwTypeData: PWSTR(ptr::null_mut()),
+        dwTypeData: PWSTR::null(),
         ..Default::default()
       };
       GetMenuItemInfoW(self.1, self.0 as u32, false, &mut mif);
@@ -269,7 +269,7 @@ impl Menu {
     match item {
       MenuItem::Separator => {
         unsafe {
-          AppendMenuW(self.hmenu, MF_SEPARATOR, 0, PCWSTR(ptr::null()));
+          AppendMenuW(self.hmenu, MF_SEPARATOR, 0, PCWSTR::null());
         };
       }
       MenuItem::Cut => unsafe {

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -158,7 +158,7 @@ impl MonitorHandle {
   #[inline]
   pub fn name(&self) -> Option<String> {
     let monitor_info = get_monitor_info(self.hmonitor()).unwrap();
-    Some(util::wchar_ptr_to_string(PCWSTR(
+    Some(util::wchar_ptr_to_string(PCWSTR::from_raw(
       monitor_info.szDevice.as_ptr(),
     )))
   }
@@ -209,7 +209,7 @@ impl MonitorHandle {
     loop {
       unsafe {
         let monitor_info = get_monitor_info(self.hmonitor()).unwrap();
-        let device_name = PCWSTR(monitor_info.szDevice.as_ptr());
+        let device_name = PCWSTR::from_raw(monitor_info.szDevice.as_ptr());
         let mut mode: DEVMODEW = mem::zeroed();
         mode.dmSize = mem::size_of_val(&mode) as u16;
         if !EnumDisplaySettingsExW(device_name, ENUM_DISPLAY_SETTINGS_MODE(i), &mut mode, 0)

--- a/src/platform_impl/windows/system_tray.rs
+++ b/src/platform_impl/windows/system_tray.rs
@@ -16,7 +16,6 @@ use crate::{
   system_tray::{Icon, SystemTray as RootSystemTray},
   TrayId,
 };
-use std::ptr;
 use windows::{
   core::PCWSTR,
   Win32::{
@@ -68,7 +67,7 @@ impl SystemTrayBuilder {
 
     let class_name = util::encode_wide("tao_system_tray_app");
     unsafe {
-      let hinstance = GetModuleHandleW(PCWSTR(ptr::null())).unwrap_or_default();
+      let hinstance = GetModuleHandleW(PCWSTR::null()).unwrap_or_default();
 
       let wnd_class = WNDCLASSW {
         lpfnWndProc: Some(util::call_default_window_proc),
@@ -90,7 +89,7 @@ impl SystemTrayBuilder {
         // It is unclear why the bug is triggered by waiting for several hours.
         WS_EX_TOOLWINDOW,
         PCWSTR(class_name.as_ptr()),
-        PCWSTR(ptr::null()),
+        PCWSTR::null(),
         WS_OVERLAPPED,
         CW_USEDEFAULT,
         0,

--- a/src/platform_impl/windows/system_tray.rs
+++ b/src/platform_impl/windows/system_tray.rs
@@ -16,8 +16,9 @@ use crate::{
   system_tray::{Icon, SystemTray as RootSystemTray},
   TrayId,
 };
+use std::ptr;
 use windows::{
-  core::{PCSTR, PCWSTR},
+  core::PCWSTR,
   Win32::{
     Foundation::{HWND, LPARAM, LRESULT, POINT, WPARAM},
     System::LibraryLoader::*,
@@ -67,7 +68,7 @@ impl SystemTrayBuilder {
 
     let class_name = util::encode_wide("tao_system_tray_app");
     unsafe {
-      let hinstance = GetModuleHandleA(PCSTR::default()).unwrap_or_default();
+      let hinstance = GetModuleHandleW(PCWSTR(ptr::null())).unwrap_or_default();
 
       let wnd_class = WNDCLASSW {
         lpfnWndProc: Some(util::call_default_window_proc),

--- a/src/platform_impl/windows/system_tray.rs
+++ b/src/platform_impl/windows/system_tray.rs
@@ -71,7 +71,7 @@ impl SystemTrayBuilder {
 
       let wnd_class = WNDCLASSW {
         lpfnWndProc: Some(util::call_default_window_proc),
-        lpszClassName: PCWSTR(class_name.as_ptr()),
+        lpszClassName: PCWSTR::from_raw(class_name.as_ptr()),
         hInstance: hinstance,
         ..Default::default()
       };
@@ -88,7 +88,7 @@ impl SystemTrayBuilder {
         // `explorer.exe` and then starting the process back up.
         // It is unclear why the bug is triggered by waiting for several hours.
         WS_EX_TOOLWINDOW,
-        PCWSTR(class_name.as_ptr()),
+        PCWSTR::from_raw(class_name.as_ptr()),
         PCWSTR::null(),
         WS_OVERLAPPED,
         CW_USEDEFAULT,

--- a/src/platform_impl/windows/system_tray.rs
+++ b/src/platform_impl/windows/system_tray.rs
@@ -89,7 +89,7 @@ impl SystemTrayBuilder {
         // It is unclear why the bug is triggered by waiting for several hours.
         WS_EX_TOOLWINDOW,
         PCWSTR(class_name.as_ptr()),
-        PCWSTR::default(),
+        PCWSTR(ptr::null()),
         WS_OVERLAPPED,
         CW_USEDEFAULT,
         0,

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -15,7 +15,7 @@ use std::{
 use crate::{dpi::PhysicalSize, window::CursorIcon};
 
 use windows::{
-  core::{HRESULT, PCWSTR},
+  core::{HRESULT, PCSTR, PCWSTR},
   Win32::{
     Foundation::{BOOL, FARPROC, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM},
     Globalization::lstrlenW,
@@ -259,25 +259,23 @@ impl CursorIcon {
 // Helper function to dynamically load function pointer.
 // `library` and `function` must be zero-terminated.
 pub(super) fn get_function_impl(library: &str, function: &str) -> FARPROC {
-  assert_eq!(library.chars().last(), Some('\0'));
+  let library = encode_wide(library);
   assert_eq!(function.chars().last(), Some('\0'));
+  let function = PCSTR(function.as_ptr());
 
   // Library names we will use are ASCII so we can use the A version to avoid string conversion.
-  let module = unsafe { LoadLibraryA(library) }.unwrap_or_default();
+  let module = unsafe { LoadLibraryW(PCWSTR(library.as_ptr())) }.unwrap_or_default();
   if module.is_invalid() {
     return None;
   }
 
-  unsafe { GetProcAddress(module, function) }
+  unsafe { GetProcAddress(module, PCSTR(function.as_ptr())) }
 }
 
 macro_rules! get_function {
   ($lib:expr, $func:ident) => {
-    crate::platform_impl::platform::util::get_function_impl(
-      concat!($lib, '\0'),
-      concat!(stringify!($func), '\0'),
-    )
-    .map(|f| unsafe { std::mem::transmute::<_, $func>(f) })
+    crate::platform_impl::platform::util::get_function_impl($lib, concat!(stringify!($func), '\0'))
+      .map(|f| unsafe { std::mem::transmute::<_, $func>(f) })
   };
 }
 

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -261,15 +261,15 @@ impl CursorIcon {
 pub(super) fn get_function_impl(library: &str, function: &str) -> FARPROC {
   let library = encode_wide(library);
   assert_eq!(function.chars().last(), Some('\0'));
-  let function = PCSTR(function.as_ptr());
+  let function = PCSTR::from_raw(function.as_ptr());
 
   // Library names we will use are ASCII so we can use the A version to avoid string conversion.
-  let module = unsafe { LoadLibraryW(PCWSTR(library.as_ptr())) }.unwrap_or_default();
+  let module = unsafe { LoadLibraryW(PCWSTR::from_raw(library.as_ptr())) }.unwrap_or_default();
   if module.is_invalid() {
     return None;
   }
 
-  unsafe { GetProcAddress(module, PCSTR(function.as_ptr())) }
+  unsafe { GetProcAddress(module, PCSTR::from_raw(function.as_ptr())) }
 }
 
 macro_rules! get_function {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -143,7 +143,7 @@ impl Window {
   pub fn set_title(&self, text: &str) {
     let text = util::encode_wide(text);
     unsafe {
-      SetWindowTextW(self.window.0, PCWSTR(text.as_ptr()));
+      SetWindowTextW(self.window.0, PCWSTR::from_raw(text.as_ptr()));
     }
   }
 
@@ -531,7 +531,7 @@ impl Window {
 
           let res = unsafe {
             ChangeDisplaySettingsExW(
-              PCWSTR(display_name.as_ptr()),
+              PCWSTR::from_raw(display_name.as_ptr()),
               &native_video_mode,
               HWND::default(),
               CDS_FULLSCREEN,
@@ -891,8 +891,8 @@ unsafe fn init<T: 'static>(
     let title = util::encode_wide(&attributes.title);
     let handle = CreateWindowExW(
       ex_style,
-      PCWSTR(class_name.as_ptr()),
-      PCWSTR(title.as_ptr()),
+      PCWSTR::from_raw(class_name.as_ptr()),
+      PCWSTR::from_raw(title.as_ptr()),
       style,
       CW_USEDEFAULT,
       CW_USEDEFAULT,
@@ -1047,7 +1047,7 @@ unsafe fn register_window_class(
     hCursor: HCURSOR::default(), // must be null in order for cursor state to work properly
     hbrBackground: HBRUSH::default(),
     lpszMenuName: PCWSTR::null(),
-    lpszClassName: PCWSTR(class_name.as_ptr()),
+    lpszClassName: PCWSTR::from_raw(class_name.as_ptr()),
     hIconSm: h_icon_small,
   };
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -549,7 +549,7 @@ impl Window {
         | (&Some(Fullscreen::Exclusive(_)), &Some(Fullscreen::Borderless(_))) => {
           let res = unsafe {
             ChangeDisplaySettingsExW(
-              PCWSTR(ptr::null()),
+              PCWSTR::null(),
               std::ptr::null_mut(),
               HWND::default(),
               CDS_FULLSCREEN,
@@ -900,7 +900,7 @@ unsafe fn init<T: 'static>(
       CW_USEDEFAULT,
       parent.unwrap_or_default(),
       pl_attribs.menu.unwrap_or_default(),
-      GetModuleHandleW(PCWSTR(ptr::null())).unwrap_or_default(),
+      GetModuleHandleW(PCWSTR::null()).unwrap_or_default(),
       Box::into_raw(Box::new(window_flags)) as _,
     );
 
@@ -1042,11 +1042,11 @@ unsafe fn register_window_class(
     lpfnWndProc: Some(window_proc),
     cbClsExtra: 0,
     cbWndExtra: 0,
-    hInstance: GetModuleHandleW(PCWSTR(ptr::null())).unwrap_or_default(),
+    hInstance: GetModuleHandleW(PCWSTR::null()).unwrap_or_default(),
     hIcon: h_icon,
     hCursor: HCURSOR::default(), // must be null in order for cursor state to work properly
     hbrBackground: HBRUSH::default(),
-    lpszMenuName: PCWSTR(ptr::null()),
+    lpszMenuName: PCWSTR::null(),
     lpszClassName: PCWSTR(class_name.as_ptr()),
     hIconSm: h_icon_small,
   };


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

The `alloc` feature has been removed, which means Win32 APIs no longer accept Rust `String` or `&str` parameters and implicitly convert them to `PWSTR` or `PSTR`.

For string literals, that feature was replaced with `s!()` and `w!()` macros which null terminate the string literal at compile time and convert to UTF-16 if necessary. The `s!()` macro is fine, however the `w!()` macro uses `HSTRING` types from WinRT for maximum compatibility with WinRT types. Since Tao only uses Win32 APIs (or dynamically loaded DLL entry-points), it still works on Win7, but I'm worried about taking any dependencies on `HSTRING`. Instead of the `w!()` macro, this change relies on the internal `util::encode_wide` function to convert to a `Vec<u16>` with the Rust standard library.