### PR TITLE
fix(windows): backport "Use SetForegroundWindow before focus hack (#719)"

### DIFF
--- a/.changes/fix-windows-focus.md
+++ b/.changes/fix-windows-focus.md
@@ -1,0 +1,5 @@
+---
+'tao': 'patch'
+---
+
+Fix set_focus not working on Windows in some situations like interactive notifications.

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1272,10 +1272,13 @@ unsafe fn taskbar_mark_fullscreen(handle: HWND, fullscreen: bool) {
 }
 
 unsafe fn force_window_active(handle: HWND) {
-  // In some situation, calling SetForegroundWindow could not bring up the window,
-  // This is a little hack which can "steal" the foreground window permission
+  // Try to focus the window without the hack first.
+  SetForegroundWindow(handle);
+
+  // In some situations, calling SetForegroundWindow could not bring up the window,
+  // This is a little hack which can "steal" the foreground window permission.
   // We only call this function in the window creation, so it should be fine.
-  // See : https://stackoverflow.com/questions/10740346/setforegroundwindow-only-working-while-visual-studio-is-open
+  // See: https://stackoverflow.com/questions/10740346/setforegroundwindow-only-working-while-visual-studio-is-open
   let alt_sc = MapVirtualKeyW(u32::from(VK_MENU.0), MAPVK_VK_TO_VSC);
 
   let mut inputs: [INPUT; 2] = mem::zeroed();


### PR DESCRIPTION
(cherry picked from commit 62db431338636dd0adafca15d636c08f68941984)

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information
See #719