### PR TITLE
fix(macos): fix `WindowExtMacOS::ns_view` invalid pointer

### DIFF
--- a/.changes/ns_view_getter.md
+++ b/.changes/ns_view_getter.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+On macOS, fix `WindowExtMacOS::ns_view` returning an invalid pointer if the view was replaced by a call to `setContentView` later on.

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1441,7 +1441,7 @@ impl WindowExtMacOS for UnownedWindow {
 
   #[inline]
   fn ns_view(&self) -> *mut c_void {
-    unsafe { (*self.ns_window).contentView() }
+    unsafe { (*self.ns_window).contentView() as *mut _ }
   }
 
   #[inline]

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1441,7 +1441,7 @@ impl WindowExtMacOS for UnownedWindow {
 
   #[inline]
   fn ns_view(&self) -> *mut c_void {
-    *self.ns_view as *mut _
+    unsafe { (*self.ns_window).contentView() }
   }
 
   #[inline]

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -34,9 +34,6 @@ use crate::{
 
 pub struct WindowDelegateState {
   ns_window: IdRef, // never changes
-  // We keep this ns_view because we still need its view state for some extern function
-  // like didResignKey
-  ns_view: IdRef, // never changes
 
   window: Weak<UnownedWindow>,
 
@@ -63,7 +60,6 @@ impl WindowDelegateState {
     let scale_factor = window.scale_factor();
     let mut delegate_state = WindowDelegateState {
       ns_window: window.ns_window.clone(),
-      ns_view: window.ns_view.clone(),
       window: Arc::downgrade(window),
       initial_fullscreen,
       previous_position: None,
@@ -391,7 +387,7 @@ extern "C" fn window_did_resign_key(this: &Object, _: Sel, _: id) {
     // Object referenced by state.ns_view (an IdRef, which is dereferenced
     // to an id)
     let view_state: &mut ViewState = unsafe {
-      let ns_view: &Object = (*state.ns_view).as_ref().expect("failed to deref");
+      let ns_view: &Object = (state.ns_view() as id).as_ref().expect("failed to deref");
       let state_ptr: *mut c_void = *ns_view.get_ivar("taoState");
       &mut *(state_ptr as *mut ViewState)
     };

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -34,6 +34,9 @@ use crate::{
 
 pub struct WindowDelegateState {
   ns_window: IdRef, // never changes
+  // We keep this ns_view because we still need its view state for some extern function
+  // like didResignKey
+  ns_view: IdRef, // never changes
 
   window: Weak<UnownedWindow>,
 
@@ -60,6 +63,7 @@ impl WindowDelegateState {
     let scale_factor = window.scale_factor();
     let mut delegate_state = WindowDelegateState {
       ns_window: window.ns_window.clone(),
+      ns_view: window.ns_view.clone(),
       window: Arc::downgrade(window),
       initial_fullscreen,
       previous_position: None,
@@ -387,7 +391,7 @@ extern "C" fn window_did_resign_key(this: &Object, _: Sel, _: id) {
     // Object referenced by state.ns_view (an IdRef, which is dereferenced
     // to an id)
     let view_state: &mut ViewState = unsafe {
-      let ns_view: &Object = (state.ns_view() as id).as_ref().expect("failed to deref");
+      let ns_view: &Object = (*state.ns_view).as_ref().expect("failed to deref");
       let state_ptr: *mut c_void = *ns_view.get_ivar("taoState");
       &mut *(state_ptr as *mut ViewState)
     };


### PR DESCRIPTION
continuation of https://github.com/tauri-apps/tao/pull/710

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist
- [ ] This PR will resolve #___
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

