### PR TITLE
feat: Add accent color support for macOS

### DIFF
--- a/.changes/macos-accent-color.md
+++ b/.changes/macos-accent-color.md
@@ -1,0 +1,5 @@
+---
+"tao": minor
+---
+
+Add support and `WindowEvent` for accent color on macOS.

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -20,6 +20,7 @@ fn main() {
     .unwrap();
 
   println!("Initial theme: {:?}", window.theme());
+  println!("Initial accent color: {:?}", window.accent_color());
 
   event_loop.run(move |event, _, control_flow| {
     *control_flow = ControlFlow::Wait;
@@ -35,6 +36,12 @@ fn main() {
         ..
       } if window_id == window.id() => {
         println!("Theme is changed: {:?}", theme)
+      }
+      Event::WindowEvent {
+        event: WindowEvent::AccentColorChanged(accent_color),
+        ..
+      } => {
+        println!("Accent color has changed: {:?}", accent_color)
       }
       _ => (),
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -46,7 +46,7 @@ use crate::{
   keyboard::{self, ModifiersState},
   menu::{MenuId, MenuType},
   platform_impl,
-  window::{Theme, WindowId},
+  window::{AccentColor, Theme, WindowId},
 };
 
 /// Describes a generic event.
@@ -482,6 +482,13 @@ pub enum WindowEvent<'a> {
   /// - **Linux / Android / iOS:** Unsupported
   ThemeChanged(Theme),
 
+  /// The system accent color has changed.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **iOS / Android / Linux / Windows:** Unsupported.
+  AccentColorChanged(Option<AccentColor>),
+
   /// The window decorations has been clicked.
   ///
   /// ## Platform-specific
@@ -574,6 +581,7 @@ impl Clone for WindowEvent<'static> {
       },
       Touch(touch) => Touch(*touch),
       ThemeChanged(theme) => ThemeChanged(*theme),
+      AccentColorChanged(color) => AccentColorChanged(*color),
       ScaleFactorChanged { .. } => {
         unreachable!("Static event can't be about scale factor changing")
       }
@@ -661,6 +669,7 @@ impl<'a> WindowEvent<'a> {
       }),
       Touch(touch) => Some(Touch(touch)),
       ThemeChanged(theme) => Some(ThemeChanged(theme)),
+      AccentColorChanged(color) => Some(AccentColorChanged(color)),
       ScaleFactorChanged { .. } => None,
       DecorationsClick => Some(DecorationsClick),
     }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -35,7 +35,8 @@ use crate::{
     OsError,
   },
   window::{
-    CursorIcon, Fullscreen, Theme, UserAttentionType, WindowAttributes, WindowId as RootWindowId,
+    AccentColor, CursorIcon, Fullscreen, Theme, UserAttentionType, WindowAttributes,
+    WindowId as RootWindowId,
   },
 };
 use cocoa::{
@@ -336,6 +337,32 @@ pub(super) fn set_ns_theme(theme: Theme) {
   }
 }
 
+pub(super) fn get_ns_accent_color() -> Option<AccentColor> {
+  unsafe {
+    let key_name = NSString::alloc(nil).init_str("AppleAccentColor");
+
+    let user_defaults: id = msg_send![class!(NSUserDefaults), standardUserDefaults];
+    let color_obj: id = msg_send![user_defaults, objectForKey: key_name];
+
+    if color_obj == nil {
+      return None;
+    }
+
+    let color_int: id = msg_send![user_defaults, integerForKey: key_name];
+
+    match color_int as i8 {
+      -1 => Some(AccentColor::Graphite),
+      0 => Some(AccentColor::Red),
+      1 => Some(AccentColor::Orange),
+      2 => Some(AccentColor::Yellow),
+      3 => Some(AccentColor::Green),
+      4 => Some(AccentColor::Blue),
+      5 => Some(AccentColor::Purple),
+      6 => Some(AccentColor::Pink),
+      _ => None,
+    }
+  }
+}
 struct WindowClass(*const Class);
 unsafe impl Send for WindowClass {}
 unsafe impl Sync for WindowClass {}
@@ -402,6 +429,7 @@ pub struct SharedState {
   save_presentation_opts: Option<NSApplicationPresentationOptions>,
   pub saved_desktop_display_mode: Option<(CGDisplay, CGDisplayMode)>,
   pub current_theme: Theme,
+  pub current_accent_color: Option<AccentColor>,
 }
 
 impl SharedState {
@@ -535,6 +563,11 @@ impl UnownedWindow {
         let mut state = window.shared_state.lock().unwrap();
         state.current_theme = get_ns_theme();
       }
+    }
+
+    {
+      let mut state = window.shared_state.lock().unwrap();
+      state.current_accent_color = get_ns_accent_color();
     }
 
     let delegate = new_delegate(&window, fullscreen.is_some());
@@ -1339,6 +1372,12 @@ impl UnownedWindow {
   pub fn theme(&self) -> Theme {
     let state = self.shared_state.lock().unwrap();
     state.current_theme
+  }
+
+  #[inline]
+  pub fn accent_color(&self) -> Option<AccentColor> {
+    let state = self.shared_state.lock().unwrap();
+    state.current_accent_color
   }
 
   pub fn set_content_protection(&self, enabled: bool) {

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -27,7 +27,7 @@ use crate::{
     event::{EventProxy, EventWrapper},
     util::{self, IdRef},
     view::ViewState,
-    window::{get_ns_theme, get_window_id, UnownedWindow},
+    window::{get_ns_accent_color, get_ns_theme, get_window_id, UnownedWindow},
   },
   window::{Fullscreen, WindowId},
 };
@@ -252,6 +252,10 @@ lazy_static! {
       sel!(effectiveAppearanceDidChangedOnMainThread:),
       effective_appearance_did_changed_on_main_thread as extern "C" fn(&Object, Sel, id),
     );
+    decl.add_method(
+      sel!(accentColorChanged:),
+      accent_color_did_change as extern "C" fn(&Object, Sel, id),
+    );
 
     decl.add_ivar::<*mut c_void>("taoState");
     WindowDelegateClass(decl.register())
@@ -292,6 +296,17 @@ extern "C" fn init_with_tao(this: &Object, _sel: Sel, state: *mut c_void) -> id 
         addObserver: this
         selector: sel!(effectiveAppearanceDidChange:)
         name: notification_name
+        object: nil
+    ];
+
+    let notification_accent_color_name =
+      NSString::alloc(nil).init_str("AppleColorPreferencesChangedNotification");
+
+    let _: () = msg_send![
+        notification_center,
+        addObserver: this
+        selector: sel!(accentColorChanged:)
+        name: notification_accent_color_name
         object: nil
     ];
 
@@ -658,4 +673,15 @@ extern "C" fn effective_appearance_did_changed_on_main_thread(this: &Object, _: 
     }
   });
   trace!("Completed `effectiveAppearDidChange:`");
+}
+
+extern "C" fn accent_color_did_change(this: &Object, _: Sel, _: id) {
+  with_state(this, |state| {
+    let accent_color = get_ns_accent_color();
+    state.with_window(|window| {
+      let mut shared_state = window.shared_state.lock().unwrap();
+      shared_state.current_accent_color = accent_color;
+    });
+    state.emit_event(WindowEvent::AccentColorChanged(accent_color));
+  });
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1062,6 +1062,17 @@ impl Window {
     self.window.theme()
   }
 
+  /// Returns the accent color of the system.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **iOS / Android / Linux / Windows:** Unsupported.
+  #[inline]
+  pub fn accent_color(&self) -> Option<AccentColor> {
+    #[cfg(target_os = "macos")]
+    self.window.accent_color()
+  }
+
   /// Prevents the window contents from being captured by other apps.
   ///
   /// ## Platform-specific
@@ -1301,6 +1312,19 @@ pub enum Fullscreen {
 pub enum Theme {
   Light,
   Dark,
+}
+
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum AccentColor {
+  Graphite,
+  Red,
+  Orange,
+  Yellow,
+  Green,
+  Blue,
+  Purple,
+  Pink,
 }
 
 impl Default for Theme {


### PR DESCRIPTION
### What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Similar to the `theme` support this adds support for the accent color for macOS.
I added this as Electron [offers something similar](https://www.electronjs.org/docs/latest/api/system-preferences#systempreferencesgetaccentcolor-windows-macos) ([or as an event](https://www.electronjs.org/docs/latest/api/system-preferences#systempreferencessubscribenotificationevent-callback-macos)).

I don't have Windows at hand, but this could potentially be added in the future for Windows as well.

Affected system setting:

<img width="650" alt="image" src="https://user-images.githubusercontent.com/571589/195842815-09aa152c-106a-4e68-b49e-e3480315c6e5.png">
