### PR TITLE
feat(windows): allow setting window class name, closes #769

### DIFF
--- a/.changes/windows-window-class-name.md
+++ b/.changes/windows-window-class-name.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+Add `WindowBuilderExtWindows::with_window_classname` to set the name of the window class created/used to create windows.

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -231,6 +231,9 @@ pub trait WindowBuilderExtWindows {
   /// Whether to create the window icon with the taskbar icon or not.
   fn with_skip_taskbar(self, skip: bool) -> WindowBuilder;
 
+  /// Customize the window class name.
+  fn with_window_classname<S: Into<String>>(self, classname: S) -> WindowBuilder;
+
   /// Shows or hides the background drop shadow for undecorated windows.
   ///
   /// The shadow is hidden by default.
@@ -281,6 +284,12 @@ impl WindowBuilderExtWindows for WindowBuilder {
   #[inline]
   fn with_skip_taskbar(mut self, skip: bool) -> WindowBuilder {
     self.platform_specific.skip_taskbar = skip;
+    self
+  }
+
+  #[inline]
+  fn with_window_classname<S: Into<String>>(mut self, classname: S) -> WindowBuilder {
+    self.platform_specific.window_classname = classname.into();
     self
   }
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -47,6 +47,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
   pub menu: Option<HMENU>,
   pub taskbar_icon: Option<Icon>,
   pub skip_taskbar: bool,
+  pub window_classname: String,
   pub no_redirection_bitmap: bool,
   pub drag_and_drop: bool,
   pub preferred_theme: Option<Theme>,
@@ -64,6 +65,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
       drag_and_drop: true,
       preferred_theme: None,
       skip_taskbar: false,
+      window_classname: "Window Class".to_string(),
       decoration_shadow: true,
       rtl: false,
     }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -996,7 +996,7 @@ unsafe fn init<T: 'static>(
   event_loop: &EventLoopWindowTarget<T>,
 ) -> Result<Window, RootOsError> {
   // registering the window class
-  let class_name = register_window_class();
+  let class_name = register_window_class::<T>(&pl_attribs.window_classname);
 
   let mut window_flags = WindowFlags::empty();
   window_flags.set(WindowFlags::MARKER_DECORATIONS, attributes.decorations);
@@ -1180,8 +1180,8 @@ unsafe fn init<T: 'static>(
   Ok(win)
 }
 
-unsafe fn register_window_class() -> Vec<u16> {
-  let class_name = util::encode_wide("Window Class");
+unsafe fn register_window_class<T: 'static>(window_classname: &String) -> Vec<u16> {
+  let class_name = util::encode_wide(window_classname);
 
   let class = WNDCLASSEXW {
     cbSize: mem::size_of::<WNDCLASSEXW>() as u32,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -996,7 +996,7 @@ unsafe fn init<T: 'static>(
   event_loop: &EventLoopWindowTarget<T>,
 ) -> Result<Window, RootOsError> {
   // registering the window class
-  let class_name = register_window_class::<T>(&pl_attribs.window_classname);
+  let class_name = register_window_class(&pl_attribs.window_classname);
 
   let mut window_flags = WindowFlags::empty();
   window_flags.set(WindowFlags::MARKER_DECORATIONS, attributes.decorations);

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1180,7 +1180,7 @@ unsafe fn init<T: 'static>(
   Ok(win)
 }
 
-unsafe fn register_window_class<T: 'static>(window_classname: &String) -> Vec<u16> {
+unsafe fn register_window_class(window_classname: &str) -> Vec<u16> {
   let class_name = util::encode_wide(window_classname);
 
   let class = WNDCLASSEXW {


### PR DESCRIPTION
allow to customize the window class name instead of current value hard coded "Window Class"

Currently, on Windows, all windows created by Tao have the same class Window Class, it would be neet to allow for customization of the Windows' window class name. One use case: some windows custom hotkey managers leverage window class names to select windows...

Waiting for merge in upstream project winit (pass all 55 checks) : https://github.com/rust-windowing/winit/pull/2978
(closing mirrored issue https://github.com/rust-windowing/winit/issues/2977)

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [X] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [X] No

### Checklist
- [X] This PR will resolve #769 
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary
- [X] It can be built on all targets and pass CI/CD.