### PR TITLE
fix: add Insert KeyCode to from_str

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -741,6 +741,7 @@ impl FromStr for KeyCode {
       "TAB" => KeyCode::Tab,
       "CONVERT" => KeyCode::Convert,
 
+      "INSERT" => KeyCode::Insert,
       "DELETE" => KeyCode::Delete,
       "END" => KeyCode::End,
       "HELP" => KeyCode::Help,


### PR DESCRIPTION
I believe the Insert key is missing.

![image](https://github.com/tauri-apps/tao/assets/62494922/7528624b-cb91-4d48-80b1-6e6a892d1486)