### PR TITLE
fix(linux): crash on set size APIs

### DIFF
--- a/.changes/fix-set-size-linux.md
+++ b/.changes/fix-set-size-linux.md
@@ -1,0 +1,5 @@
+---
+"tao": patch:bug
+---
+
+Fixes set size APIs crashing on Linux.

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -385,11 +385,11 @@ impl Window {
     .to_physical(self.scale_factor.load(Ordering::Acquire) as f64)
   }
 
-  fn set_size_constraints(&self) {
-    if let Err(e) = self.window_requests_tx.send((
-      self.window_id,
-      WindowRequest::SizeConstraints(*self.inner_size_constraints.borrow()),
-    )) {
+  fn set_size_constraints(&self, constraints: WindowSizeConstraints) {
+    if let Err(e) = self
+      .window_requests_tx
+      .send((self.window_id, WindowRequest::SizeConstraints(constraints)))
+    {
       log::warn!("Fail to send size constraint request: {}", e);
     }
   }
@@ -398,19 +398,19 @@ impl Window {
     let mut size_constraints = self.inner_size_constraints.borrow_mut();
     size_constraints.min_width = size.map(|s| s.width());
     size_constraints.min_height = size.map(|s| s.height());
-    self.set_size_constraints()
+    self.set_size_constraints(*size_constraints)
   }
 
   pub fn set_max_inner_size(&self, size: Option<Size>) {
     let mut size_constraints = self.inner_size_constraints.borrow_mut();
     size_constraints.max_width = size.map(|s| s.width());
     size_constraints.max_height = size.map(|s| s.height());
-    self.set_size_constraints()
+    self.set_size_constraints(*size_constraints)
   }
 
   pub fn set_inner_size_constraints(&self, constraints: WindowSizeConstraints) {
     *self.inner_size_constraints.borrow_mut() = constraints;
-    self.set_size_constraints()
+    self.set_size_constraints(constraints)
   }
 
   pub fn set_title(&self, title: &str) {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

