### PR TITLE
fix(android) fix app crash on restart due to Android context not released

### DIFF
--- a/.changes/android-context-release.md
+++ b/.changes/android-context-release.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix the app crash on restart due to Android context was not released. Release the Android context when the app is destroyed to avoid assertion failure.

--- a/src/platform_impl/android/ndk_glue.rs
+++ b/src/platform_impl/android/ndk_glue.rs
@@ -297,6 +297,7 @@ pub unsafe fn save(_: JNIEnv, _: JClass, _: JObject) {
 
 pub unsafe fn destroy(_: JNIEnv, _: JClass, _: JObject) {
   wake(Event::Destroy);
+  ndk_context::release_android_context();
 }
 
 pub unsafe fn memory(_: JNIEnv, _: JClass, _: JObject) {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
This PR fixes a bug that causes the app to crash when it is restarted after any exit that triggers the onDestroy callback.

To reproduce this bug:
- Build the latest tauri alpha android app using `npm run tauri android build`
- Install and open the app
- Press the back button to close the app
- Reopen the app
- The app will crash with `RustStdoutStderr: assertion failed: previous.is_none()`

The bug occurs because the Android context is not released when the app is destroyed, and the ndk-context crate asserts that the context is initialized only once.

This PR adds a call to release_android_context when the app is destroyed. This ensures that the Android context is freed and can be reinitialized on the next launch.

This PR is based on [this commit](https://github.com/rust-mobile/ndk-glue/commit/725085c3504882d377ffbf6d745fa9793062fa0a) from the ndk-glue repository.

