### PR TITLE
fix: parse `Arrow*` in a accelerator string

### DIFF
--- a/.changes/accelerator-arrowup.md
+++ b/.changes/accelerator-arrowup.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+Add support for parsing `ArrowUp`, `ArrowDown`, `ArrowLeft` and `ArrowRight` in a str as valid key. Previously only `Up`, `Down`, `Left` and `Right` worked.

--- a/src/accelerator.rs
+++ b/src/accelerator.rs
@@ -310,7 +310,7 @@ fn parse_accelerator(accelerator_string: &str) -> Result<Accelerator, Accelerato
   let mut mods = ModifiersState::empty();
   let mut key = KeyCode::Unidentified(NativeKeyCode::Unidentified);
 
-  for raw in accelerator_string.to_uppercase().split('+') {
+  for raw in accelerator_string.split('+') {
     let token = raw.trim().to_string();
     if token.is_empty() {
       return Err(AcceleratorParseError(
@@ -330,7 +330,7 @@ fn parse_accelerator(accelerator_string: &str) -> Result<Accelerator, Accelerato
       )));
     }
 
-    match token.as_str() {
+    match token.to_uppercase().as_str() {
       "OPTION" | "ALT" => {
         mods.set(ModifiersState::ALT, true);
       }
@@ -350,7 +350,7 @@ fn parse_accelerator(accelerator_string: &str) -> Result<Accelerator, Accelerato
         mods.set(ModifiersState::CONTROL, true);
       }
       _ => {
-        if let Ok(keycode) = KeyCode::from_str(token.to_uppercase().as_str()) {
+        if let Ok(keycode) = KeyCode::from_str(&token) {
           match keycode {
             KeyCode::Unidentified(_) => {
               return Err(AcceleratorParseError(format!(

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -754,10 +754,10 @@ impl FromStr for KeyCode {
       "PAGEDOWN" => KeyCode::PageDown,
       "PAGEUP" => KeyCode::PageUp,
 
-      "DOWN" => KeyCode::ArrowDown,
-      "UP" => KeyCode::ArrowUp,
-      "LEFT" => KeyCode::ArrowLeft,
-      "RIGHT" => KeyCode::ArrowRight,
+      "DOWN" | "ARROWDOWN" => KeyCode::ArrowDown,
+      "UP" | "ARROWUP" => KeyCode::ArrowUp,
+      "LEFT" | "ARROWLEFT" => KeyCode::ArrowLeft,
+      "RIGHT" | "ARROWRIGHT" => KeyCode::ArrowRight,
 
       "NUMLOCK" => KeyCode::NumLock,
       "NUMADD" | "NUMPADADD" => KeyCode::NumpadAdd,


### PR DESCRIPTION
ref: https://github.com/tauri-apps/tauri/issues/5516

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
