### PR TITLE
feat(macos): add setters to set title bar style on macOS

### DIFF
--- a/.changes/feat-set-title-bar-style.md
+++ b/.changes/feat-set-title-bar-style.md
@@ -1,0 +1,5 @@
+---
+'tao': patch
+---
+
+On macOS, add `set_fullsize_content_view` and `set_titlebar_transparent` to `Window` to set the title bar style.

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -74,6 +74,16 @@ pub trait WindowExtMacOS {
 
   /// Returns the window's tabbing identifier.
   fn tabbing_identifier(&self) -> String;
+
+  /// The content view consumes the full size of the window.
+  ///
+  /// <https://developer.apple.com/documentation/appkit/nsfullsizecontentviewwindowmask>
+  fn set_fullsize_content_view(&self, fullsize: bool);
+
+  /// A Boolean value that indicates whether the title bar draws its background.
+  ///
+  /// <https://developer.apple.com/documentation/appkit/nswindow/1419167-titlebarappearstransparent>
+  fn set_titlebar_transparent(&self, transparent: bool);
 }
 
 impl WindowExtMacOS for Window {
@@ -140,6 +150,16 @@ impl WindowExtMacOS for Window {
   #[inline]
   fn tabbing_identifier(&self) -> String {
     self.window.tabbing_identifier()
+  }
+
+  #[inline]
+  fn set_fullsize_content_view(&self, fullsize: bool) {
+    self.window.set_fullsize_content_view(fullsize);
+  }
+
+  #[inline]
+  fn set_titlebar_transparent(&self, transparent: bool) {
+    self.window.set_titlebar_transparent(transparent);
   }
 }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1613,6 +1613,24 @@ impl WindowExtMacOS for UnownedWindow {
       ns_string_to_rust(tabbing_identifier)
     }
   }
+
+  #[inline]
+  fn set_fullsize_content_view(&self, fullsize: bool) {
+    let mut mask = unsafe { self.ns_window.styleMask() };
+    if fullsize {
+      mask |= NSWindowStyleMask::NSFullSizeContentViewWindowMask;
+    } else {
+      mask &= !NSWindowStyleMask::NSFullSizeContentViewWindowMask;
+    }
+    self.set_style_mask_sync(mask);
+  }
+
+  #[inline]
+  fn set_titlebar_transparent(&self, transparent: bool) {
+    unsafe {
+      self.ns_window.setTitlebarAppearsTransparent_(transparent);
+    }
+  }
 }
 
 impl Drop for UnownedWindow {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1628,7 +1628,9 @@ impl WindowExtMacOS for UnownedWindow {
   #[inline]
   fn set_titlebar_transparent(&self, transparent: bool) {
     unsafe {
-      self.ns_window.setTitlebarAppearsTransparent_(transparent);
+      self
+        .ns_window
+        .setTitlebarAppearsTransparent_(transparent as BOOL);
     }
   }
 }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

https://github.com/tauri-apps/tauri/issues/9763
Support dynamically changing titlebar style on macOS.

Blocks: https://github.com/tauri-apps/tauri/pull/9788