### PR TITLE
fix(macos/menu): set native image height to 18

### DIFF
--- a/.changes/macos-native-image-menu.md
+++ b/.changes/macos-native-image-menu.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+On macOS, force `NativeImage` height to be `18` to have consistent size for all icons and match custom icons.

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -110,8 +110,10 @@ impl MenuItemAttributes {
   pub fn set_native_image(&mut self, icon: NativeImage) {
     unsafe {
       let ns_image: id = icon.get_ns_image();
-      let image_ref: id = msg_send![class!(NSImage), imageNamed: ns_image];
-      let () = msg_send![self.1, setImage: image_ref];
+      let nsimage: id = msg_send![class!(NSImage), imageNamed: ns_image];
+      let size = NSSize::new(18.0, 18.0);
+      let _: () = msg_send![nsimage, setSize: size];
+      let _: () = msg_send![self.1, setImage: nsimage];
     }
   }
 }

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -109,8 +109,8 @@ impl MenuItemAttributes {
   // Available only with CustomMenuItemExtMacOS
   pub fn set_native_image(&mut self, icon: NativeImage) {
     unsafe {
-      let ns_image: id = icon.get_ns_image();
-      let nsimage: id = msg_send![class!(NSImage), imageNamed: ns_image];
+      let named_img: id = icon.get_ns_image();
+      let nsimage: id = msg_send![class!(NSImage), imageNamed: named_img];
       let size = NSSize::new(18.0, 18.0);
       let _: () = msg_send![nsimage, setSize: size];
       let _: () = msg_send![self.1, setImage: nsimage];


### PR DESCRIPTION
closes https://github.com/tauri-apps/tauri/issues/7077

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [X] This PR will resolve https://github.com/tauri-apps/tauri/issues/7077
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary
- [X] It can be built on all targets and pass CI/CD.

### Other information

