### PR TITLE
fix(Windows): fix build regression when tray feature is used

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -1,7 +1,9 @@
 {
   "gitSiteUrl": "https://github.com/tauri-apps/tao/",
   "timeout": 3600000,
-  "additionalBumpTypes": ["housekeeping"],
+  "additionalBumpTypes": [
+    "housekeeping"
+  ],
   "pkgManagers": {
     "rust": {
       "version": true,
@@ -35,7 +37,7 @@
       ],
       "publish": [
         {
-          "command": "cargo package --allow-dirty",
+          "command": "cargo package --allow-dirty --features tray",
           "dryRunCommand": true
         },
         {

--- a/.changes/fix-compile-regression.md
+++ b/.changes/fix-compile-regression.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+On Windows, fix compliation regression introduced in 0.15.1 when `tray` feature is active

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -97,6 +97,8 @@ impl DeviceId {
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum OsError {
+  #[allow(unused)]
+  CreationError(&'static str),
   IoError(std::io::Error),
 }
 impl std::error::Error for OsError {}
@@ -104,6 +106,7 @@ impl std::error::Error for OsError {}
 impl std::fmt::Display for OsError {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
+      OsError::CreationError(e) => f.pad(e),
       OsError::IoError(e) => f.pad(&e.to_string()),
     }
   }

--- a/src/platform_impl/windows/system_tray.rs
+++ b/src/platform_impl/windows/system_tray.rs
@@ -259,7 +259,7 @@ unsafe extern "system" fn tray_subclass_proc(
   let mut subclass_input = &mut *(subclass_input_ptr);
 
   if msg == WM_DESTROY {
-    Box::from_raw(subclass_input_ptr);
+    drop(Box::from_raw(subclass_input_ptr));
   }
 
   if msg == WM_USER_UPDATE_TRAYMENU {


### PR DESCRIPTION
regression was introduced in [ae06c3e2](https://github.com/tauri-apps/tao/commit/ae06c3e2806b85a9baa10b84c898cd0c15af7de4)

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
