### PR TITLE
fix(macos): retain and release NSMenu manually

### DIFF
--- a/.changes/menu-no-autorelease.md
+++ b/.changes/menu-no-autorelease.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Retain NSMenu reference instead of autoreleasing it.

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -122,10 +122,19 @@ impl Default for Menu {
   }
 }
 
+impl Drop for Menu {
+  fn drop(&mut self) {
+    unsafe {
+      let _: () = msg_send![self.menu, release];
+    }
+  }
+}
+
 impl Menu {
   pub fn new() -> Self {
     unsafe {
-      let menu = NSMenu::alloc(nil).autorelease();
+      let menu = NSMenu::alloc(nil);
+      let _: () = msg_send![menu, retain];
       let () = msg_send![menu, setAutoenablesItems: NO];
       Self { menu }
     }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

