### PR TITLE
feat(macOS): support progress bar on dock

### DIFF
--- a/.changes/implementTaskbarProgress.md
+++ b/.changes/implementTaskbarProgress.md
@@ -2,4 +2,4 @@
 "tao": minor
 ---
 
-Added APIs for setting progress bars for the application icon on Linux (Unity only) and for specific window on Windows.
+Added APIs for setting progress bars for the application icon on Linux (Unity only) and macOS, along with progress indicator for specific window on Windows.

--- a/.changes/macos-taskbar-progress.md
+++ b/.changes/macos-taskbar-progress.md
@@ -1,5 +1,0 @@
----
-"tao": minor
----
-
-On macOS, support setting progress indicator in the Dock.

--- a/.changes/macos-taskbar-progress.md
+++ b/.changes/macos-taskbar-progress.md
@@ -1,0 +1,5 @@
+---
+"tao": minor
+---
+
+On macOS, support setting progress indicator in the Dock.

--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -53,7 +53,7 @@ fn main() {
               "1" => progress = 0,
               "2" => progress = 25,
               "3" => progress = 50,
-              "4" => progress = 70,
+              "4" => progress = 75,
               "5" => progress = 100,
               _ => {}
             }

--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -1,0 +1,89 @@
+// Copyright 2014-2021 The winit contributors
+// Copyright 2021-2023 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+
+use tao::{
+  event::{ElementState, Event, KeyEvent, WindowEvent},
+  event_loop::{ControlFlow, EventLoop},
+  keyboard::{Key, ModifiersState},
+  window::{ProgressBarState, ProgressState, WindowBuilder},
+};
+
+#[allow(clippy::single_match)]
+fn main() {
+  env_logger::init();
+  let event_loop = EventLoop::new();
+
+  let window = WindowBuilder::new().build(&event_loop).unwrap();
+
+  let mut modifiers = ModifiersState::default();
+
+  eprintln!("Key mappings:");
+  eprintln!("  [1-5]: Set progress to [0%, 25%, 50%, 75%, 100%]");
+  eprintln!("  Ctrl+1: Set state to None");
+  eprintln!("  Ctrl+2: Set state to Normal");
+  eprintln!("  Ctrl+3: Set state to Indeterminate");
+  eprintln!("  Ctrl+4: Set state to Paused");
+  eprintln!("  Ctrl+5: Set state to Error");
+
+  event_loop.run(move |event, _, control_flow| {
+    *control_flow = ControlFlow::Wait;
+
+    match event {
+      Event::WindowEvent {
+        event: WindowEvent::CloseRequested,
+        ..
+      } => *control_flow = ControlFlow::Exit,
+      Event::WindowEvent { event, .. } => match event {
+        WindowEvent::ModifiersChanged(new_state) => {
+          modifiers = new_state;
+        }
+        WindowEvent::KeyboardInput {
+          event:
+            KeyEvent {
+              logical_key: Key::Character(key_str),
+              state: ElementState::Released,
+              ..
+            },
+          ..
+        } => {
+          if modifiers.is_empty() {
+            let mut progress: u64 = 0;
+            match key_str {
+              "1" => progress = 0,
+              "2" => progress = 25,
+              "3" => progress = 50,
+              "4" => progress = 70,
+              "5" => progress = 100,
+              _ => {}
+            }
+
+            window.set_progress_bar(ProgressBarState {
+              progress: Some(progress),
+              state: Some(ProgressState::Normal),
+              unity_uri: None,
+            });
+          } else if modifiers.control_key() {
+            let mut state = ProgressState::None;
+            match key_str {
+              "1" => state = ProgressState::None,
+              "2" => state = ProgressState::Normal,
+              "3" => state = ProgressState::Indeterminate,
+              "4" => state = ProgressState::Paused,
+              "5" => state = ProgressState::Error,
+              _ => {}
+            }
+
+            window.set_progress_bar(ProgressBarState {
+              progress: None,
+              state: Some(state),
+              unity_uri: None,
+            });
+          }
+        }
+        _ => {}
+      },
+      _ => {}
+    }
+  });
+}

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -265,7 +265,7 @@ impl<T> EventLoopWindowTarget<T> {
   /// - **iOS / Android:** Unsupported.
   #[inline]
   pub fn set_progress_bar(&self, _progress: ProgressBarState) {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     self.p.set_progress_bar(_progress)
   }
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -261,7 +261,6 @@ impl<T> EventLoopWindowTarget<T> {
   ///
   /// - **Windows:** Unsupported. Use the Progress Bar Function Available in Window (Windows can have different progress bars for different window)
   /// - **Linux:** Only supported desktop environments with `libunity` (e.g. GNOME).
-  /// - **macOS:** Unimplemented.
   /// - **iOS / Android:** Unsupported.
   #[inline]
   pub fn set_progress_bar(&self, _progress: ProgressBarState) {

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -37,6 +37,8 @@ use crate::{
     observer::*,
     util::{self, IdRef},
   },
+  platform_impl::set_progress_indicator,
+  window::ProgressBarState,
 };
 
 #[derive(Default)]
@@ -110,6 +112,11 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     } else {
       Err(ExternalError::Os(os_error!(super::OsError::CGError(0))))
     }
+  }
+
+  #[inline]
+  pub fn set_progress_bar(&self, progress: ProgressBarState) {
+    set_progress_indicator(progress);
   }
 }
 

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -17,6 +17,7 @@ mod keycode;
 mod menu;
 mod monitor;
 mod observer;
+mod progress_bar;
 #[cfg(feature = "tray")]
 mod system_tray;
 mod util;
@@ -38,6 +39,7 @@ pub use self::{
   keycode::{keycode_from_scancode, keycode_to_scancode},
   menu::{Menu, MenuItemAttributes},
   monitor::{MonitorHandle, VideoMode},
+  progress_bar::set_progress_indicator,
   window::{Id as WindowId, Parent, PlatformSpecificWindowBuilderAttributes, UnownedWindow},
 };
 use crate::{

--- a/src/platform_impl/macos/progress_bar.rs
+++ b/src/platform_impl/macos/progress_bar.rs
@@ -146,8 +146,8 @@ extern "C" fn draw_progress_bar(this: &Object, _: Sel, rect: NSRect) {
     // draw progress
     let state: u8 = *(this.get_ivar("state"));
     let progress_color: id = match state {
-      3 => msg_send![class!(NSColor), grayColor], // paused
-      4 => msg_send![class!(NSColor), redColor],  // error
+      x if x == ProgressState::Paused as u8 => msg_send![class!(NSColor), grayColor],
+      x if x == ProgressState::Error as u8 => msg_send![class!(NSColor), redColor],
       _ => msg_send![class!(NSColor), whiteColor],
     };
     let _: () = msg_send![progress_color, set];

--- a/src/platform_impl/macos/progress_bar.rs
+++ b/src/platform_impl/macos/progress_bar.rs
@@ -1,0 +1,156 @@
+use std::sync::Once;
+
+use cocoa::{
+  base::{id, nil},
+  foundation::{NSArray, NSPoint, NSRect, NSSize},
+};
+use objc::{
+  declare::ClassDecl,
+  runtime::{Class, Object, Sel, NO},
+};
+
+use crate::window::{ProgressBarState, ProgressState};
+
+/// Set progress indicator in the Dock.
+pub fn set_progress_indicator(progress_state: ProgressBarState) {
+  unsafe {
+    let ns_app: id = msg_send![class!(NSApplication), sharedApplication];
+    let dock_tile: id = msg_send![ns_app, dockTile];
+    if dock_tile == nil {
+      return;
+    }
+
+    // check progress indicator is already set or create new one
+    let progress_indicator: id = get_exist_progress_indicator(dock_tile)
+      .unwrap_or_else(|| create_progress_indicator(ns_app, dock_tile));
+
+    // set progress indicator state
+    if let Some(progress) = progress_state.progress {
+      let progress = progress.clamp(0, 100) as f64;
+      let _: () = msg_send![progress_indicator, setDoubleValue: progress];
+      let _: () = msg_send![progress_indicator, setHidden: NO];
+    }
+    if let Some(state) = progress_state.state {
+      let _: () = msg_send![
+        progress_indicator,
+        setHidden: matches!(state, ProgressState::None)
+      ];
+    }
+
+    let _: () = msg_send![dock_tile, display];
+  }
+}
+
+fn create_progress_indicator(ns_app: id, dock_tile: id) -> id {
+  unsafe {
+    let mut image_view: id = msg_send![dock_tile, contentView];
+    if image_view == nil {
+      // create new dock tile view with current app icon
+      let app_icon_image: id = msg_send![ns_app, applicationIconImage];
+      image_view = msg_send![class!(NSImageView), imageViewWithImage: app_icon_image];
+      let _: () = msg_send![dock_tile, setContentView: image_view];
+    }
+
+    // create custom progress indicator
+    let dock_tile_size: NSSize = msg_send![dock_tile, size];
+    let frame = NSRect::new(
+      NSPoint::new(0.0, 0.0),
+      NSSize::new(dock_tile_size.width, 15.0),
+    );
+    let progress_class = create_progress_indicator_class();
+    let progress_indicator: id = msg_send![progress_class, alloc];
+    let progress_indicator: id = msg_send![progress_indicator, initWithFrame: frame];
+    let _: () = msg_send![progress_indicator, autorelease];
+
+    // set progress indicator to the dock tile
+    let _: () = msg_send![image_view, addSubview: progress_indicator];
+
+    return progress_indicator;
+  }
+}
+
+fn get_exist_progress_indicator(dock_tile: id) -> Option<id> {
+  unsafe {
+    let content_view: id = msg_send![dock_tile, contentView];
+    if content_view == nil {
+      return None;
+    }
+    let subviews: id /* NSArray */ = msg_send![content_view, subviews];
+    if subviews == nil {
+      return None;
+    }
+
+    for idx in 0..subviews.count() {
+      let subview: id = msg_send![subviews, objectAtIndex: idx];
+
+      let is_progress_indicator: bool =
+        msg_send![subview, isKindOfClass: class!(NSProgressIndicator)];
+      if is_progress_indicator {
+        return Some(subview);
+      }
+    }
+  }
+  None
+}
+
+fn create_progress_indicator_class() -> *const Class {
+  static mut APP_CLASS: *const Class = 0 as *const Class;
+  static INIT: Once = Once::new();
+
+  INIT.call_once(|| unsafe {
+    let superclass = class!(NSProgressIndicator);
+    let mut decl = ClassDecl::new("TaoProgressIndicator", superclass).unwrap();
+
+    decl.add_method(
+      sel!(drawRect:),
+      draw_progress_bar as extern "C" fn(&Object, _, NSRect),
+    );
+
+    APP_CLASS = decl.register();
+  });
+
+  unsafe { APP_CLASS }
+}
+
+extern "C" fn draw_progress_bar(_this: &Object, _: Sel, rect: NSRect) {
+  unsafe {
+    let bar = NSRect::new(
+      NSPoint { x: 0.0, y: 0.0 },
+      NSSize {
+        width: rect.size.width,
+        height: 15.0,
+      },
+    );
+    let bar_inner = bar.inset(0.5, 0.5);
+    let mut bar_progress = bar.inset(1.0, 1.0);
+
+    // set progress width
+    let current_progress: f64 = msg_send![_this, doubleValue];
+    let normalized_progress: f64 = (current_progress / 100.0).clamp(0.0, 1.0);
+    bar_progress.size.width *= normalized_progress;
+
+    // draw outer bar
+    let white_color_alpha: id = msg_send![class!(NSColor), colorWithWhite:1.0 alpha:0.8];
+    let _: () = msg_send![white_color_alpha, set];
+    draw_rounded_rect(bar);
+
+    // draw inner bar
+    let black_color_alpha: id = msg_send![class!(NSColor), colorWithWhite:0.0 alpha:0.8];
+    let _: () = msg_send![black_color_alpha, set];
+    draw_rounded_rect(bar_inner);
+
+    // draw progress
+    let white_color: id = msg_send![class!(NSColor), whiteColor];
+    let _: () = msg_send![white_color, set];
+    draw_rounded_rect(bar_progress);
+  }
+}
+
+fn draw_rounded_rect(rect: NSRect) {
+  unsafe {
+    let raduis = rect.size.height / 2.0;
+    let bezier_path: id =
+      msg_send![class!(NSBezierPath), bezierPathWithRoundedRect:rect xRadius:raduis yRadius:raduis];
+    let _: () = msg_send![bezier_path, fill];
+  }
+}

--- a/src/platform_impl/macos/progress_bar.rs
+++ b/src/platform_impl/macos/progress_bar.rs
@@ -119,10 +119,10 @@ fn create_progress_indicator_class() -> *const Class {
 extern "C" fn draw_progress_bar(this: &Object, _: Sel, rect: NSRect) {
   unsafe {
     let bar = NSRect::new(
-      NSPoint { x: 0.0, y: 0.0 },
+      NSPoint { x: 0.0, y: 4.0 },
       NSSize {
         width: rect.size.width,
-        height: 15.0,
+        height: 8.0,
       },
     );
     let bar_inner = bar.inset(0.5, 0.5);
@@ -134,21 +134,18 @@ extern "C" fn draw_progress_bar(this: &Object, _: Sel, rect: NSRect) {
     bar_progress.size.width *= normalized_progress;
 
     // draw outer bar
-    let white_color_alpha: id = msg_send![class!(NSColor), colorWithWhite:1.0 alpha:0.8];
-    let _: () = msg_send![white_color_alpha, set];
+    let bg_color: id = msg_send![class!(NSColor), colorWithWhite:1.0 alpha:0.05];
+    let _: () = msg_send![bg_color, set];
     draw_rounded_rect(bar);
-
     // draw inner bar
-    let black_color_alpha: id = msg_send![class!(NSColor), colorWithWhite:0.0 alpha:0.8];
-    let _: () = msg_send![black_color_alpha, set];
     draw_rounded_rect(bar_inner);
 
     // draw progress
     let state: u8 = *(this.get_ivar("state"));
     let progress_color: id = match state {
-      x if x == ProgressState::Paused as u8 => msg_send![class!(NSColor), grayColor],
-      x if x == ProgressState::Error as u8 => msg_send![class!(NSColor), redColor],
-      _ => msg_send![class!(NSColor), whiteColor],
+      x if x == ProgressState::Paused as u8 => msg_send![class!(NSColor), systemYellowColor],
+      x if x == ProgressState::Error as u8 => msg_send![class!(NSColor), systemRedColor],
+      _ => msg_send![class!(NSColor), systemBlueColor],
     };
     let _: () = msg_send![progress_color, set];
     draw_rounded_rect(bar_progress);

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -34,8 +34,10 @@ use crate::{
     window_delegate::new_delegate,
     OsError,
   },
+  platform_impl::set_progress_indicator,
   window::{
-    CursorIcon, Fullscreen, Theme, UserAttentionType, WindowAttributes, WindowId as RootWindowId,
+    CursorIcon, Fullscreen, ProgressBarState, Theme, UserAttentionType, WindowAttributes,
+    WindowId as RootWindowId,
   },
 };
 use cocoa::{
@@ -1409,6 +1411,10 @@ impl UnownedWindow {
       };
       self.ns_window.setCollectionBehavior_(collection_behavior)
     }
+  }
+
+  pub fn set_progress_bar(&self, progress: ProgressBarState) {
+    set_progress_indicator(progress);
   }
 }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -891,7 +891,7 @@ impl Window {
         let taskbar_state = {
           match state {
             ProgressState::None => 0,
-            ProgressState::Intermediate => 1,
+            ProgressState::Indeterminate => 1,
             ProgressState::Normal => 2,
             ProgressState::Error => 3,
             ProgressState::Paused => 4,

--- a/src/window.rs
+++ b/src/window.rs
@@ -19,15 +19,15 @@ use crate::{
 pub use crate::icon::{BadIcon, Icon};
 
 /// Progress State
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum ProgressState {
   None,
   Normal,
   /// **Treated as Normal in linux and macOS**
   Indeterminate,
-  /// **Treated as Normal in linux and macOS**
+  /// **Treated as Normal in linux**
   Paused,
-  /// **Treated as Normal in linux and macOS**
+  /// **Treated as Normal in linux**
   Error,
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -19,14 +19,15 @@ use crate::{
 pub use crate::icon::{BadIcon, Icon};
 
 /// Progress State
+#[derive(Debug)]
 pub enum ProgressState {
   None,
   Normal,
-  /// **Treated as Normal in linux**
-  Intermediate,
-  /// **Treated as Normal in linux**
+  /// **Treated as Normal in linux and macOS**
+  Indeterminate,
+  /// **Treated as Normal in linux and macOS**
   Paused,
-  /// **Treated as Normal in linux**
+  /// **Treated as Normal in linux and macOS**
   Error,
 }
 
@@ -1078,7 +1079,8 @@ impl Window {
       target_os = "dragonfly",
       target_os = "freebsd",
       target_os = "netbsd",
-      target_os = "openbsd"
+      target_os = "openbsd",
+      target_os = "macos",
     ))]
     self.window.set_progress_bar(progress)
   }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1085,8 +1085,7 @@ impl Window {
   ///
   /// ## Platform-specific
   ///
-  /// - **Linux**: Progress bar is app-wide and not specific to this window. Only supported desktop environments with `libunity` (e.g. GNOME).
-  /// - **macOS**: Unimplemented.
+  /// - **Linux / macOS**: Progress bar is app-wide and not specific to this window. Only supported desktop environments with `libunity` (e.g. GNOME).
   /// - **iOS / Android:** Unsupported.
   #[inline]
   pub fn set_progress_bar(&self, progress: ProgressBarState) {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

#### Implement `macOS` functionality for #418 

On macOS, it didn't provide a simple API to set the progress indicator. Instead, we had to create an `NSProgressIndicator` and attach it to the dock tile.

Also, I found the original `ProgressState::Intermediate` might be a typo. It should be `Indeterminate`.
https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-itaskbarlist3-setprogressstate