### PR TITLE
fix(macOS): fix `SystemTrayEvent` not emitted after calling `set_menu`

### DIFF
--- a/.changes/macos-fix-set-tray-menu.md
+++ b/.changes/macos-fix-set-tray-menu.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On macOS, fix `SystemTrayEvent` not emitted after calling `set_menu`.

--- a/src/platform_impl/macos/system_tray.rs
+++ b/src/platform_impl/macos/system_tray.rs
@@ -145,7 +145,11 @@ impl SystemTray {
 
   pub fn set_menu(&mut self, tray_menu: &Menu) {
     unsafe {
-      self.ns_status_bar.setMenu_(tray_menu.menu);
+      self.tray_menu = Some(tray_menu.clone());
+
+      let tray_target: id = msg_send![self.ns_status_bar.button(), target];
+      (*tray_target).set_ivar("menu", tray_menu.menu);
+      let () = msg_send![tray_menu.menu, setDelegate: tray_target];
     }
   }
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve tauri-apps/tauri#7364 tauri-apps/tauri#5842
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

We didn't set the tray menu direct to `ns_status_bar`. Instead, we set it to `tray_target.menu` and let the `tray_target` attach it when we click the tray icon.
https://github.com/tauri-apps/tao/blob/731e39755a2ecca9e82a09feab0dc19498080a34/src/platform_impl/macos/system_tray.rs#L91-L98

However, when calling the `set_menu`, it sets the new menu to `ns_status_bar`, not `tray_target`. Therefore the customized click handler is not triggered
https://github.com/tauri-apps/tao/blob/731e39755a2ecca9e82a09feab0dc19498080a34/src/platform_impl/macos/system_tray.rs#L146-L150