### PR TITLE
fix(linux): avoid unwrapping in `Window::current_monitor`

### DIFF
--- a/.changes/linux-current-monitor.md
+++ b/.changes/linux-current-monitor.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix `Window::current_monitor` sometimes panicking on Linux when the window is invisible.

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -678,11 +678,12 @@ impl Window {
     let monitor = self
       .window
       .window()
-      .map(|window| display.monitor_at_window(&window))
-      .unwrap_or_else(|| display.primary_monitor())
-      .unwrap();
-    let handle = MonitorHandle { monitor };
-    Some(RootMonitorHandle { inner: handle })
+      .and_then(|window| display.monitor_at_window(&window))
+      .or_else(|| display.primary_monitor());
+
+    monitor.map(|monitor| RootMonitorHandle {
+      inner: MonitorHandle { monitor },
+    })
   }
 
   #[inline]


### PR DESCRIPTION
closes tauri-apps/tauri#7986

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [x] This PR will resolve tauri-apps/tauri#7986
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

