### PR TITLE
fix(macOS): correct tray_target in set_menu

### DIFF
--- a/.changes/fix-set-menu.md
+++ b/.changes/fix-set-menu.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fixes `set_menu` SystemTray implementation on macOS.

--- a/src/platform_impl/macos/system_tray.rs
+++ b/src/platform_impl/macos/system_tray.rs
@@ -173,12 +173,11 @@ impl SystemTray {
 
   pub fn set_menu(&mut self, tray_menu: &Menu) {
     unsafe {
-      self.tray_menu = Some(tray_menu.clone());
-
-      let tray_target: id = msg_send![self.ns_status_bar.button(), target];
-      (*tray_target).set_ivar("menu", tray_menu.menu);
-      let () = msg_send![tray_menu.menu, setDelegate: tray_target];
+      (*self.tray_target).set_ivar(TRAY_MENU, tray_menu.menu);
+      self.ns_status_bar.setMenu_(tray_menu.menu);
+      let () = msg_send![tray_menu.menu, setDelegate: self.ns_status_bar];
     }
+    self.tray_menu = Some(tray_menu.clone());
   }
 
   pub fn set_tooltip(&self, tooltip: &str) {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve https://github.com/tauri-apps/tauri/issues/7925
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

I also forgot to fix the `set_menu`'s implement 😢 