### PR TITLE
fix(macos): race condition when toggling traffic light, close tauri#9210

### DIFF
--- a/.changes/fix-mac-style-mask-race-condition.md
+++ b/.changes/fix-mac-style-mask-race-condition.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On macOS, fix an issue where the set minimize maximize and close buttons would interfere with each other.

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -744,7 +744,7 @@ impl UnownedWindow {
       } else {
         mask &= !NSWindowStyleMask::NSResizableWindowMask;
       }
-      self.set_style_mask_async(mask);
+      self.set_style_mask_sync(mask);
     } // Otherwise, we don't change the mask until we exit fullscreen.
   }
 
@@ -756,7 +756,7 @@ impl UnownedWindow {
     } else {
       mask &= !NSWindowStyleMask::NSMiniaturizableWindowMask;
     }
-    self.set_style_mask_async(mask);
+    self.set_style_mask_sync(mask);
   }
 
   #[inline]
@@ -777,7 +777,7 @@ impl UnownedWindow {
     } else {
       mask &= !NSWindowStyleMask::NSClosableWindowMask;
     }
-    self.set_style_mask_async(mask);
+    self.set_style_mask_sync(mask);
   }
 
   pub fn set_cursor_icon(&self, cursor: CursorIcon) {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
Issue: https://github.com/tauri-apps/tauri/issues/9210

styleMask is a bitmask. When toggling minimize, maximize and close buttons, they will call an async setter and overwrite each other's mask if they are called in a short time.