### PR TITLE
fix(android): use a crossbeam channel instead of a Mutex<VecDeque>

### DIFF
--- a/.changes/android-deadlock-fix.md
+++ b/.changes/android-deadlock-fix.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On Android, use a lockfree queue (crossbeam channel) to prevent deadlocks inside send_event.


### PR DESCRIPTION
### What kind of change does this PR introduce?
This fixes #760 by using a crossbeam channel, like its sibling iOS implementation.

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve #760
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

