### PR TITLE
fix: platform_impl::ios::view::application_continue return type

### DIFF
--- a/.changes/ios-application-continue-type.md
+++ b/.changes/ios-application-continue-type.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix compilation error on iOS.

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -566,7 +566,7 @@ pub fn create_delegate_class() {
     unsafe {
       let webpage_url: id = msg_send![user_activity, webpageURL];
       if webpage_url == nil {
-        return false;
+        return NO;
       }
       let absolute_url: id = msg_send![webpage_url, absoluteString];
       let bytes = {


### PR DESCRIPTION
### What kind of change does this PR introduce?
The return type of the [application_continue](https://github.com/tauri-apps/tao/blob/dev/src/platform_impl/ios/view.rs#L559) should be `NO` rather than false.  This is currently causing a complication error.

error: 
```
error[E0308]: mismatched types
   --> /Users/logankeenan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tao-0.22.1/src/platform_impl/ios/view.rs:569:16
    |
565 |   ) -> BOOL {
    |        ---- expected `i8` because of return type
...
569 |         return false;
    |                ^^^^^ expected `i8`, found `bool`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `tao` (lib) due to previous error
```
 
- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?


- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

