### PR TITLE
fix(windows): fix build error on target i686-pc-windows-msvc

### DIFF
--- a/.changes/build-error-i686-pc-windows-msvc.md
+++ b/.changes/build-error-i686-pc-windows-msvc.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+Fix build error on target i686-pc-windows-msvc


### PR DESCRIPTION
Fix `error[E0793]: reference to packed field is unaligned`.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

This PR fixes Tauri 0.13 build error on target i686-pc-windows-msvc.