### PR TITLE
feat: added text support to system tray for macos, closes #65

### DIFF
--- a/.changes/macos-sytem-tray-title.md
+++ b/.changes/macos-sytem-tray-title.md
@@ -2,4 +2,4 @@
 "tao": "minor"
 ---
 
-Added `set_title(title: &str)` to `SystemTray` and `with_title(title: &str)` to `SystemTrayBuilder` to set the title on MacOS
+Added `SystemTrayExtMacOS::set_title` to `SystemTray` and `SystemTrayBuilderExtMacOS::with_title` to set the tray icon title on MacOS

--- a/.changes/macos-sytem-tray-title.md
+++ b/.changes/macos-sytem-tray-title.md
@@ -1,0 +1,5 @@
+---
+"tao": "minor"
+---
+
+Added `set_title(title: &str)` to `SystemTray` and `with_title(title: &str)` to `SystemTrayBuilder` to set the title on MacOS

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -515,6 +515,9 @@ pub trait SystemTrayBuilderExtMacOS {
 
   /// Enables or disables showing the tray menu on left click, default is true.
   fn with_menu_on_left_click(self, enable: bool) -> Self;
+
+  /// Sets the tray icon title
+  fn with_title(self, title: &str) -> Self;
 }
 
 #[cfg(feature = "tray")]
@@ -526,6 +529,11 @@ impl SystemTrayBuilderExtMacOS for SystemTrayBuilder {
 
   fn with_menu_on_left_click(mut self, enable: bool) -> Self {
     self.platform_tray_builder.system_tray.menu_on_left_click = enable;
+    self
+  }
+
+  fn with_title(mut self, title: &str) -> Self {
+    self.platform_tray_builder.system_tray.title = Some(title.to_owned());
     self
   }
 }
@@ -540,6 +548,9 @@ pub trait SystemTrayExtMacOS {
 
   /// Enables or disables showing the tray menu on left click, default is true.
   fn enable_menu_on_left_click(&mut self, enable: bool);
+
+  /// Sets the tray icon title
+  fn set_title(&mut self, title: &str);
 }
 
 #[cfg(feature = "tray")]
@@ -550,5 +561,9 @@ impl SystemTrayExtMacOS for SystemTray {
 
   fn enable_menu_on_left_click(&mut self, enable: bool) {
     self.0.menu_on_left_click = enable
+  }
+
+  fn set_title(&mut self, title: &str) {
+    self.0.set_title(title)
   }
 }

--- a/src/platform_impl/macos/system_tray.rs
+++ b/src/platform_impl/macos/system_tray.rs
@@ -18,8 +18,8 @@ use crate::{
 };
 use cocoa::{
   appkit::{
-    NSButton, NSEventMask, NSEventModifierFlags, NSEventType, NSImage, NSSquareStatusItemLength,
-    NSStatusBar, NSStatusItem, NSWindow,
+    NSButton, NSEventMask, NSEventModifierFlags, NSEventType, NSImage, NSStatusBar, NSStatusItem,
+    NSVariableStatusItemLength, NSWindow,
   },
   base::{id, nil, NO, YES},
   foundation::{NSData, NSPoint, NSSize, NSString},
@@ -40,7 +40,7 @@ impl SystemTrayBuilder {
   pub fn new(icon: Icon, tray_menu: Option<Menu>) -> Self {
     unsafe {
       let ns_status_bar =
-        NSStatusBar::systemStatusBar(nil).statusItemWithLength_(NSSquareStatusItemLength);
+        NSStatusBar::systemStatusBar(nil).statusItemWithLength_(NSVariableStatusItemLength);
       let _: () = msg_send![ns_status_bar, retain];
 
       Self {
@@ -50,6 +50,7 @@ impl SystemTrayBuilder {
           menu_on_left_click: true,
           tray_menu,
           ns_status_bar,
+          title: None,
         },
       }
     }
@@ -100,6 +101,11 @@ impl SystemTrayBuilder {
       if let Some(tooltip) = tooltip {
         self.system_tray.set_tooltip(&tooltip);
       }
+
+      // set up title if provided
+      if let Some(title) = &self.system_tray.title {
+        self.system_tray.set_title(title);
+      }
     }
 
     Ok(RootSystemTray(self.system_tray))
@@ -114,6 +120,7 @@ pub struct SystemTray {
   pub(crate) menu_on_left_click: bool,
   pub(crate) tray_menu: Option<Menu>,
   pub(crate) ns_status_bar: id,
+  pub(crate) title: Option<String>,
 }
 
 impl Drop for SystemTray {
@@ -149,6 +156,15 @@ impl SystemTray {
     }
   }
 
+  pub fn set_title(&self, title: &str) {
+    unsafe {
+      NSButton::setTitle_(
+        self.ns_status_bar.button(),
+        NSString::alloc(nil).init_str(title),
+      );
+    }
+  }
+
   fn create_button_with_icon(&self) {
     const ICON_WIDTH: f64 = 18.0;
     const ICON_HEIGHT: f64 = 18.0;
@@ -171,6 +187,7 @@ impl SystemTray {
 
       button.setImage_(nsimage);
       let _: () = msg_send![nsimage, setSize: new_size];
+      let _: () = msg_send![button, setImagePosition: 2]; // https://developer.apple.com/documentation/appkit/nscellimageposition/nsimageleft
       let is_template = match self.icon_is_template {
         true => YES,
         false => NO,

--- a/src/platform_impl/macos/system_tray.rs
+++ b/src/platform_impl/macos/system_tray.rs
@@ -168,6 +168,8 @@ impl SystemTray {
   fn create_button_with_icon(&self) {
     const ICON_WIDTH: f64 = 18.0;
     const ICON_HEIGHT: f64 = 18.0;
+    // The image is to the right of the title https://developer.apple.com/documentation/appkit/nscellimageposition/nsimageleft
+    const IMAGE_POSITION: i32 = 2;
 
     let icon = self.icon.inner.to_png();
 
@@ -187,7 +189,7 @@ impl SystemTray {
 
       button.setImage_(nsimage);
       let _: () = msg_send![nsimage, setSize: new_size];
-      let _: () = msg_send![button, setImagePosition: 2]; // https://developer.apple.com/documentation/appkit/nscellimageposition/nsimageleft
+      let _: () = msg_send![button, setImagePosition: IMAGE_POSITION];
       let is_template = match self.icon_is_template {
         true => YES,
         false => NO,

--- a/src/platform_impl/macos/system_tray.rs
+++ b/src/platform_impl/macos/system_tray.rs
@@ -169,7 +169,7 @@ impl SystemTray {
     const ICON_WIDTH: f64 = 18.0;
     const ICON_HEIGHT: f64 = 18.0;
     // The image is to the right of the title https://developer.apple.com/documentation/appkit/nscellimageposition/nsimageleft
-    const IMAGE_POSITION: i32 = 2;
+    const NSIMAGE_LEFT: i32 = 2;
 
     let icon = self.icon.inner.to_png();
 
@@ -189,7 +189,7 @@ impl SystemTray {
 
       button.setImage_(nsimage);
       let _: () = msg_send![nsimage, setSize: new_size];
-      let _: () = msg_send![button, setImagePosition: IMAGE_POSITION];
+      let _: () = msg_send![button, setImagePosition: NSIMAGE_LEFT];
       let is_template = match self.icon_is_template {
         true => YES,
         false => NO,


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

This is just my attempt to finish the work introduced in https://github.com/tauri-apps/tao/pull/369, all credits go to @BenJeau

Tested via `RUSTFLAGS='--cfg target_os="macos" --cfg feature="tray"' cargo run --example system_tray`


https://user-images.githubusercontent.com/660716/189293815-dc36ff51-3abb-4e34-a66b-aeebd9eb2f36.mov


