### PR TITLE
fix(windows): remove `WS_CLIPCHILDREN` from window style

### DIFF
--- a/.changes/windows-ws-clipchildren.md
+++ b/.changes/windows-ws-clipchildren.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+On Windows, remove `WS_CLIPCHILDREN` from window style

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -231,7 +231,7 @@ impl WindowFlags {
 
   pub fn to_window_styles(self) -> (WINDOW_STYLE, WINDOW_EX_STYLE) {
     let (mut style, mut style_ex) = (Default::default(), Default::default());
-    style |= WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_SYSMENU | WS_CAPTION;
+    style |= WS_CLIPSIBLINGS | WS_SYSMENU | WS_CAPTION;
     style_ex |= WS_EX_ACCEPTFILES | WS_EX_WINDOWEDGE;
 
     if self.contains(WindowFlags::RESIZABLE) {


### PR DESCRIPTION
While working on https://github.com/tauri-apps/wry/pull/1041 which allows adding the webview as a child window, I noticed that when setting the webview to be transparent, the portion of the parent behind it doesn't render properly and that was because of `WS_CLIPCHILDREN`

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

