### PR TITLE
fix(Windows): retain `WS_MAXIMIZE` when unminimizing a maximized window, closes #622

### DIFF
--- a/.changes/fix-un-minimining-maximized.md
+++ b/.changes/fix-un-minimining-maximized.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+On Windows, retain `WS_MAXIMIZE` window style when unminimizing a maximized window.

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -7,7 +7,7 @@
 use tao::{
   dpi::{LogicalSize, PhysicalSize},
   event::{DeviceEvent, ElementState, Event, KeyEvent, RawKeyEvent, WindowEvent},
-  event_loop::{ControlFlow, EventLoop},
+  event_loop::{ControlFlow, DeviceEventFilter, EventLoop},
   keyboard::{Key, KeyCode},
   window::{Fullscreen, WindowBuilder},
 };
@@ -17,6 +17,7 @@ use tao::{
 fn main() {
   env_logger::init();
   let event_loop = EventLoop::new();
+  event_loop.set_device_event_filter(DeviceEventFilter::Never);
 
   let window = WindowBuilder::new()
     .with_title("A fantastic window!")
@@ -62,6 +63,7 @@ fn main() {
         KeyCode::KeyM => {
           if window.is_minimized() {
             window.set_minimized(false);
+            window.set_focus()
           }
         }
         KeyCode::KeyV => {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1197,12 +1197,16 @@ unsafe fn public_window_callback_inner<T: 'static>(
       {
         let mut w = subclass_input.window_state.lock();
         // See WindowFlags::MARKER_RETAIN_STATE_ON_SIZE docs for info on why this `if` check exists.
-        if !w
-          .window_flags()
-          .contains(WindowFlags::MARKER_RETAIN_STATE_ON_SIZE)
-        {
+        let window_flags = w.window_flags();
+        if !window_flags.contains(WindowFlags::MARKER_RETAIN_STATE_ON_SIZE) {
           let maximized = wparam.0 == win32wm::SIZE_MAXIMIZED as _;
-          w.set_window_flags_in_place(|f| f.set(WindowFlags::MAXIMIZED, maximized));
+          let minimized = wparam.0 == win32wm::SIZE_MINIMIZED as _;
+          let was_maximized = window_flags.contains(WindowFlags::MAXIMIZED);
+
+          w.set_window_flags_in_place(|f| {
+            f.set(WindowFlags::MAXIMIZED, maximized);
+            f.set(WindowFlags::MARKER_WAS_MAXIMIZED, minimized & was_maximized)
+          });
         }
       }
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -106,6 +106,12 @@ bitflags! {
 
         const MARKER_DONT_FOCUS = 1 << 20;
 
+         /// When minmizing a maximized Windows, `WM_SIZE` which we use to update the `MAXIMIZED` bit
+        /// is fired with `wparam` set to `SIZE_MINIMIZED` and thus the `MAXIMIZED` bit will be unset
+        /// and when un-minimizing the window, the `MAXIMIZED` bit will still be unset and later on
+        /// in `apply_diff` when `new.to_window_styles()` is called, it will not add `WS_MAXIMIZE` window style.
+        const MARKER_WAS_MAXIMIZED = 1 << 21;
+
         const EXCLUSIVE_FULLSCREEN_OR_MASK = WindowFlags::ALWAYS_ON_TOP.bits;
     }
 }
@@ -385,7 +391,7 @@ impl WindowFlags {
     }
 
     if diff != WindowFlags::empty() {
-      let (style, style_ex) = new.to_window_styles();
+      let (mut style, style_ex) = new.to_window_styles();
 
       unsafe {
         SendMessageW(
@@ -397,6 +403,10 @@ impl WindowFlags {
 
         // This condition is necessary to avoid having an unrestorable window
         if !new.contains(WindowFlags::MINIMIZED) {
+          if self.contains(WindowFlags::MARKER_WAS_MAXIMIZED) {
+            style |= WS_MAXIMIZE;
+          }
+
           SetWindowLongW(window, GWL_STYLE, style.0 as i32);
           SetWindowLongW(window, GWL_EXSTYLE, style_ex.0 as i32);
         }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
