### PR TITLE
fix(windows): apply `ScaleFactorChanged` if new size is different than OS

### DIFF
--- a/.changes/windows-scale-factor-maximized.md
+++ b/.changes/windows-scale-factor-maximized.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+On Windows, apply `ScaleFactorChanged` if new size is different than what OS reported. This fixes an issue when moving the window to another monitor and immediately maximizing it, resulting in a maximized window (i.e have `WS_MAXIMIZE` window style) but doesn't cover the monitor work area.

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -428,6 +428,8 @@ impl<T> BufferedEvent<T> {
     match self {
       Self::Event(event) => dispatch(event),
       Self::ScaleFactorChanged(window_id, scale_factor, mut new_inner_size) => {
+        let os_inner_size = new_inner_size.clone();
+
         dispatch(Event::WindowEvent {
           window_id,
           event: WindowEvent::ScaleFactorChanged {
@@ -435,12 +437,15 @@ impl<T> BufferedEvent<T> {
             new_inner_size: &mut new_inner_size,
           },
         });
-        util::set_inner_size_physical(
-          HWND(window_id.0 .0),
-          new_inner_size.width as _,
-          new_inner_size.height as _,
-          true,
-        );
+
+        if new_inner_size != os_inner_size {
+          util::set_inner_size_physical(
+            HWND(window_id.0 .0),
+            new_inner_size.width as _,
+            new_inner_size.height as _,
+            true,
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
this fixes an issue when moving the window to another monitor and immediately maximizing it, resulting in a maximized window (i.e have `WS_MAXIMIZE` window style) but doesn't cover the monitor work area

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
