### PR TITLE
refactor(macOS): use NSEvent::mouseLocation for cursor_position instead of CGEventSource

### DIFF
--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -113,12 +113,7 @@ impl<T: 'static> EventLoopWindowTarget<T> {
   }
   #[inline]
   pub fn cursor_position(&self) -> Result<PhysicalPosition<f64>, ExternalError> {
-    let point = util::cursor_position()?;
-    if let Some(m) = self.monitor_from_point(point.x, point.y) {
-      Ok(point.to_physical(m.scale_factor()))
-    } else {
-      Err(ExternalError::Os(os_error!(super::OsError::CGError(0))))
-    }
+    util::cursor_position()
   }
 
   #[inline]

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -17,11 +17,7 @@ use cocoa::{
   base::{id, nil},
   foundation::{NSAutoreleasePool, NSPoint, NSRect, NSString, NSUInteger},
 };
-use core_graphics::{
-  display::CGDisplay,
-  event::CGEvent,
-  event_source::{CGEventSource, CGEventSourceStateID},
-};
+use core_graphics::display::CGDisplay;
 use objc::class;
 use objc::runtime::{Class, Object, Sel, BOOL, YES};
 
@@ -115,11 +111,10 @@ pub fn window_position(position: LogicalPosition<f64>) -> NSPoint {
   )
 }
 
-// FIXME: This is actually logical position.
 pub fn cursor_position() -> Result<PhysicalPosition<f64>, ExternalError> {
-  let point: NSPoint = msg_send![class!(NSEvent), mouseLocation];
+  let point: NSPoint = unsafe { msg_send![class!(NSEvent), mouseLocation] };
   let y = CGDisplay::main().pixels_high() as f64 - point.y;
-  let point = LogicalPosition::new(point.x, point.y);
+  let point = LogicalPosition::new(point.x, y);
   Ok(point.to_physical(super::monitor::primary_monitor().scale_factor()))
 }
 

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -25,7 +25,7 @@ use core_graphics::{
 use objc::class;
 use objc::runtime::{Class, Object, Sel, BOOL, YES};
 
-use crate::{dpi::LogicalPosition, error::ExternalError, platform_impl::platform::ffi};
+use crate::{dpi::{LogicalPosition, PhysicalPosition}, error::ExternalError, platform_impl::platform::ffi};
 
 // Replace with `!` once stable
 #[derive(Debug)]
@@ -112,7 +112,7 @@ pub fn window_position(position: LogicalPosition<f64>) -> NSPoint {
 }
 
 // FIXME: This is actually logical position.
-pub fn cursor_position() -> Result<LogicalPosition<f64>, ExternalError> {
+pub fn cursor_position() -> Result<PhysicalPosition<f64>, ExternalError> {
   let point: NSPoint = msg_send![class!(NSEvent), mouseLocation];
   let y = CGDisplay::main().pixels_high() as f64 - point.y;
   let point = LogicalPosition::new(point.x, point.y);

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -25,7 +25,11 @@ use core_graphics::{
 use objc::class;
 use objc::runtime::{Class, Object, Sel, BOOL, YES};
 
-use crate::{dpi::{LogicalPosition, PhysicalPosition}, error::ExternalError, platform_impl::platform::ffi};
+use crate::{
+  dpi::{LogicalPosition, PhysicalPosition},
+  error::ExternalError,
+  platform_impl::platform::ffi,
+};
 
 // Replace with `!` once stable
 #[derive(Debug)]

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -22,6 +22,7 @@ use core_graphics::{
   event::CGEvent,
   event_source::{CGEventSource, CGEventSourceStateID},
 };
+use objc::class;
 use objc::runtime::{Class, Object, Sel, BOOL, YES};
 
 use crate::{dpi::LogicalPosition, error::ExternalError, platform_impl::platform::ffi};
@@ -112,15 +113,10 @@ pub fn window_position(position: LogicalPosition<f64>) -> NSPoint {
 
 // FIXME: This is actually logical position.
 pub fn cursor_position() -> Result<LogicalPosition<f64>, ExternalError> {
-  if let Ok(s) = CGEventSource::new(CGEventSourceStateID::CombinedSessionState) {
-    if let Ok(e) = CGEvent::new(s) {
-      let pt = e.location();
-      let pos = LogicalPosition::new(pt.x, pt.y);
-      return Ok(pos);
-    }
-  }
-
-  return Err(ExternalError::Os(os_error!(super::OsError::CGError(0))));
+  let point: NSPoint = msg_send![class!(NSEvent), mouseLocation];
+  let y = CGDisplay::main().pixels_high() as f64 - point.y;
+  let point = LogicalPosition::new(point.x, point.y);
+  Ok(point.to_physical(super::monitor::primary_monitor().scale_factor()))
 }
 
 pub unsafe fn ns_string_id_ref(s: &str) -> IdRef {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -817,12 +817,7 @@ impl UnownedWindow {
 
   #[inline]
   pub fn cursor_position(&self) -> Result<PhysicalPosition<f64>, ExternalError> {
-    let point = util::cursor_position()?;
-    if let Some(m) = self.monitor_from_point(point.x, point.y) {
-      Ok(point.to_physical(m.scale_factor()))
-    } else {
-      Err(ExternalError::Os(os_error!(OsError::CGError(0))))
-    }
+    util::cursor_position()
   }
 
   #[inline]


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
