### PR TITLE
fixed transparent windows

### DIFF
--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -255,6 +255,9 @@ impl WindowFlags {
     if self.contains(WindowFlags::NO_BACK_BUFFER) {
       style_ex |= WS_EX_NOREDIRECTIONBITMAP;
     }
+    if self.contains(WindowFlags::TRANSPARENT) {
+      style_ex |= WS_EX_LAYERED;
+    }
     if self.contains(WindowFlags::CHILD) {
       style |= WS_CHILD; // This is incompatible with WS_POPUP if that gets added eventually.
     }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information
This fix was found in a [old unmerged winit pullrequest](https://github.com/rust-windowing/winit/issues/2502). This fix removes the buggy inital white background from transparent windows and fixes transparent fullscreen windows too. I tested it on Win10.

