### PR TITLE
fix(linux): improve event loop process on Linux

### DIFF
--- a/.changes/linux-drag.md
+++ b/.changes/linux-drag.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+fix(linux): Improve event loop process on Linux a bit. This changes only a few check and should make dragging windows on egui smoother.

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -949,7 +949,7 @@ impl<T: 'static> EventLoop<T> {
                 break code;
               }
               ControlFlow::Wait => {
-                if !events.is_empty() || !draws.is_empty() {
+                if !events.is_empty() {
                   callback(
                     Event::NewEvents(StartCause::WaitCancelled {
                       start: Instant::now(),
@@ -989,7 +989,7 @@ impl<T: 'static> EventLoop<T> {
                   blocking = true;
                 }
               }
-              ControlFlow::Poll => {
+              _ => {
                 callback(
                   Event::NewEvents(StartCause::Poll),
                   window_target,
@@ -1010,11 +1010,7 @@ impl<T: 'static> EventLoop<T> {
                 },
                 Err(_) => {
                   callback(Event::MainEventsCleared, window_target, &mut control_flow);
-                  if draws.is_empty() {
-                    state = EventState::NewStart;
-                  } else {
-                    state = EventState::DrawQueue;
-                  }
+                  state = EventState::DrawQueue;
                 }
               },
             },


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
Update a few conditions when processing event loop. This could make dragging windows on egui smoother.
Idealy, we should have multi  thread to do so. But gtk has stubborn nature about this so this is what I could do at least.