### PR TITLE
refactor: remove linking to `ColorSync`

### DIFF
--- a/.changes/remove-colorsync-link.md
+++ b/.changes/remove-colorsync-link.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+On macOS, Remove linking to `ColorSync`

--- a/README.md
+++ b/README.md
@@ -77,15 +77,6 @@ sudo apt install libappindicator3-dev
 sudo apt install libayatana-appindicator3-dev
 ```
 
-#### macOS
-
-To ensure compatibility with older macOS systems, TAO links to
-CGDisplayCreateUUIDFromDisplayID through the CoreGraphics framework.
-However, under certain setups this function is only available to be linked
-through the newer ColorSync framework. So, TAO provides the
-`TAO_LINK_COLORSYNC` environment variable which can be set to `1` or `true`
-while compiling to enable linking via ColorSync.
-
 ### Acknowledgement
 
 This is a fork of [winit](https://crates.io/crates/winit) which replaces Linux's port to Gtk.

--- a/build.rs
+++ b/build.rs
@@ -3,14 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fn main() {
-  // If building for macos and TAO_LINK_COLORSYNC is set to true
-  // use CGDisplayCreateUUIDFromDisplayID from ColorSync instead of CoreGraphics
-  if std::env::var("CARGO_CFG_TARGET_OS").map_or(false, |os| os == "macos")
-    && std::env::var("TAO_LINK_COLORSYNC")
-      .map_or(false, |v| v == "1" || v.eq_ignore_ascii_case("true"))
-  {
-    println!("cargo:rustc-cfg=use_colorsync_cgdisplaycreateuuidfromdisplayid");
-  }
   // link carbon hotkey on macOS
   {
     if std::env::var("CARGO_CFG_TARGET_OS").map_or(false, |os| os == "macos") {

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -182,16 +182,7 @@ pub type CGDisplayModeRef = *mut libc::c_void;
 // directly. Fortunately, it has always been available as a subframework of
 // `ApplicationServices`, see:
 // https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/OSX_Technology_Overview/SystemFrameworks/SystemFrameworks.html#//apple_ref/doc/uid/TP40001067-CH210-BBCFFIEG
-//
-// TODO: Remove the WINIT_LINK_COLORSYNC hack, it is probably not needed.
-#[cfg_attr(
-  not(use_colorsync_cgdisplaycreateuuidfromdisplayid),
-  link(name = "ApplicationServices", kind = "framework")
-)]
-#[cfg_attr(
-  use_colorsync_cgdisplaycreateuuidfromdisplayid,
-  link(name = "ColorSync", kind = "framework")
-)]
+#[link(name = "ApplicationServices", kind = "framework")]
 extern "C" {
   pub fn CGDisplayCreateUUIDFromDisplayID(display: CGDirectDisplayID) -> CFUUIDRef;
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

