### PR TITLE
feat(linux): use dirs instead of dirs-next

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ targets = [
 [features]
 default = [ ]
 dox = [ "gtk/dox" ]
-tray = [ "libappindicator", "dirs-next" ]
+tray = [ "libappindicator", "dirs" ]
 
 [build-dependencies]
 cc = "1"
@@ -115,7 +115,7 @@ gdk-sys = "0.15"
 gdkx11-sys = "0.15"
 gdk-pixbuf = { version = "0.15", features = [ "v2_36_8" ] }
 libappindicator = { version = "0.7.1", optional = true }
-dirs-next = { version = "2.0.0", optional = true }
+dirs = { version = "4.0.0", optional = true }
 x11-dl = "2.20"
 uuid = { version = "1.2", features = [ "v4" ] }
 png = "0.17"

--- a/src/platform_impl/linux/system_tray.rs
+++ b/src/platform_impl/linux/system_tray.rs
@@ -119,7 +119,7 @@ impl Drop for SystemTray {
 fn temp_icon_path(temp_icon_dir: Option<&PathBuf>) -> std::io::Result<(PathBuf, PathBuf)> {
   let parent_path = match temp_icon_dir.as_ref() {
     Some(path) => path.to_path_buf(),
-    None => dirs_next::runtime_dir()
+    None => dirs::runtime_dir()
       .unwrap_or_else(|| std::env::temp_dir())
       .join("tao"),
   };


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

deps: use [dirs](https://github.com/dirs-dev/dirs-rs) instead of [dirs-next](https://github.com/xdg-rs/dirs), seems like latter is unmaintained

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
