### PR TITLE
feat: add app activated event for macos

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -84,6 +84,12 @@ pub enum Event<'a, T: 'static> {
   /// Emitted when the application has been resumed.
   Resumed,
 
+  /// Emitted when the application has been activated.
+  /// ## Platform-specific
+  ///
+  /// - Only available on **macOS**.
+  Activated,
+
   /// Emitted when all of the event loop's input events have been processed and redraw processing
   /// is about to begin.
   ///
@@ -158,6 +164,7 @@ impl<T: Clone> Clone for Event<'static, T> {
       LoopDestroyed => LoopDestroyed,
       Suspended => Suspended,
       Resumed => Resumed,
+      Activated => Activated,
       Opened { urls } => Opened { urls: urls.clone() },
     }
   }
@@ -177,6 +184,7 @@ impl<'a, T> Event<'a, T> {
       LoopDestroyed => Ok(LoopDestroyed),
       Suspended => Ok(Suspended),
       Resumed => Ok(Resumed),
+      Activated => Ok(Activated),
       Opened { urls } => Ok(Opened { urls }),
     }
   }
@@ -198,6 +206,7 @@ impl<'a, T> Event<'a, T> {
       LoopDestroyed => Some(LoopDestroyed),
       Suspended => Some(Suspended),
       Resumed => Some(Resumed),
+      Activated => Some(Activated),
       Opened { urls } => Some(Opened { urls }),
     }
   }

--- a/src/platform_impl/macos/app.rs
+++ b/src/platform_impl/macos/app.rs
@@ -53,9 +53,20 @@ extern "C" fn send_event(this: &Object, _sel: Sel, event: id) {
       let key_window: id = msg_send![this, keyWindow];
       let _: () = msg_send![key_window, sendEvent: event];
     } else {
+      maybe_dispatch_app_event(event);
       maybe_dispatch_device_event(event);
       let superclass = util::superclass(this);
       let _: () = msg_send![super(this, superclass), sendEvent: event];
+    }
+  }
+}
+
+unsafe fn maybe_dispatch_app_event(event: id) {
+  let event_type = event.eventType();
+  if event_type == appkit::NSEventType::NSAppKitDefined {
+    let event_subtype = event.subtype();
+    if let appkit::NSEventSubtype::NSApplicationActivatedEventType = event_subtype {
+      AppState::queue_event(EventWrapper::StaticEvent(Event::Activated));
     }
   }
 }


### PR DESCRIPTION
This PR adds Activated event for `macOS`, resolving [#218](https://github.com/tauri-apps/tao/issues/218).

Useful in two cases:

1. When the app is open but no windows are visible, clicking its icon in the dock will emit the `Activated` event.
2. When the app is running in the background with no windows, and you try to open it again, `macOS` usually brings the already open instance to the front (without activating windows, so nothing happens). With this change, the `Activated` event will be emitted in such cases.