### PR TITLE
fix(menus): add app name to native Quit and Hide items, closes #536

### DIFF
--- a/.changes/macos-menus-appname.md
+++ b/.changes/macos-menus-appname.md
@@ -1,5 +1,5 @@
 ---
-"tao": minor
+"tao": patch
 ---
 
-Add the application name to the "Quit" and "Hide" native menu items.
+Add the application name to the "Quit" and "Hide" native menu items on macOS.

--- a/.changes/macos-menus-appname.md
+++ b/.changes/macos-menus-appname.md
@@ -1,0 +1,5 @@
+---
+"tao": minor
+---
+
+Add the application name to the "Quit" and "Hide" native menu items.

--- a/examples/custom_menu.rs
+++ b/examples/custom_menu.rs
@@ -56,6 +56,7 @@ fn main() {
   // add `my_sub_menu` children of `first_menu` with `Sub menu` title
   first_menu.add_submenu("Sub menu", true, my_sub_menu);
   first_menu.add_native_item(MenuItem::CloseWindow);
+  first_menu.add_native_item(MenuItem::Hide);
   first_menu.add_native_item(MenuItem::Quit);
 
   // create custom item `Selected and disabled` children of `second_menu`

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -210,7 +210,7 @@ impl Menu {
             menu_type,
           ),
         ))
-      },
+      }
       MenuItem::Hide => {
         let label = match get_app_name() {
           Some(name) => format!("Hide {}", name),
@@ -226,7 +226,7 @@ impl Menu {
             menu_type,
           ),
         ))
-      },
+      }
       MenuItem::HideOthers => Some((
         None,
         make_menu_item(

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -26,7 +26,7 @@ use crate::{
 use super::{
   app_state::AppState,
   event::EventWrapper,
-  util::{app_name, ns_string_to_rust},
+  util::{app_name_string, ns_string_to_rust},
   window::get_window_id,
 };
 
@@ -197,40 +197,24 @@ impl Menu {
           menu_type,
         ),
       )),
-      MenuItem::Quit => {
-        let label = unsafe {
-          match app_name() {
-            Some(app_name) => format!("Quit {}", ns_string_to_rust(app_name)),
-            None => "Quit".to_string(),
-          }
-        };
-        Some((
-          None,
-          make_menu_item(
-            label.as_str(),
-            Some(selector("terminate:")),
-            Some(Accelerator::new(RawMods::Meta, KeyCode::KeyQ)),
-            menu_type,
-          ),
-        ))
-      }
-      MenuItem::Hide => {
-        let label = unsafe {
-          match app_name() {
-            Some(app_name) => format!("Hide {}", ns_string_to_rust(app_name)),
-            None => "Hide".to_string(),
-          }
-        };
-        Some((
-          None,
-          make_menu_item(
-            label.as_str(),
-            Some(selector("hide:")),
-            Some(Accelerator::new(RawMods::Meta, KeyCode::KeyH)),
-            menu_type,
-          ),
-        ))
-      }
+      MenuItem::Quit => Some((
+        None,
+        make_menu_item(
+          format!("Quit {}", unsafe { app_name_string() }.unwrap_or_default()).trim(),
+          Some(selector("terminate:")),
+          Some(Accelerator::new(RawMods::Meta, KeyCode::KeyQ)),
+          menu_type,
+        ),
+      )),
+      MenuItem::Hide => Some((
+        None,
+        make_menu_item(
+          format!("Hide {}", unsafe { app_name_string() }.unwrap_or_default()).trim(),
+          Some(selector("hide:")),
+          Some(Accelerator::new(RawMods::Meta, KeyCode::KeyH)),
+          menu_type,
+        ),
+      )),
       MenuItem::HideOthers => Some((
         None,
         make_menu_item(

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -11,8 +11,7 @@ use objc::{
   declare::ClassDecl,
   runtime::{Class, Object, Sel, NO, YES},
 };
-
-use std::{str, sync::Once};
+use std::sync::Once;
 
 use crate::{
   accelerator::{Accelerator, RawMods},
@@ -198,24 +197,40 @@ impl Menu {
           menu_type,
         ),
       )),
-      MenuItem::Quit => Some((
-        None,
-        make_menu_item(
-          format!("Quit {}", app_name()).as_str(),
-          Some(selector("terminate:")),
-          Some(Accelerator::new(RawMods::Meta, KeyCode::KeyQ)),
-          menu_type,
-        ),
-      )),
-      MenuItem::Hide => Some((
-        None,
-        make_menu_item(
-          format!("Hide {}", app_name()).as_str(),
-          Some(selector("hide:")),
-          Some(Accelerator::new(RawMods::Meta, KeyCode::KeyH)),
-          menu_type,
-        ),
-      )),
+      MenuItem::Quit => {
+        let label = unsafe {
+          match app_name() {
+            Some(app_name) => format!("Quit {}", ns_string_to_rust(app_name)),
+            None => "Quit".to_string(),
+          }
+        };
+        Some((
+          None,
+          make_menu_item(
+            label.as_str(),
+            Some(selector("terminate:")),
+            Some(Accelerator::new(RawMods::Meta, KeyCode::KeyQ)),
+            menu_type,
+          ),
+        ))
+      }
+      MenuItem::Hide => {
+        let label = unsafe {
+          match app_name() {
+            Some(app_name) => format!("Hide {}", ns_string_to_rust(app_name)),
+            None => "Hide".to_string(),
+          }
+        };
+        Some((
+          None,
+          make_menu_item(
+            label.as_str(),
+            Some(selector("hide:")),
+            Some(Accelerator::new(RawMods::Meta, KeyCode::KeyH)),
+            menu_type,
+          ),
+        ))
+      }
       MenuItem::HideOthers => Some((
         None,
         make_menu_item(

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -11,7 +11,8 @@ use objc::{
   declare::ClassDecl,
   runtime::{Class, Object, Sel, NO, YES},
 };
-use std::sync::Once;
+
+use std::{os::raw::c_char, slice, str, sync::Once};
 
 use crate::{
   accelerator::{Accelerator, RawMods},
@@ -194,24 +195,38 @@ impl Menu {
           menu_type,
         ),
       )),
-      MenuItem::Quit => Some((
-        None,
-        make_menu_item(
-          "Quit",
-          Some(selector("terminate:")),
-          Some(Accelerator::new(RawMods::Meta, KeyCode::KeyQ)),
-          menu_type,
-        ),
-      )),
-      MenuItem::Hide => Some((
-        None,
-        make_menu_item(
-          "Hide",
-          Some(selector("hide:")),
-          Some(Accelerator::new(RawMods::Meta, KeyCode::KeyH)),
-          menu_type,
-        ),
-      )),
+      MenuItem::Quit => {
+        let label = match get_app_name() {
+          Some(name) => format!("Quit {}", name),
+          _ => "Quit".to_string(),
+        };
+
+        Some((
+          None,
+          make_menu_item(
+            label.as_str(),
+            Some(selector("terminate:")),
+            Some(Accelerator::new(RawMods::Meta, KeyCode::KeyQ)),
+            menu_type,
+          ),
+        ))
+      },
+      MenuItem::Hide => {
+        let label = match get_app_name() {
+          Some(name) => format!("Hide {}", name),
+          _ => "Hide".to_string(),
+        };
+
+        Some((
+          None,
+          make_menu_item(
+            label.as_str(),
+            Some(selector("hide:")),
+            Some(Accelerator::new(RawMods::Meta, KeyCode::KeyH)),
+            menu_type,
+          ),
+        ))
+      },
       MenuItem::HideOthers => Some((
         None,
         make_menu_item(
@@ -605,5 +620,20 @@ impl Accelerator {
       flags.insert(NSEventModifierFlags::NSControlKeyMask);
     }
     flags
+  }
+}
+
+fn get_app_name() -> Option<&'static str> {
+  unsafe {
+    let app_class = class!(NSRunningApplication);
+    let app: id = msg_send![app_class, currentApplication];
+    let name: *const Object = msg_send![app, localizedName];
+    let size: usize = msg_send![name, lengthOfBytesUsingEncoding:4];
+    let bytes: *const c_char = msg_send!(name, UTF8String);
+    let c_str = str::from_utf8(slice::from_raw_parts(bytes as *const u8, size));
+    match c_str {
+      Ok(name) => Some(name),
+      _ => None,
+    }
   }
 }

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -131,16 +131,13 @@ pub unsafe fn ns_string_to_rust(ns_string: id) -> String {
   string.to_owned()
 }
 
-#[allow(dead_code)] // In case we want to use this function in the future
-pub unsafe fn app_name() -> Option<id> {
-  let bundle: id = msg_send![class!(NSBundle), mainBundle];
-  let dict: id = msg_send![bundle, infoDictionary];
-  let key = ns_string_id_ref("CFBundleName");
-  let app_name: id = msg_send![dict, objectForKey:*key];
-  if app_name != nil {
-    Some(app_name)
-  } else {
-    None
+/// Gets the app's name from the `localizedName` property of `NSRunningApplication`
+pub fn app_name() -> String {
+  unsafe {
+    let app_class = class!(NSRunningApplication);
+    let app: id = msg_send![app_class, currentApplication];
+    let name: id = msg_send![app, localizedName];
+    ns_string_to_rust(name)
   }
 }
 

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -143,6 +143,11 @@ pub unsafe fn app_name() -> Option<id> {
   }
 }
 
+/// Gets the app's name as a `String` from the `localizedName` property of `NSRunningApplication`
+pub unsafe fn app_name_string() -> Option<String> {
+  app_name().map(|name| ns_string_to_rust(name))
+}
+
 pub unsafe fn superclass<'a>(this: &'a Object) -> &'a Class {
   let superclass: *const Class = msg_send![this, superclass];
   &*superclass

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -132,12 +132,14 @@ pub unsafe fn ns_string_to_rust(ns_string: id) -> String {
 }
 
 /// Gets the app's name from the `localizedName` property of `NSRunningApplication`
-pub fn app_name() -> String {
-  unsafe {
-    let app_class = class!(NSRunningApplication);
-    let app: id = msg_send![app_class, currentApplication];
-    let name: id = msg_send![app, localizedName];
-    ns_string_to_rust(name)
+pub unsafe fn app_name() -> Option<id> {
+  let app_class = class!(NSRunningApplication);
+  let app: id = msg_send![app_class, currentApplication];
+  let app_name: id = msg_send![app, localizedName];
+  if app_name != nil {
+    Some(app_name)
+  } else {
+    None
   }
 }
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
Implemented by getting the name of the current app from `NSRunningApplication` and adding it to the menu items labels.

closes #536