### PR TITLE
fix(deps): Use less specific version for once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ jni = "0.19"
 ndk = "0.6"
 ndk-sys = "0.3"
 ndk-context = "0.1"
-once_cell = "1.14"
+once_cell = "1"
 paste = "1.0"
 
 [target."cfg(any(target_os = \"ios\", target_os = \"macos\"))".dependencies]


### PR DESCRIPTION
Reason: One of tauri's dependencies lock it to 1.13.

Edit: This dependency is specific to the android target which i don't have set up right now. I didn't see anything in the source code that needs a newer version than 1.0 but if we want to be absolutely sure we need someone with a working android setup who can lock it to 1.0.2 or something locally and try it out.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary