### PR TITLE
Prevent global shortcut activation from repeating on Windows

### DIFF
--- a/.changes/windows-global-shortcut-no-repeat.md
+++ b/.changes/windows-global-shortcut-no-repeat.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Default to MOD_NOREPEAT for registering global shortcuts / hotkeys via win32 RegisterHotKey on Windows. This prevents shortcuts from repeatedly activating when the accelerator is pressed and held down, and ensures that we maintain platform-agnostic consistency.

--- a/src/platform_impl/windows/global_shortcut.rs
+++ b/src/platform_impl/windows/global_shortcut.rs
@@ -24,7 +24,7 @@ impl ShortcutManager {
     accelerator: Accelerator,
   ) -> Result<RootGlobalShortcut, ShortcutManagerError> {
     unsafe {
-      let mut converted_modifiers = Default::default();
+      let mut converted_modifiers = MOD_NOREPEAT;
       let modifiers: ModifiersState = accelerator.mods;
       if modifiers.shift_key() {
         converted_modifiers |= MOD_SHIFT;


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: platform feature consistency

Currently, when global shortcuts are registered on Windows, the `MOD_NOREPEAT` flag is not included which causes the global shortcut to repeatedly activate when the key is pressed down (similar to pressing and holding a single key on the keyboard, which causes the key press to repeat). To mimic the functionality of how shortcuts are managed in other platforms, we may add the `MOD_NOREPEAT` flag by default.

Reference: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registerhotkey

Relevant Discord thread: https://discord.com/channels/616186924390023171/807549941936816148/1033114071832207471

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
