### PR TITLE
fux: avoid running the focus hack if the first focus attempt succeedes

### DIFF
--- a/.changes/windows-set-foreground-short-circuit.md
+++ b/.changes/windows-set-foreground-short-circuit.md
@@ -1,0 +1,5 @@
+---
+'tao': 'patch'
+---
+
+Avoid running the focus hack code if the first attempt to set the foreground window succeeded

--- a/.changes/windows-set-foreground-short-circuit.md
+++ b/.changes/windows-set-foreground-short-circuit.md
@@ -1,5 +1,0 @@
----
-'tao': 'patch'
----
-
-Avoid running the focus hack code if the first attempt to set the foreground window succeeded

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1267,7 +1267,10 @@ unsafe fn taskbar_mark_fullscreen(handle: HWND, fullscreen: bool) {
 
 unsafe fn force_window_active(handle: HWND) {
   // Try to focus the window without the hack first.
-  SetForegroundWindow(handle);
+  let initial_try_succeeded = SetForegroundWindow(handle).as_bool();
+  if initial_try_succeeded {
+    return;
+  }
 
   // In some situations, calling SetForegroundWindow could not bring up the window,
   // This is a little hack which can "steal" the foreground window permission.

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1267,8 +1267,7 @@ unsafe fn taskbar_mark_fullscreen(handle: HWND, fullscreen: bool) {
 
 unsafe fn force_window_active(handle: HWND) {
   // Try to focus the window without the hack first.
-  let initial_try_succeeded = SetForegroundWindow(handle).as_bool();
-  if initial_try_succeeded {
+  if SetForegroundWindow(handle).as_bool() {
     return;
   }
 


### PR DESCRIPTION
We don't need to send the keystrokes or call `SetForegroundWindow` a second time if the first try succeeded.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Optimization

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.
