### PR TITLE
feat!: allow specifying android activity in binding macro

### DIFF
--- a/.changes/android-activity.md
+++ b/.changes/android-activity.md
@@ -1,0 +1,5 @@
+---
+"tao": "minor"
+---
+
+**Breaking change**: All ow specifying the android activity in `android_binding` macro.

--- a/.changes/android-activity.md
+++ b/.changes/android-activity.md
@@ -2,4 +2,4 @@
 "tao": "minor"
 ---
 
-**Breaking change**: All ow specifying the android activity in `android_binding` macro.
+**Breaking change**: All ow specifying the android activity in `android_binding` macro, instead of hard-coded `TauriActivity`.

--- a/src/platform_impl/android/ndk_glue.rs
+++ b/src/platform_impl/android/ndk_glue.rs
@@ -29,7 +29,7 @@ pub static PACKAGE: OnceCell<&str> = OnceCell::new();
 
 #[macro_export]
 macro_rules! android_binding {
-  ($domain:ident, $package:ident, $setup: ident, $main: ident) => {
+  ($domain:ident, $package:ident, $activity:ident, $setup:ident, $main:ident) => {
     fn __store_package_name__() {
       PACKAGE.get_or_init(move || generate_package_name!($domain, $package));
     }
@@ -37,21 +37,21 @@ macro_rules! android_binding {
     android_fn!(
       $domain,
       $package,
-      TauriActivity,
+      $activity,
       create,
       [JObject],
       __VOID__,
       [$setup, $main],
       __store_package_name__,
     );
-    android_fn!($domain, $package, TauriActivity, start, [JObject]);
-    android_fn!($domain, $package, TauriActivity, stop, [JObject]);
-    android_fn!($domain, $package, TauriActivity, resume, [JObject]);
-    android_fn!($domain, $package, TauriActivity, pause, [JObject]);
-    android_fn!($domain, $package, TauriActivity, save, [JObject]);
-    android_fn!($domain, $package, TauriActivity, destroy, [JObject]);
-    android_fn!($domain, $package, TauriActivity, memory, [JObject]);
-    android_fn!($domain, $package, TauriActivity, focus, [i32]);
+    android_fn!($domain, $package, $activity, start, [JObject]);
+    android_fn!($domain, $package, $activity, stop, [JObject]);
+    android_fn!($domain, $package, $activity, resume, [JObject]);
+    android_fn!($domain, $package, $activity, pause, [JObject]);
+    android_fn!($domain, $package, $activity, save, [JObject]);
+    android_fn!($domain, $package, $activity, destroy, [JObject]);
+    android_fn!($domain, $package, $activity, memory, [JObject]);
+    android_fn!($domain, $package, $activity, focus, [i32]);
   };
 }
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [x] Yes
- [ ] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

