### PR TITLE
feat(macos): add `allows_automatic_window_tabbing` APIs

### DIFF
--- a/.changes/macos-automatic-tabbing.md
+++ b/.changes/macos-automatic-tabbing.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Add `WindowExtMacOS::set_allows_automatic_window_tabbing` and `WindowExtMacOS::allows_automatic_window_tabbing` on macOS.

--- a/.changes/macos-automatic-tabbing.md
+++ b/.changes/macos-automatic-tabbing.md
@@ -2,4 +2,4 @@
 "tao": patch
 ---
 
-Add `WindowExtMacOS::set_allows_automatic_window_tabbing` and `WindowExtMacOS::allows_automatic_window_tabbing` on macOS.
+Add `WindowExtMacOS::set_allows_automatic_window_tabbing`, `WindowExtMacOS::allows_automatic_window_tabbing`, and `WindowBuilderExtMacOS::with_automatic_window_tabbing` on macOS.

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -375,6 +375,7 @@ pub trait WindowBuilderExtMacOS {
   fn with_resize_increments(self, increments: LogicalSize<f64>) -> WindowBuilder;
   fn with_disallow_hidpi(self, disallow_hidpi: bool) -> WindowBuilder;
   fn with_has_shadow(self, has_shadow: bool) -> WindowBuilder;
+  fn with_automatic_window_tabbing(self, automatic_tabbing: bool) -> WindowBuilder;
 }
 
 impl WindowBuilderExtMacOS for WindowBuilder {
@@ -438,6 +439,12 @@ impl WindowBuilderExtMacOS for WindowBuilder {
   #[inline]
   fn with_has_shadow(mut self, has_shadow: bool) -> WindowBuilder {
     self.platform_specific.has_shadow = has_shadow;
+    self
+  }
+
+  #[inline]
+  fn with_automatic_window_tabbing(mut self, automatic_tabbing: bool) -> WindowBuilder {
+    self.platform_specific.automatic_tabbing = automatic_tabbing;
     self
   }
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -63,6 +63,14 @@ pub trait WindowExtMacOS {
 
   /// Get the window's edit state
   fn is_document_edited(&self) -> bool;
+
+  /// Sets whether the system can automatically organize windows into tabs.
+  ///
+  /// <https://developer.apple.com/documentation/appkit/nswindow/1646657-allowsautomaticwindowtabbing>
+  fn set_allows_automatic_window_tabbing(&self, enabled: bool);
+
+  /// Returns whether the system can automatically organize windows into tabs.
+  fn allows_automatic_window_tabbing(&self) -> bool;
 }
 
 impl WindowExtMacOS for Window {
@@ -104,6 +112,16 @@ impl WindowExtMacOS for Window {
   #[inline]
   fn is_document_edited(&self) -> bool {
     self.window.is_document_edited()
+  }
+
+  #[inline]
+  fn set_allows_automatic_window_tabbing(&self, enabled: bool) {
+    self.window.set_allows_automatic_window_tabbing(enabled)
+  }
+
+  #[inline]
+  fn allows_automatic_window_tabbing(&self) -> bool {
+    self.window.allows_automatic_window_tabbing()
   }
 }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -91,6 +91,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
   pub resize_increments: Option<LogicalSize<f64>>,
   pub disallow_hidpi: bool,
   pub has_shadow: bool,
+  pub automatic_tabbing: bool,
 }
 
 impl Default for PlatformSpecificWindowBuilderAttributes {
@@ -107,6 +108,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
       resize_increments: None,
       disallow_hidpi: false,
       has_shadow: true,
+      automatic_tabbing: true,
     }
   }
 }
@@ -270,6 +272,10 @@ fn create_window(
 
       if let Parent::ChildOf(parent) = pl_attrs.parent {
         let _: () = msg_send![parent as id, addChildWindow: *ns_window ordered: NSWindowOrderingMode::NSWindowAbove];
+      }
+
+      if !pl_attrs.automatic_tabbing {
+        NSWindow::setAllowsAutomaticWindowTabbing_(*ns_window, NO);
       }
 
       if !pl_attrs.has_shadow {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1472,6 +1472,21 @@ impl WindowExtMacOS for UnownedWindow {
       is_document_edited == YES
     }
   }
+
+  #[inline]
+  fn set_allows_automatic_window_tabbing(&self, enabled: bool) {
+    unsafe {
+      NSWindow::setAllowsAutomaticWindowTabbing_(*self.ns_window, if enabled { YES } else { NO })
+    }
+  }
+
+  #[inline]
+  fn allows_automatic_window_tabbing(&self) -> bool {
+    unsafe {
+      let allows_tabbing: BOOL = NSWindow::allowsAutomaticWindowTabbing(*self.ns_window);
+      allows_tabbing == YES
+    }
+  }
 }
 
 impl Drop for UnownedWindow {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
Adds the following APIs on macOS:
- `WindowExtMacOS::set_allows_automatic_window_tabbing`
- `WindowExtMacOS::allows_automatic_window_tabbing`
- `WindowBuilderExtMacOS::with_automatic_window_tabbing`

This allows disabling macOS's "automatic window tabbing" feature, whereby an undesired tab bar is added to the app and all the windows are merged into one.

See https://github.com/tauri-apps/tauri/issues/3912.