### PR TITLE
On macOS, fix resize event emits before fullscreen actually exit

### DIFF
--- a/.changes/mac-fullscreen-resize.md
+++ b/.changes/mac-fullscreen-resize.md
@@ -1,0 +1,6 @@
+---
+"tao": patch
+---
+
+Fix resize event emits before fullscreen actually exit.
+

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -335,7 +335,18 @@ extern "C" fn window_will_close(this: &Object, _: Sel, _: id) {
 extern "C" fn window_did_resize(this: &Object, _: Sel, _: id) {
   trace!("Triggered `windowDidResize:`");
   with_state(this, |state| {
-    if !state.is_checking_zoomed_in {
+    // If window is entering/exiting, resize and move event will be emitted in
+    // window_did_enter_fullscreen & window_did_exit_fullscreen.
+    let in_fullscreen_transition = state
+      .with_window(|window| {
+        trace!("Locked shared state in `window_did_resize`");
+        let shared_state = window.shared_state.lock().unwrap();
+        trace!("Unlocked shared state in `window_did_resize`");
+        shared_state.in_fullscreen_transition
+      })
+      .unwrap_or(false);
+
+    if !state.is_checking_zoomed_in && !in_fullscreen_transition {
       state.emit_resize_event();
       state.emit_move_event();
     }
@@ -572,6 +583,8 @@ extern "C" fn window_did_enter_fullscreen(this: &Object, _: Sel, _: id) {
         window.set_fullscreen(target_fullscreen);
       }
     });
+    state.emit_resize_event();
+    state.emit_move_event();
   });
   trace!("Completed `windowDidEnterFullscreen:`");
 }
@@ -591,7 +604,9 @@ extern "C" fn window_did_exit_fullscreen(this: &Object, _: Sel, _: id) {
       if let Some(target_fullscreen) = target_fullscreen {
         window.set_fullscreen(target_fullscreen);
       }
-    })
+    });
+    state.emit_resize_event();
+    state.emit_move_event();
   });
   trace!("Completed `windowDidExitFullscreen:`");
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve https://github.com/tauri-apps/tauri/issues/4519
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

