### PR TITLE
Fix `WindowEvent::Destroyed` might fire twice on macOS

### DIFF
--- a/.changes/mac-destroy.md
+++ b/.changes/mac-destroy.md
@@ -1,0 +1,6 @@
+---
+"tao": patch
+---
+
+On macOS, fix `WindowEvent::Destroyed` may fire twice.
+

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -20,15 +20,7 @@ use objc::{
 
 use crate::{
   dpi::LogicalSize,
-  event::{Event, WindowEvent},
-  platform_impl::platform::{
-    app_state::AppState,
-    event::EventWrapper,
-    ffi,
-    util::IdRef,
-    window::{get_window_id, SharedState},
-  },
-  window::WindowId,
+  platform_impl::platform::{ffi, util::IdRef, window::SharedState},
 };
 
 pub fn is_main_thread() -> bool {
@@ -251,14 +243,9 @@ pub unsafe fn set_focus(ns_window: id) {
 // through the `IdRef` because otherwise it would dereference free'd memory
 pub unsafe fn close_async(ns_window: IdRef) {
   let ns_window = MainThreadSafe(ns_window);
-  Queue::main().exec_async(move || {
+  run_on_main(move || {
     autoreleasepool(move || {
       ns_window.close();
-      let event = Event::WindowEvent {
-        window_id: WindowId(get_window_id(*ns_window.0)),
-        event: WindowEvent::Destroyed,
-      };
-      AppState::queue_event(EventWrapper::StaticEvent(event));
     });
   });
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

