### PR TITLE
fix(windows): remove `SetWindowTheme` call with `DarkMode_Explorer` theme

### DIFF
--- a/.changes/windows-dark-menubar-glitches.md
+++ b/.changes/windows-dark-menubar-glitches.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+On Windows, remove `SetWindowTheme` call with `DarkMode_Explorer` theme which fixes a glitch downstream in `muda` crate when manually drawing the menu bar.

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -7,11 +7,11 @@ use once_cell::sync::Lazy;
 /// This is a simple implementation of support for Windows Dark Mode,
 /// which is inspired by the solution in https://github.com/ysc3839/win32-darkmode
 use windows::{
-  core::{s, w, PCSTR, PCWSTR, PSTR},
+  core::{s, w, PCSTR, PSTR},
   Win32::{
     Foundation::{BOOL, HANDLE, HMODULE, HWND},
     System::LibraryLoader::*,
-    UI::{Accessibility::*, Controls::SetWindowTheme, WindowsAndMessaging::*},
+    UI::{Accessibility::*, WindowsAndMessaging::*},
   },
 };
 
@@ -140,12 +140,6 @@ pub fn try_window_theme(hwnd: HWND, preferred_theme: Option<Theme>) -> Theme {
       true => Theme::Dark,
       false => Theme::Light,
     };
-
-    let theme_name = match theme {
-      Theme::Dark => w!("DarkMode_Explorer"),
-      Theme::Light => w!(""),
-    };
-    let _ = unsafe { SetWindowTheme(hwnd, theme_name, PCWSTR::null()) };
 
     allow_dark_mode_for_window(hwnd, is_dark_mode);
     refresh_titlebar_theme_color(hwnd, is_dark_mode);


### PR DESCRIPTION
Fixes a glitch downstream in `muda` crate when manually drawing the menu bar

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist
- [ ] This PR will resolve #___
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

