### PR TITLE
fix: don't panic if primary monitor not discoverable.

### DIFF
--- a/.changes/linux-primary-monitor.md
+++ b/.changes/linux-primary-monitor.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Attempt to get primary monitor on linux will now return None rather than panicking if monitor not found.

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -79,9 +79,11 @@ impl<T> EventLoopWindowTarget<T> {
 
   #[inline]
   pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
-    let monitor = self.display.primary_monitor().unwrap();
-    let handle = MonitorHandle { monitor };
-    Some(RootMonitorHandle { inner: handle })
+    let monitor = self.display.primary_monitor();
+    monitor.and_then(|monitor| {
+      let handle = MonitorHandle { monitor };
+      Some(RootMonitorHandle { inner: handle })
+    })
   }
 
   pub fn raw_display_handle(&self) -> RawDisplayHandle {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve #704 
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

