### PR TITLE
refactor(Windows): remove `MARKER_WAS_MAXIMIZED`

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1197,16 +1197,12 @@ unsafe fn public_window_callback_inner<T: 'static>(
       {
         let mut w = subclass_input.window_state.lock();
         // See WindowFlags::MARKER_RETAIN_STATE_ON_SIZE docs for info on why this `if` check exists.
-        let window_flags = w.window_flags();
-        if !window_flags.contains(WindowFlags::MARKER_RETAIN_STATE_ON_SIZE) {
+        if !w
+          .window_flags()
+          .contains(WindowFlags::MARKER_RETAIN_STATE_ON_SIZE)
+        {
           let maximized = wparam.0 == win32wm::SIZE_MAXIMIZED as _;
-          let minimized = wparam.0 == win32wm::SIZE_MINIMIZED as _;
-          let was_maximized = window_flags.contains(WindowFlags::MAXIMIZED);
-
-          w.set_window_flags_in_place(|f| {
-            f.set(WindowFlags::MAXIMIZED, maximized);
-            f.set(WindowFlags::MARKER_WAS_MAXIMIZED, minimized & was_maximized)
-          });
+          w.set_window_flags_in_place(|f| f.set(WindowFlags::MAXIMIZED, maximized));
         }
       }
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

