### PR TITLE
feat: add `EventLoopExtMacOS::set_activate_ignoring_other_apps`

### DIFF
--- a/.changes/macos-activate-ignoring-other-apps.md
+++ b/.changes/macos-activate-ignoring-other-apps.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Add `EventLoopExtMacOS::set_activate_ignoring_other_apps` on macOS.

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -501,6 +501,16 @@ pub trait EventLoopExtMacOS {
   /// [`run`](crate::event_loop::EventLoop::run) or
   /// [`run_return`](crate::platform::run_return::EventLoopExtRunReturn::run_return)
   fn enable_default_menu_creation(&mut self, enable: bool);
+
+  /// Used to prevent the application from automatically activating when launched if
+  /// another application is already active
+  ///
+  /// The default behavior is to ignore other applications and activate when launched.
+  ///
+  /// This function only takes effect if it's called before calling
+  /// [`run`](crate::event_loop::EventLoop::run) or
+  /// [`run_return`](crate::platform::run_return::EventLoopExtRunReturn::run_return)
+  fn set_activate_ignoring_other_apps(&mut self, ignore: bool);
 }
 impl<T> EventLoopExtMacOS for EventLoop<T> {
   #[inline]
@@ -514,6 +524,13 @@ impl<T> EventLoopExtMacOS for EventLoop<T> {
   fn enable_default_menu_creation(&mut self, enable: bool) {
     unsafe {
       get_aux_state_mut(&**self.event_loop.delegate).create_default_menu = enable;
+    }
+  }
+
+  #[inline]
+  fn set_activate_ignoring_other_apps(&mut self, ignore: bool) {
+    unsafe {
+      get_aux_state_mut(&**self.event_loop.delegate).activate_ignoring_other_apps = ignore;
     }
   }
 }

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -23,6 +23,8 @@ pub struct AuxDelegateState {
   pub activation_policy: ActivationPolicy,
 
   pub create_default_menu: bool,
+
+  pub activate_ignoring_other_apps: bool,
 }
 
 pub struct AppDelegateClass(pub *const Class);
@@ -67,6 +69,7 @@ extern "C" fn new(class: &Class, _: Sel) -> id {
       Box::into_raw(Box::new(RefCell::new(AuxDelegateState {
         activation_policy: ActivationPolicy::Regular,
         create_default_menu: true,
+        activate_ignoring_other_apps: true,
       }))) as *mut c_void,
     );
     this

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -286,8 +286,12 @@ impl AppState {
     unsafe {
       let ns_app = NSApp();
       window_activation_hack(ns_app);
-      // TODO: Consider allowing the user to specify they don't want their application activated
-      ns_app.activateIgnoringOtherApps_(YES);
+      let ignore = if get_aux_state_mut(app_delegate).activate_ignoring_other_apps {
+        YES
+      } else {
+        NO
+      };
+      ns_app.activateIgnoringOtherApps_(ignore);
     };
     HANDLER.set_ready();
     HANDLER.waker().start();


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

This adds the ability to modify the call to `activateIgnoringOtherApps` and set the argument to `NO` which was previously not possible
