### PR TITLE
feat(windows): Enable native resizing on undecorated windows with shadows

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -23,7 +23,8 @@ use windows::{
   core::{s, PCWSTR},
   Win32::{
     Foundation::{
-      BOOL, HANDLE, HINSTANCE, HMODULE, HWND, LPARAM, LRESULT, POINT, RECT, WAIT_TIMEOUT, WPARAM,
+      BOOL, FALSE, HANDLE, HINSTANCE, HMODULE, HWND, LPARAM, LRESULT, POINT, RECT, WAIT_TIMEOUT,
+      WPARAM,
     },
     Graphics::Gdi::*,
     System::{
@@ -2121,9 +2122,27 @@ unsafe fn public_window_callback_inner<T: 'static>(
             params.rgrc[0] = rect;
           }
         } else if window_flags.contains(WindowFlags::MARKER_UNDECORATED_SHADOW) {
+          let mut rect = RECT::default();
+          if AdjustWindowRectEx(
+            &mut rect,
+            WINDOW_STYLE((GetWindowLongPtrW(window, GWL_STYLE) & !(WS_CAPTION.0 as isize)) as u32),
+            FALSE,
+            WINDOW_EX_STYLE::default(),
+          )
+          .is_ok()
+          {
+            rect.left *= -1;
+            rect.top *= -1;
+          } else {
+            // As a fallback value, this keeps the shadow border but disables the resizing.
+            rect.bottom = -1;
+          }
+
           let params = &mut *(lparam.0 as *mut NCCALCSIZE_PARAMS);
           params.rgrc[0].top += 1;
-          params.rgrc[0].bottom += 1;
+          params.rgrc[0].left += rect.left;
+          params.rgrc[0].right -= rect.right;
+          params.rgrc[0].bottom -= rect.bottom;
         }
         result = ProcResult::Value(LRESULT(0)); // return 0 here to make the window borderless
       }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -183,6 +183,24 @@ impl Window {
   }
 
   #[inline]
+  pub(crate) fn request_nccalcsize(&self) {
+    unsafe {
+      let mut rect = RECT::default();
+      if GetWindowRect(self.window.0, &mut rect).is_ok() {
+        let _ = SetWindowPos(
+          self.window.0,
+          HWND::default(),
+          rect.left,
+          rect.top,
+          rect.right - rect.left,
+          rect.bottom - rect.top,
+          SWP_FRAMECHANGED,
+        );
+      }
+    }
+  }
+
+  #[inline]
   pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
     unsafe { util::get_window_rect(self.window.0) }
       .map(|rect| Ok(PhysicalPosition::new(rect.left as i32, rect.top as i32)))

--- a/src/window.rs
+++ b/src/window.rs
@@ -556,6 +556,8 @@ impl WindowBuilder {
   ) -> Result<Window, OsError> {
     platform_impl::Window::new(&window_target.p, self.window, self.platform_specific).map(
       |window| {
+        #[cfg(windows)]
+        window.request_nccalcsize();
         window.request_redraw();
         Window { window }
       },


### PR DESCRIPTION
I started looking into the code because i wanted to remove the titlebar but keep the borders + shadows. Turns out the undecorated shadows code is basically what i wanted already but the code i saw when researching it was a bit different.
Turns out, it _looks_ the same (i think) as before, but now enables native resizing with resize handles outside of the window.

Only the top bar resizing is still messed up because it's just 1px because top bar resizing is typically inside the window, not outside like on the other borders :/ -> Increasing the bordersize there will make the window look ugly _or_ will require us to color match the titlebar with the window content but it'd still be weird with the control buttons.

I never resize with the top bar so i feel like this is good enough already but we can do that in JS in tauri later and there it'd actually be correct behavior (as opposed to the current undecorated resizing which is inside the window)

----

I only tested this on Windows 11 so far which is why this is a draft pr, apart from wanting to get general feedback of course.