### PR TITLE
Fix cross compilation.

### DIFF
--- a/.changes/macos-crosscompile.md
+++ b/.changes/macos-crosscompile.md
@@ -1,0 +1,5 @@
+---
+"wry": patch
+---
+
+Support cross compiling for macos from a non macos host.

--- a/.changes/macos-crosscompile.md
+++ b/.changes/macos-crosscompile.md
@@ -1,5 +1,5 @@
 ---
-"wry": patch
+"tao": patch
 ---
 
 Support cross compiling for macos from a non macos host.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ default = [ ]
 dox = [ "gtk/dox" ]
 tray = [ "libappindicator", "dirs-next" ]
 
+[build-dependencies]
+cc = "1"
+
 [dependencies]
 instant = "0.1"
 lazy_static = "1"
@@ -63,9 +66,6 @@ core-graphics = "0.22"
 dispatch = "0.2"
 scopeguard = "1.1"
 png = "0.17"
-
-[target."cfg(target_os = \"macos\")".build-dependencies]
-cc = "1"
 
 [target."cfg(target_os = \"windows\")".dependencies]
 parking_lot = "0.12"

--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,6 @@ fn main() {
     println!("cargo:rustc-cfg=use_colorsync_cgdisplaycreateuuidfromdisplayid");
   }
   // link carbon hotkey on macOS
-  #[cfg(target_os = "macos")]
   {
     if std::env::var("CARGO_CFG_TARGET_OS").map_or(false, |os| os == "macos") {
       println!("cargo:rustc-link-lib=framework=Carbon");


### PR DESCRIPTION
This is one of the patches that allows users to cross compile dioxus apps for macos using xbuild.

Closes #383