### PR TITLE
feat(menus): add support for Plus key in accelerators, closes #227

### DIFF
--- a/.changes/macos-menus-accel-plus.md
+++ b/.changes/macos-menus-accel-plus.md
@@ -1,0 +1,6 @@
+---
+"tao": patch
+---
+
+Add support for the "+" key in menu accelerators using `KeyCode::Plus` or the "Plus" keyword.
+See documentation for `KeyCode::Plus` for notes on platform-dependent behaviour.

--- a/examples/custom_menu.rs
+++ b/examples/custom_menu.rs
@@ -74,8 +74,7 @@ fn main() {
 
   second_menu.add_native_item(MenuItem::Separator);
   let mut zoom_in_item = second_menu.add_item(
-    MenuItemAttributes::new("Zoom in")
-      .with_accelerators(&"CmdOrCtrl+Plus".parse().unwrap()),
+    MenuItemAttributes::new("Zoom in").with_accelerators(&"CmdOrCtrl+Plus".parse().unwrap()),
   );
 
   // add all our childs to menu_bar_menu (order is how they'll appear)

--- a/examples/custom_menu.rs
+++ b/examples/custom_menu.rs
@@ -72,6 +72,12 @@ fn main() {
   // create custom item `Change menu` children of `second_menu`
   let change_menu = second_menu.add_item(MenuItemAttributes::new("Change menu"));
 
+  second_menu.add_native_item(MenuItem::Separator);
+  let mut zoom_in_item = second_menu.add_item(
+    MenuItemAttributes::new("Zoom in")
+      .with_accelerators(&"CmdOrCtrl+Plus".parse().unwrap()),
+  );
+
   // add all our childs to menu_bar_menu (order is how they'll appear)
   menu_bar_menu.add_submenu("My app", true, first_menu);
   menu_bar_menu.add_submenu("Other menu", true, second_menu);
@@ -135,6 +141,13 @@ fn main() {
         ..
       } if menu_id == custom_read_clipboard.clone().id() => {
         println!("Clipboard content: {:?}", cliboard.read_text());
+      }
+      Event::MenuEvent {
+        menu_id,
+        origin: MenuType::MenuBar,
+        ..
+      } if menu_id == zoom_in_item.clone().id() => {
+        println!("Zoom in!");
       }
       _ => (),
     }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -323,6 +323,8 @@ pub enum KeyCode {
   KeyZ,
   /// <kbd>-</kbd> on a US keyboard.
   Minus,
+  /// <kbd>+</kbd> on a US keyboard.
+  Plus,
   /// <kbd>.</kbd> on a US keyboard.
   Period,
   /// <kbd>'</kbd> on a US keyboard.
@@ -698,6 +700,7 @@ impl FromStr for KeyCode {
       "NUM9" | "NUMPAD9" => KeyCode::Numpad9,
       "=" => KeyCode::Equal,
       "-" => KeyCode::Minus,
+      "PLUS" => KeyCode::Plus,
       "." | "PERIOD" => KeyCode::Period,
       "'" | "QUOTE" => KeyCode::Quote,
       "\\" => KeyCode::IntlBackslash,

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -323,7 +323,14 @@ pub enum KeyCode {
   KeyZ,
   /// <kbd>-</kbd> on a US keyboard.
   Minus,
-  /// <kbd>+</kbd> on a US keyboard.
+  /// <kbd>Shift</kbd>+<kbd>=</kbd> on a US keyboard.
+  ///
+  /// When used as a menu accelerator this is displayed as <kbd>+</kbd>, and on macOS
+  /// and Windows the accelerator can be used without pressing the <kbd>Shift</kbd> key.
+  /// On Linux the <kbd>Shift</kbd> key is still required with a US keyboard layout.
+  ///
+  /// `Plus` does not work as a value for keyboard accelerators outside menus, on
+  /// US keyboards or others where <kbd>+</kbd> requires a modifier key.
   Plus,
   /// <kbd>.</kbd> on a US keyboard.
   Period,

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -328,9 +328,8 @@ pub enum KeyCode {
   /// When used as a menu accelerator this is displayed as <kbd>+</kbd>, and on macOS
   /// and Windows the accelerator can be used without pressing the <kbd>Shift</kbd> key.
   /// On Linux the <kbd>Shift</kbd> key is still required with a US keyboard layout.
-  ///
-  /// `Plus` does not work as a value for keyboard accelerators outside menus, on
-  /// US keyboards or others where <kbd>+</kbd> requires a modifier key.
+  /// `Plus` does not work as a value for keyboard accelerators outside menus on
+  /// keyboards where <kbd>+</kbd> requires a modifier key.
   Plus,
   /// <kbd>.</kbd> on a US keyboard.
   Period,

--- a/src/platform_impl/linux/keyboard.rs
+++ b/src/platform_impl/linux/keyboard.rs
@@ -330,6 +330,7 @@ pub fn key_to_raw_key(src: &KeyCode) -> Option<RawKey> {
     KeyCode::PageDown => Page_Down,
 
     KeyCode::NumLock => Num_Lock,
+    KeyCode::Plus => plus,
 
     KeyCode::ArrowUp => Up,
     KeyCode::ArrowDown => Down,

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -534,6 +534,7 @@ impl Accelerator {
       KeyCode::Digit9 => "9".into(),
       KeyCode::Comma => ",".into(),
       KeyCode::Minus => "-".into(),
+      KeyCode::Plus => "+".into(),
       KeyCode::Period => ".".into(),
       KeyCode::Space => "\u{0020}".into(),
       KeyCode::Equal => "=".into(),

--- a/src/platform_impl/windows/keyboard.rs
+++ b/src/platform_impl/windows/keyboard.rs
@@ -846,6 +846,7 @@ pub(crate) fn key_to_vk(key: &KeyCode) -> Option<VIRTUAL_KEY> {
     KeyCode::Digit9 => unsafe { VIRTUAL_KEY(VkKeyScanW('9' as u16) as u16) },
     KeyCode::Comma => VK_OEM_COMMA,
     KeyCode::Minus => VK_OEM_MINUS,
+    KeyCode::Plus => VK_OEM_PLUS,
     KeyCode::Period => VK_OEM_PERIOD,
     KeyCode::Equal => unsafe { VIRTUAL_KEY(VkKeyScanW('=' as u16) as u16) },
     KeyCode::Semicolon => unsafe { VIRTUAL_KEY(VkKeyScanW(';' as u16) as u16) },

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -552,6 +552,7 @@ impl fmt::Display for Accelerator {
       KeyCode::Digit9 => write!(f, "9"),
       KeyCode::Comma => write!(f, ","),
       KeyCode::Minus => write!(f, "-"),
+      KeyCode::Plus => write!(f, "+"),
       KeyCode::Period => write!(f, "."),
       KeyCode::Space => write!(f, "Space"),
       KeyCode::Equal => write!(f, "="),


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
Adds `KeyCode::Plus` which can also be used (eg in Tauri) with the string `"Plus"` such as in `"CmdOrCtrl+Plus"`.
As [noted in the added docs](https://github.com/tauri-apps/tao/pull/573/files#diff-792b8d0bfd0c836c48cce2af6cc7d60ec434486ba56de63ffbaa1a6d09d17246R326), behaviour is somewhat platform-dependent and (at least for US and similar keyboards) only works in menu accelerators.

A solution which also works with `Accelerator::matches` for app-wide keyboard shortcuts would be ideal, but the implementation would be very complex (if it's even feasible at all in a cross-platform way).

I'm not sure if this is a full resolution for #227 but using `+` in menus is the only case specifically discussed there. Any other missing values will have to be implemented on a case-by-case basis I think.