### PR TITLE
fix(linux): Fix `Window::theme` may return incorrect theme

### DIFF
--- a/.changes/get-window-theme.md
+++ b/.changes/get-window-theme.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+Fix `Window::theme` may return a theme different from the actual window's theme on Linux.

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -67,7 +67,7 @@ pub struct Window {
   inner_size_constraints: RefCell<WindowSizeConstraints>,
   /// Draw event Sender
   draw_tx: crossbeam_channel::Sender<WindowId>,
-  theme: Theme,
+  preferred_theme: Option<Theme>,
 }
 
 impl Window {
@@ -184,16 +184,10 @@ impl Window {
       window.set_icon(Some(&icon.inner.into()));
     }
 
-    let settings = Settings::default();
-
-    let mut theme = Theme::Light;
-    if let Some(settings) = settings {
+    let preferred_theme = if let Some(settings) = Settings::default() {
       if let Some(preferred_theme) = attributes.preferred_theme {
         match preferred_theme {
-          Theme::Dark => {
-              settings.set_gtk_application_prefer_dark_theme(true);
-              theme = Theme::Dark;
-          }
+          Theme::Dark => settings.set_gtk_application_prefer_dark_theme(true),
           Theme::Light => {
             let theme_name = settings.gtk_theme_name().map(|t| t.as_str().to_owned());
             if let Some(theme) = theme_name {
@@ -209,7 +203,10 @@ impl Window {
           }
         }
       }
-    }
+      attributes.preferred_theme
+    } else {
+      None
+    };
 
     if attributes.visible {
       window.show_all();
@@ -308,7 +305,7 @@ impl Window {
       minimized,
       fullscreen: RefCell::new(attributes.fullscreen),
       inner_size_constraints: RefCell::new(attributes.inner_size_constraints),
-      theme,
+      preferred_theme,
     };
 
     win.set_skip_taskbar(pl_attribs.skip_taskbar);
@@ -779,7 +776,20 @@ impl Window {
   }
 
   pub fn theme(&self) -> Theme {
-    self.theme
+    if let Some(theme) = self.preferred_theme {
+      return theme;
+    }
+
+    if let Some(settings) = Settings::default() {
+      let theme_name = settings.gtk_theme_name().map(|s| s.as_str().to_owned());
+      if let Some(theme) = theme_name {
+        if GTK_THEME_SUFFIX_LIST.iter().any(|t| theme.ends_with(t)) {
+          return Theme::Dark;
+        }
+      }
+    }
+
+    Theme::Light
   }
 }
 

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -67,6 +67,7 @@ pub struct Window {
   inner_size_constraints: RefCell<WindowSizeConstraints>,
   /// Draw event Sender
   draw_tx: crossbeam_channel::Sender<WindowId>,
+  theme: Theme,
 }
 
 impl Window {
@@ -185,10 +186,14 @@ impl Window {
 
     let settings = Settings::default();
 
+    let mut theme = Theme::Light;
     if let Some(settings) = settings {
       if let Some(preferred_theme) = attributes.preferred_theme {
         match preferred_theme {
-          Theme::Dark => settings.set_gtk_application_prefer_dark_theme(true),
+          Theme::Dark => {
+              settings.set_gtk_application_prefer_dark_theme(true);
+              theme = Theme::Dark;
+          }
           Theme::Light => {
             let theme_name = settings.gtk_theme_name().map(|t| t.as_str().to_owned());
             if let Some(theme) = theme_name {
@@ -303,6 +308,7 @@ impl Window {
       minimized,
       fullscreen: RefCell::new(attributes.fullscreen),
       inner_size_constraints: RefCell::new(attributes.inner_size_constraints),
+      theme,
     };
 
     win.set_skip_taskbar(pl_attribs.skip_taskbar);
@@ -773,15 +779,7 @@ impl Window {
   }
 
   pub fn theme(&self) -> Theme {
-    if let Some(settings) = Settings::default() {
-      let theme_name = settings.gtk_theme_name().map(|s| s.as_str().to_owned());
-      if let Some(theme) = theme_name {
-        if GTK_THEME_SUFFIX_LIST.iter().any(|t| theme.ends_with(t)) {
-          return Theme::Dark;
-        }
-      }
-    }
-    return Theme::Light;
+    self.theme
   }
 }
 

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -189,8 +189,8 @@ impl Window {
         match preferred_theme {
           Theme::Dark => settings.set_gtk_application_prefer_dark_theme(true),
           Theme::Light => {
-            let theme_name = settings.gtk_theme_name().map(|t| t.as_str().to_owned());
-            if let Some(theme) = theme_name {
+            if let Some(theme) = settings.gtk_theme_name() {
+              let theme = theme.as_str();
               // Remove dark variant.
               if let Some(theme) = GTK_THEME_SUFFIX_LIST
                 .iter()
@@ -780,12 +780,10 @@ impl Window {
       return theme;
     }
 
-    if let Some(settings) = Settings::default() {
-      let theme_name = settings.gtk_theme_name().map(|s| s.as_str().to_owned());
-      if let Some(theme) = theme_name {
-        if GTK_THEME_SUFFIX_LIST.iter().any(|t| theme.ends_with(t)) {
-          return Theme::Dark;
-        }
+    if let Some(theme) = Settings::default().and_then(|s| s.gtk_theme_name()) {
+      let theme = theme.as_str();
+      if GTK_THEME_SUFFIX_LIST.iter().any(|t| theme.ends_with(t)) {
+        return Theme::Dark;
       }
     }
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve #799
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

On Ubuntu 22.04, the default theme name is ["Yaru"](https://github.com/ubuntu/yaru) in both dark mode and light mode. So it is not possible to check the theme mode by suffix like "-dark". The only way I could come up with was remembering what theme was set on building the window and returning the value at `Window::theme`. This PR adopts the idea.