### PR TITLE
fix(windows): fix `set_fullscreen` early return for `Fullscreen::Borderless(None)`

### DIFF
--- a/.changes/windows-set-fullscreen-early-return.md
+++ b/.changes/windows-set-fullscreen-early-return.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+On Windows, fix consecutive calls to `window.set_fullscreen(Some(Fullscreen::Borderless(None)))` resulting in losing previous window state when eventually exiting fullscreen using `window.set_fullscreen(None)`.

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -621,9 +621,19 @@ impl Window {
 
     let mut window_state_lock = window_state.lock();
     let old_fullscreen = window_state_lock.fullscreen.clone();
-    if window_state_lock.fullscreen == fullscreen {
-      return;
+
+    match (&old_fullscreen, &fullscreen) {
+      // Return if we already in the same fullscreen mode
+      _ if old_fullscreen == fullscreen => return,
+      // Return if saved Borderless(monitor) is the same as current monitor when requested fullscreen is Borderless(None)
+      (Some(Fullscreen::Borderless(Some(monitor))), Some(Fullscreen::Borderless(None)))
+        if monitor.inner == monitor::current_monitor(window.0) =>
+      {
+        return
+      }
+      _ => {}
     }
+
     window_state_lock.fullscreen = fullscreen.clone();
     drop(window_state_lock);
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [X] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [X] No

### Checklist
- [X] This PR will resolve #853 
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary
- [X] It can be built on all targets and pass CI/CD.

### Other information

