### PR TITLE
feat: switch android_fn! to a proc_macro

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -78,6 +78,10 @@
     "tao": {
       "path": "./",
       "manager": "rust"
+    },
+    "tao-macros": {
+      "path": "./tao-macros",
+      "manager": "rust"
     }
   }
 }

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,8 +6,8 @@ on:
     - cron: '0 0 * * *'
   push:
     paths:
-      - "Cargo.lock"
-      - "Cargo.toml"
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
 
 jobs:
   audit-rust:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          target: ${{ matrix.platform.target }}
-          toolchain: ${{ matrix.rust_version }}
+          toolchain: stable
 
       - name: Run tests
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,26 @@ jobs:
           !contains(matrix.platform.target, 'ios'))
         run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,tray,$FEATURES
 
+  test_tao_macros:
+    runs-on: ${{ matrix.platform.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache cargo folder
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo
+          key: ${{ matrix.platform.target }}-cargo-${{ matrix.rust_version }}
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          toolchain: ${{ matrix.rust_version }}
+
+      - name: Run tests
+        shell: bash
+        run: cargo test
+
   fmt:
     name: fmt check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Run tests
         shell: bash
-        run: cargo test
+        run: cargo test --package tao-macros
 
   fmt:
     name: fmt check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,tray,$FEATURES
 
   test_tao_macros:
-    runs-on: ${{ matrix.platform.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ repository = "https://github.com/tauri-apps/tao"
 documentation = "https://docs.rs/tao"
 categories = [ "gui" ]
 
+[workspace]
+members = [ "tao-macros" ]
+
 [package.metadata.docs.rs]
 features = [ "serde", "tray", "dox" ]
 default-target = "x86_64-unknown-linux-gnu"
@@ -54,7 +57,7 @@ ndk = "0.6"
 ndk-sys = "0.3"
 ndk-context = "0.1"
 once_cell = "1"
-paste = "1.0"
+tao-macros = { version = "0.0.0", path = "./tao-macros" }
 
 [target."cfg(any(target_os = \"ios\", target_os = \"macos\"))".dependencies]
 objc = "0.2"

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -42,7 +42,7 @@ fn main() {
       }
       Event::MainEventsCleared => {
         if let Some(w) = &window {
-          // w.request_redraw();
+          w.request_redraw();
         }
       }
       _ => (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,9 @@
 )]
 #![deny(rustdoc::broken_intra_doc_links)]
 
+#[cfg(target_os = "android")]
+pub use tao_macros::{android_fn, generate_package_name};
+
 use std::{
   collections::hash_map::DefaultHasher,
   hash::{Hash, Hasher},

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -487,7 +487,7 @@ impl<T: 'static> EventLoopWindowTarget<T> {
   }
 
   #[inline]
-  pub fn monitor_from_point(&self, x: f64, y: f64) -> Option<MonitorHandle> {
+  pub fn monitor_from_point(&self, _x: f64, _y: f64) -> Option<MonitorHandle> {
     warn!("`Window::monitor_from_point` is ignored on Android");
     return None;
   }
@@ -553,7 +553,7 @@ impl Window {
   }
 
   #[inline]
-  pub fn monitor_from_point(&self, x: f64, y: f64) -> Option<monitor::MonitorHandle> {
+  pub fn monitor_from_point(&self, _x: f64, _y: f64) -> Option<monitor::MonitorHandle> {
     warn!("`Window::monitor_from_point` is ignored on Android");
     None
   }

--- a/src/platform_impl/android/ndk_glue.rs
+++ b/src/platform_impl/android/ndk_glue.rs
@@ -24,57 +24,36 @@ use std::{
   thread,
 };
 
+// pub static PACKAGE: OnceCell<&str> = OnceCell::new();
+pub static PACKAGE: OnceCell<&str> = OnceCell::new();
+
 #[macro_export]
 macro_rules! android_binding {
   ($domain:ident, $package:ident, $setup: ident, $main: ident) => {
-    paste::paste! {
-        #[no_mangle]
-        unsafe extern "C" fn [< Java_ $domain _ $package _ TauriActivity_create >](
-          env: JNIEnv,
-          class: JClass,
-          object: JObject,
-        ) {
-            let domain = stringify!($domain).replace("_", "/");
-            let package = format!("{}/{}", domain, stringify!($package).replace("_1","_"));
-            PACKAGE.get_or_init(move || package);
-            create(env, class, object, $setup, $main)
-        }
-
-        android_fn!($domain, $package, TauriActivity, start);
-        android_fn!($domain, $package, TauriActivity, stop);
-        android_fn!($domain, $package, TauriActivity, resume);
-        android_fn!($domain, $package, TauriActivity, pause);
-        android_fn!($domain, $package, TauriActivity, save);
-        android_fn!($domain, $package, TauriActivity, destroy);
-        android_fn!($domain, $package, TauriActivity, memory);
-        android_fn!($domain, $package, TauriActivity, focus, i32);
+    fn __store_package_name__() {
+      PACKAGE.get_or_init(move || generate_package_name!($domain, $package));
     }
+
+    android_fn!(
+      $domain,
+      $package,
+      TauriActivity,
+      create,
+      [JObject],
+      __VOID__,
+      [$setup, $main],
+      __store_package_name__,
+    );
+    android_fn!($domain, $package, TauriActivity, start, [JObject]);
+    android_fn!($domain, $package, TauriActivity, stop, [JObject]);
+    android_fn!($domain, $package, TauriActivity, resume, [JObject]);
+    android_fn!($domain, $package, TauriActivity, pause, [JObject]);
+    android_fn!($domain, $package, TauriActivity, save, [JObject]);
+    android_fn!($domain, $package, TauriActivity, destroy, [JObject]);
+    android_fn!($domain, $package, TauriActivity, memory, [JObject]);
+    android_fn!($domain, $package, TauriActivity, focus, [i32]);
   };
 }
-
-#[macro_export]
-macro_rules! android_fn {
-  ($domain:ident, $package:ident, $class:ident, $function:ident) => {
-    android_fn!($domain, $package, $class, $function, JObject)
-  };
-  ($domain:ident, $package:ident, $class:ident, $function:ident, $arg:ty) => {
-    android_fn!($domain, $package, $class, $function, $arg, ())
-  };
-  ($domain:ident, $package:ident, $class:ident, $function:ident, $arg:ty, $ret: ty) => {
-    paste::paste! {
-        #[no_mangle]
-        unsafe extern "C" fn [< Java_ $domain _ $package _ $class _ $function >](
-          env: JNIEnv,
-          class: JClass,
-          object: $arg,
-        ) -> $ret {
-            $function(env, class, object)
-        }
-    }
-  };
-}
-
-pub static PACKAGE: OnceCell<String> = OnceCell::new();
 
 /// `ndk-glue` macros register the reading end of an event pipe with the
 /// main [`ThreadLooper`] under this `ident`.

--- a/tao-macros/Cargo.toml
+++ b/tao-macros/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "tao-macros"
+description = "Proc macros for tao"
+version = "0.0.0"
+edition = "2021"
+authors = ["Tauri Programme within The Commons Conservancy"]
+rust-version = "1.56"
+license = "MIT OR Apache-2.0"
+readme = "../README.md"
+repository = "https://github.com/tauri-apps/tao"
+documentation = "https://docs.rs/tao-macros"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "1", features = ["full"] }

--- a/tao-macros/examples/android_fn.rs
+++ b/tao-macros/examples/android_fn.rs
@@ -3,12 +3,12 @@ use tao_macros::android_fn;
 struct JNIEnv;
 struct JClass;
 
-android_fn![com_example, tauri_app, SomeClass, add, [i32, i32], i32];
+android_fn![com_example, tao_app, SomeClass, add, [i32, i32], i32];
 unsafe fn add(_env: JNIEnv, _class: JClass, a: i32, b: i32) -> i32 {
   a + b
 }
 
-android_fn!(com_example, tauri_app, SomeClass, add2, [i32, i32]);
+android_fn!(com_example, tao_app, SomeClass, add2, [i32, i32]);
 unsafe fn add2(_env: JNIEnv, _class: JClass, a: i32, b: i32) {
   let _ = a + b;
 }
@@ -17,7 +17,7 @@ fn __store_package_name__() {}
 
 android_fn!(
   com_example,
-  tauri_app,
+  tao_app,
   SomeClass,
   add3,
   [i32, i32],

--- a/tao-macros/examples/android_fn.rs
+++ b/tao-macros/examples/android_fn.rs
@@ -1,0 +1,33 @@
+use tao_macros::android_fn;
+
+struct JNIEnv;
+struct JClass;
+
+android_fn![com_example, tauri_app, SomeClass, add, [i32, i32], i32];
+unsafe fn add(_env: JNIEnv, _class: JClass, a: i32, b: i32) -> i32 {
+  a + b
+}
+
+android_fn!(com_example, tauri_app, SomeClass, add2, [i32, i32]);
+unsafe fn add2(_env: JNIEnv, _class: JClass, a: i32, b: i32) {
+  let _ = a + b;
+}
+
+fn __store_package_name__() {}
+
+android_fn!(
+  com_example,
+  tauri_app,
+  SomeClass,
+  add3,
+  [i32, i32],
+  __VOID__,
+  [setup, main],
+  __store_package_name__,
+);
+unsafe fn add3(_env: JNIEnv, _class: JClass, a: i32, b: i32, _setup: fn(), _main: fn()) {
+  let _ = a + b;
+}
+
+fn setup() {}
+fn main() {}

--- a/tao-macros/examples/generate_package_name.rs
+++ b/tao-macros/examples/generate_package_name.rs
@@ -1,5 +1,5 @@
 use tao_macros::generate_package_name;
 
-pub const PACKAGE: &str = generate_package_name!(com_example, tauri_app);
+pub const PACKAGE: &str = generate_package_name!(com_example, tao_app);
 
 fn main() {}

--- a/tao-macros/examples/generate_package_name.rs
+++ b/tao-macros/examples/generate_package_name.rs
@@ -1,0 +1,5 @@
+use tao_macros::generate_package_name;
+
+pub const PACKAGE: &str = generate_package_name!(com_example, tauri_app);
+
+fn main() {}

--- a/tao-macros/src/lib.rs
+++ b/tao-macros/src/lib.rs
@@ -1,0 +1,186 @@
+use proc_macro::TokenStream;
+use quote::{format_ident, quote, ToTokens};
+use syn::{
+  bracketed,
+  parse::{Parse, ParseStream},
+  parse_macro_input,
+  punctuated::Punctuated,
+  token::Comma,
+  Ident, LitStr, Token, Type,
+};
+
+struct AndroidFnInput {
+  domain: Ident,
+  package: Ident,
+  class: Ident,
+  function: Ident,
+  args: Punctuated<Type, Comma>,
+  non_jni_args: Punctuated<Ident, Comma>,
+  ret: Option<Type>,
+  function_before: Option<Ident>,
+}
+
+struct IdentArgPair(syn::Ident, syn::Type);
+
+impl ToTokens for IdentArgPair {
+  fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+    let ident = &self.0;
+    let type_ = &self.1;
+    let tok = quote! {
+      #ident: #type_
+    };
+    tokens.extend([tok]);
+  }
+}
+
+impl Parse for AndroidFnInput {
+  fn parse(input: ParseStream) -> syn::Result<Self> {
+    let domain: Ident = input.parse()?;
+    let _: Comma = input.parse()?;
+    let package: Ident = input.parse()?;
+    let _: Comma = input.parse()?;
+    let class: Ident = input.parse()?;
+    let _: Comma = input.parse()?;
+    let function: Ident = input.parse()?;
+    let _: Comma = input.parse()?;
+    let args;
+    let _: syn::token::Bracket = bracketed!(args in input);
+    let args = args.parse_terminated::<Type, Token![,]>(Type::parse)?;
+    let _: syn::Result<Comma> = input.parse();
+    let ret = if input.peek(Ident) {
+      let ret = input.parse::<Type>()?;
+      if ret.to_token_stream().to_string() == "__VOID__" {
+        None
+      } else {
+        Some(ret)
+      }
+    } else {
+      None
+    };
+
+    let non_jni_args = if input.peek2(syn::token::Bracket) {
+      let _: syn::Result<Comma> = input.parse();
+
+      let non_jni_args;
+      let _: syn::token::Bracket = bracketed!(non_jni_args in input);
+      let non_jni_args = non_jni_args.parse_terminated::<Ident, Token![,]>(Ident::parse)?;
+      let _: syn::Result<Comma> = input.parse();
+      non_jni_args
+    } else {
+      Punctuated::new()
+    };
+
+    let function_before = if input.peek(Ident) {
+      let function: Ident = input.parse()?;
+      let _: syn::Result<Comma> = input.parse();
+      Some(function)
+    } else {
+      None
+    };
+    Ok(Self {
+      domain,
+      package,
+      class,
+      function,
+      ret,
+      args,
+      non_jni_args,
+      function_before,
+    })
+  }
+}
+
+#[proc_macro]
+pub fn android_fn(tokens: TokenStream) -> TokenStream {
+  let tokens = parse_macro_input!(tokens as AndroidFnInput);
+  let AndroidFnInput {
+    domain,
+    package,
+    class,
+    function,
+    ret,
+    args,
+    non_jni_args,
+    function_before,
+  } = tokens;
+
+  let domain = domain.to_string();
+  let package = package
+    .to_string()
+    .replace("_", "_1")
+    //  TODO: is this what we want? should we remove it instead?
+    .replace("-", "_1");
+  let class = class.to_string();
+  let args = args
+    .into_iter()
+    .enumerate()
+    .map(|(i, t)| IdentArgPair(format_ident!("a_{}", i), t))
+    .collect::<Vec<_>>();
+  let non_jni_args = non_jni_args.into_iter().collect::<Vec<_>>();
+
+  let java_fn_name = format_ident!(
+    "Java_{domain}_{package}_{class}_{function}",
+    domain = domain,
+    package = package,
+    class = class,
+    function = function,
+  );
+
+  let args_ = args.iter().map(|a| &a.0);
+
+  let ret = if let Some(ret) = ret {
+    syn::ReturnType::Type(
+      syn::token::RArrow(proc_macro2::Span::call_site()),
+      Box::new(ret),
+    )
+  } else {
+    syn::ReturnType::Default
+  };
+
+  quote! {
+    #[no_mangle]
+    unsafe extern "C" fn #java_fn_name(
+      env: JNIEnv,
+      class: JClass,
+      #(#args),*
+    )  #ret {
+      #function_before();
+      #function(env, class, #(#args_),*, #(#non_jni_args),*)
+    }
+
+  }
+  .into()
+}
+
+struct GeneratePackageNameInput {
+  domain: Ident,
+  package: Ident,
+}
+
+impl Parse for GeneratePackageNameInput {
+  fn parse(input: ParseStream) -> syn::Result<Self> {
+    let domain: Ident = input.parse()?;
+    let _: Comma = input.parse()?;
+    let package: Ident = input.parse()?;
+    let _: syn::Result<Comma> = input.parse();
+
+    Ok(Self { domain, package })
+  }
+}
+
+#[proc_macro]
+pub fn generate_package_name(tokens: TokenStream) -> TokenStream {
+  let tokens = parse_macro_input!(tokens as GeneratePackageNameInput);
+  let GeneratePackageNameInput { domain, package } = tokens;
+
+  let domain = domain.to_string().replace("_", "/");
+  let package = package
+    .to_string()
+    //  TODO: is this what we want? should we remove it instead?
+    .replace("-", "_");
+
+  let path = format!("{}/{}", domain, package);
+  let litstr = LitStr::new(&path, proc_macro2::Span::call_site());
+
+  quote! {#litstr}.into()
+}

--- a/tao-macros/src/lib.rs
+++ b/tao-macros/src/lib.rs
@@ -97,7 +97,7 @@ impl Parse for AndroidFnInput {
 /// - The third parameter is the Java/Kotlin class name.
 /// - The fourth parameter is the rust function name (`ident`).
 /// - The fifth parameter is a list of extra types your Rust function expects
-/// (Note that all rust functions should expect the first two parameters to be [`JNIEnv`](https://docs.rs/jni/latest/jni/struct.JNIEnv.html) and [`JClass`](https://docs.rs/jni/latest/jni/objects/struct.JClass.html)).
+/// (Note that all rust functions should expect the first two parameters to be [`JNIEnv`](https://docs.rs/jni/latest/jni/struct.JNIEnv.html) and [`JClass`](https://docs.rs/jni/latest/jni/objects/struct.JClass.html) so make sure they are imported into scope).
 /// - The fifth parameter is the return type of your rust function.
 /// This is optional but if you want to use the next parameter you need to provide a type
 /// or just pass `__VOID__` if the function doesn't return anything.
@@ -107,6 +107,10 @@ impl Parse for AndroidFnInput {
 /// ## Example
 ///
 /// ```
+/// # use tao_macros::android_fn;
+/// # struct JNIEnv;
+/// # struct JClass;
+///
 /// android_fn![com_example, tao, OperationsClass, add, [i32, i32], i32];
 /// unsafe fn add(_env: JNIEnv, _class: JClass, a: i32, b: i32) -> i32 {
 ///   a + b
@@ -114,6 +118,8 @@ impl Parse for AndroidFnInput {
 /// ```
 /// which will expand into:
 /// ```
+/// # struct JNIEnv;
+/// # struct JClass;
 /// #[no_mangle]
 /// unsafe extern "C" fn Java_com_example_tao_OperationsClass_add(
 ///   env: JNIEnv,
@@ -221,15 +227,19 @@ impl Parse for GeneratePackageNameInput {
 /// ## Example
 ///
 /// ```
+/// # use tao_macros::generate_package_name;
+///
 /// const PACKAGE_NAME: &str = generate_package_name!(com_example, tao_app);
 /// ```
 /// which can be used later on with JNI:
 /// ```
-/// # find_my_class(env: i32, activity: i32, package: String) {}
+/// # use tao_macros::generate_package_name;
+/// # fn find_my_class(env: i32, activity: i32, package: String) -> Result<(), ()> { Ok(()) }
 /// # let env = 0;
 /// # let activity = 0;
+///
 /// const PACKAGE_NAME: &str = generate_package_name!(com_example, tao_app); // constructs `com/example/tao_app`
-/// let ipc_class = find_my_class(env, activity, format!("{}/Ipc", PACKAGE_NAME))?;
+/// let ipc_class = find_my_class(env, activity, format!("{}/Ipc", PACKAGE_NAME)).unwrap();
 /// ```
 #[proc_macro]
 pub fn generate_package_name(tokens: TokenStream) -> TokenStream {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

This is rewrite was due to happen soon and it allows us to:
1. handle `_` in package name and escape it properly, instead of relying on users to pass it escaped.
2. support variadic arguments to functions (encountered while implementing https://github.com/tauri-apps/wry/issues/804)
