### PR TITLE
fix(maxOS): fix event's mouse location in drag_window after closing share dialog

### DIFF
--- a/.changes/drag-window-cursor-position.md
+++ b/.changes/drag-window-cursor-position.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On macOS, fix the unexpected shifting of the window when dragging after closing the share dialog.


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve tauri-apps/tauri#7019
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

0x15 `NSEvent` emitted when you started dragging the window after closing the share dialog. This event contains an incorrect mouse location causing unexpected window shifting.

Since 0x15 is a private `NSEventType`, it might be changed at any time, so another approach is to generate a dummy event with the current mouse location every time `drag_window` is called.

I think this is much like a workaround for a special case. If anyone has a better solution, feel free to discuss and modify the commit.