### PR TITLE
On macOS, call next responder in view's keyDown and doCommandbySelector

### DIFF
--- a/.changes/responder.md
+++ b/.changes/responder.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On macOS, call next responder in view's keyDown and doCommandbySelector.

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -206,6 +206,10 @@ lazy_static! {
       first_rect_for_character_range as extern "C" fn(&Object, Sel, NSRange, *mut c_void) -> NSRect,
     );
     decl.add_method(
+      sel!(doCommandBySelector:),
+      do_command_by_selector as extern "C" fn(&Object, Sel, Sel),
+    );
+    decl.add_method(
       sel!(keyDown:),
       key_down as extern "C" fn(&mut Object, Sel, id),
     );
@@ -567,6 +571,54 @@ extern "C" fn insert_text(this: &Object, _sel: Sel, string: id, _replacement_ran
     }
   }
   trace!("Completed `insertText`");
+}
+
+extern "C" fn do_command_by_selector(this: &Object, _sel: Sel, command: Sel) {
+  trace!("Triggered `doCommandBySelector`");
+  // TODO: (Artur) all these inputs seem to trigger a key event with the correct text
+  // content so this is not needed anymore, it seems.
+
+  // Basically, we're sent this message whenever a keyboard event that doesn't generate a "human readable" character
+  // happens, i.e. newlines, tabs, and Ctrl+C.
+
+  // unsafe {
+  //     let state_ptr: *mut c_void = *this.get_ivar("taoState");
+  //     let state = &mut *(state_ptr as *mut ViewState);
+
+  //     let mut events = VecDeque::with_capacity(1);
+  //     if command == sel!(insertNewline:) {
+  //         // The `else` condition would emit the same character, but I'm keeping this here both...
+  //         // 1) as a reminder for how `doCommandBySelector` works
+  //         // 2) to make our use of carriage return explicit
+  //         events.push_back(EventWrapper::StaticEvent(Event::WindowEvent {
+  //             window_id: WindowId(get_window_id(state.ns_window)),
+  //             event: WindowEvent::ReceivedCharacter('\r'),
+  //         }));
+  //     } else {
+  //         let raw_characters = state.raw_characters.take();
+  //         if let Some(raw_characters) = raw_characters {
+  //             for character in raw_characters
+  //                 .chars()
+  //                 .filter(|c| !is_corporate_character(*c))
+  //             {
+  //                 events.push_back(EventWrapper::StaticEvent(Event::WindowEvent {
+  //                     window_id: WindowId(get_window_id(state.ns_window)),
+  //                     event: WindowEvent::ReceivedCharacter(character),
+  //                 }));
+  //             }
+  //         }
+  //     };
+  //     AppState::queue_events(events);
+  // }
+
+  unsafe {
+    let responder: id = msg_send![this, nextResponder];
+    if !responder.is_null() {
+      let () = msg_send![responder, doCommandBySelector: command];
+    }
+  }
+
+  trace!("Completed `doCommandBySelector`");
 }
 
 // Get characters

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -695,6 +695,11 @@ extern "C" fn key_down(this: &mut Object, _sel: Sel, event: id) {
       },
     };
     AppState::queue_event(EventWrapper::StaticEvent(window_event));
+
+    let responder: id = msg_send![this, nextResponder];
+    if !responder.is_null() {
+      let () = msg_send![responder, keyDown: event];
+    }
   }
   trace!("Completed `keyDown`");
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
fix https://github.com/tauri-apps/tauri/issues/5592#issuecomment-1312756976