### PR TITLE
fix(windows): backport default undecorated shadow to false (#690)

### DIFF
--- a/.changes/shadow.md
+++ b/.changes/shadow.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+Fix undecorated window shadow enabled by default on Windows.

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -63,7 +63,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
       drag_and_drop: true,
       preferred_theme: None,
       skip_taskbar: false,
-      decoration_shadow: true,
+      decoration_shadow: false,
     }
   }
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve #690
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information
This is a backport of an already fixed issue to tao 0.16. The reason this is needed is that currently (per tauri dev branch) transparent doesn't work on windows cause it seems like shadows are breaking transparent similar to decorations.

(I tried cherry picking but that won't really work with commit signing)
