### PR TITLE
Gtk: wake the main context in EventLoopProxy::send_event(), closes #625

### DIFF
--- a/.changes/loop-proxy.md
+++ b/.changes/loop-proxy.md
@@ -1,0 +1,6 @@
+---
+"tao": patch
+---
+
+On Linux, wake the main context in `EventLoopProxy::send_event()`.
+

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -1088,7 +1088,12 @@ impl<T: 'static> EventLoopProxy<T> {
         } else {
           unreachable!();
         }
-      })
+      })?;
+
+      let context = MainContext::default();
+      context.wakeup();
+
+      Ok(())
   }
 }
 

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -1090,10 +1090,10 @@ impl<T: 'static> EventLoopProxy<T> {
         }
       })?;
 
-      let context = MainContext::default();
-      context.wakeup();
+    let context = MainContext::default();
+    context.wakeup();
 
-      Ok(())
+    Ok(())
   }
 }
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [X] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

See #625 and my comments in https://github.com/tauri-apps/tauri/issues/3654