### PR TITLE
chore: Fix changelog

### DIFF
--- a/.github/fix-macos-delegate-usage.md
+++ b/.github/fix-macos-delegate-usage.md
@@ -1,5 +1,0 @@
----
-"tao": patch
----
-
-Ensure the macOS app delegate is defined before accessing it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - [`b31cb692`](https://github.com/tauri-apps/tao/commit/b31cb692df2b0a03d2fbdf2fbf7ba82591678e24)([#772](https://github.com/tauri-apps/tao/pull/772)) On macOS, fix `WindowExtMacOS::ns_view` returning an invalid pointer if the view was replaced by a call to `setContentView` later on.
 - [`4d0e1862`](https://github.com/tauri-apps/tao/commit/4d0e1862b6a2a7580631d637ef937d217f0797bf)([#762](https://github.com/tauri-apps/tao/pull/762)) Add `WindowExtWindows::set_rtl` and `WindowBuilderExtWindows::with_rtl` to set right-to-left layout on Windows.
 - [`75eb0c1e`](https://github.com/tauri-apps/tao/commit/75eb0c1e7e83a766af0e083ce09c761d1974cde4)([#769](https://github.com/tauri-apps/tao/pull/769)) Add `WindowBuilderExtWindows::with_window_classname` to set the name of the window class created/used to create windows.
+- [`494e4585`](https://github.com/tauri-apps/tao/commit/494e4585d1177b12bdaacbb3aa381d0514f5252f)([#775](https://github.com/tauri-apps/tao/pull/775)) Ensure the macOS app delegate is defined before accessing it.
 
 ## \[0.21.0]
 


### PR DESCRIPTION
In #775, the Covector change file was added in `.github` instead of `.changes`.
The change was [published in Tao 0.21.1](https://github.com/tauri-apps/tao/compare/tao-v0.21.0...tao-v0.21.1), but never added to the changelog.

This PR deletes the change file and adjusts the changelog, as Covector would have normally done.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

