### PR TITLE
fix(macOS): icon_is_template isn't apply when set

### DIFF
--- a/.changes/updateIconIsTemplateWhenSet.md
+++ b/.changes/updateIconIsTemplateWhenSet.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix set_icon_is_template isn't apply the change to system 

--- a/src/platform_impl/macos/system_tray.rs
+++ b/src/platform_impl/macos/system_tray.rs
@@ -141,6 +141,7 @@ impl SystemTray {
 
   pub fn set_icon_as_template(mut self, is_template: bool) {
     self.icon_is_template = is_template;
+    self.create_button_with_icon();
   }
 
   pub fn set_menu(&mut self, tray_menu: &Menu) {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve tauri-apps/tauri#6240
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

