### PR TITLE
On macOS, add `WindowExtMacOS::reset_cursor_rect`

### DIFF
--- a/.changes/reset-cursor.md
+++ b/.changes/reset-cursor.md
@@ -1,5 +1,5 @@
 ---
-"tao"
+"tao": patch
 ---
 
 On macOS, add `WindowExtMacOS::reset_cursor_rect`.

--- a/.changes/reset-cursor.md
+++ b/.changes/reset-cursor.md
@@ -1,0 +1,5 @@
+---
+"tao"
+---
+
+On macOS, add `WindowExtMacOS::reset_cursor_rect`.

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -79,6 +79,10 @@ pub trait WindowExtMacOS {
 
   /// Returns the window's tabbing identifier.
   fn tabbing_identifier(&self) -> String;
+
+  /// Load cursor icon set by tao when `resetCursorRect` is called. Default is ture. Set it to
+  /// false will diable methods of cursor icon setting and hidding.
+  fn reset_cursor_rect(&self, reset: bool);
 }
 
 impl WindowExtMacOS for Window {
@@ -140,6 +144,10 @@ impl WindowExtMacOS for Window {
   #[inline]
   fn tabbing_identifier(&self) -> String {
     self.window.tabbing_identifier()
+  }
+
+  fn reset_cursor_rect(&self, reset: bool) {
+    self.window.reset_cursor_rect(reset)
   }
 }
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -38,6 +38,7 @@ use crate::{
 };
 
 pub struct CursorState {
+  pub reset_cursor_rect: bool,
   pub visible: bool,
   pub cursor: util::Cursor,
 }
@@ -45,6 +46,7 @@ pub struct CursorState {
 impl Default for CursorState {
   fn default() -> Self {
     Self {
+      reset_cursor_rect: true,
       visible: true,
       cursor: Default::default(),
     }
@@ -407,17 +409,19 @@ extern "C" fn reset_cursor_rects(this: &Object, _sel: Sel) {
     let state_ptr: *mut c_void = *this.get_ivar("taoState");
     let state = &mut *(state_ptr as *mut ViewState);
 
-    let bounds: NSRect = msg_send![this, bounds];
     let cursor_state = state.cursor_state.lock().unwrap();
-    let cursor = if cursor_state.visible {
-      cursor_state.cursor.load()
-    } else {
-      util::invisible_cursor()
-    };
-    let _: () = msg_send![this,
-        addCursorRect:bounds
-        cursor:cursor
-    ];
+    if cursor_state.reset_cursor_rect {
+      let bounds: NSRect = msg_send![this, bounds];
+      let cursor = if cursor_state.visible {
+        cursor_state.cursor.load()
+      } else {
+        util::invisible_cursor()
+      };
+      let _: () = msg_send![this,
+          addCursorRect:bounds
+          cursor:cursor
+      ];
+    }
   }
 }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1515,6 +1515,17 @@ impl WindowExtMacOS for UnownedWindow {
       ns_string_to_rust(tabbing_identifier)
     }
   }
+
+  #[inline]
+  fn reset_cursor_rect(&self, reset: bool) {
+    if let Some(cursor_access) = self.cursor_state.upgrade() {
+      let mut cursor_state = cursor_access.lock().unwrap();
+      if reset != cursor_state.reset_cursor_rect {
+        cursor_state.reset_cursor_rect = reset;
+        drop(cursor_state);
+      }
+    }
+  }
 }
 
 impl Drop for UnownedWindow {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
