### PR TITLE
fix(macos::app_state): fix unwanted deviation when drag around monitor boundaries, closes #922

### DIFF
--- a/.changes/fix-macos-drag-deviation.md
+++ b/.changes/fix-macos-drag-deviation.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix unwanted deviation when dragging window around monitor boundaries on macOS.

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -226,21 +226,22 @@ impl Handler {
     scale_factor: f64,
   ) {
     let mut size = suggested_size.to_physical(scale_factor);
-    let new_inner_size = &mut size;
+    let old_size = size.clone();
     let event = Event::WindowEvent {
       window_id: WindowId(get_window_id(*ns_window)),
       event: WindowEvent::ScaleFactorChanged {
         scale_factor,
-        new_inner_size,
+        new_inner_size: &mut size,
       },
     };
 
     callback.handle_nonuser_event(event, &mut *self.control_flow.lock().unwrap());
 
-    let physical_size = *new_inner_size;
-    let logical_size = physical_size.to_logical(scale_factor);
-    let size = NSSize::new(logical_size.width, logical_size.height);
-    unsafe { NSWindow::setContentSize_(*ns_window, size) };
+    if old_size != size {
+      let logical_size = size.to_logical(scale_factor);
+      let size = NSSize::new(logical_size.width, logical_size.height);
+      unsafe { NSWindow::setContentSize_(*ns_window, size) };
+    }
   }
 
   fn handle_proxy(&self, proxy: EventProxy, callback: &mut Box<dyn EventHandler + 'static>) {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

related: #922 

unconditionally call to `setContentSize_` would cause some weird unwanted behavior.
and the "old size" is same as the default target size since it's [get from the NSView at the event happens](https://github.com/tauri-apps/tao/blob/f06843be442c4ad06e66166d1a7924347739c204/src/platform_impl/macos/window_delegate.rs#L108)
so change it to only call `setContentSize_` if the "new size" changed.