### PR TITLE
refactor(windows): Modify the flashing behavior of UserAttentionType::Informational in multiple windows

### DIFF
--- a/.changes/refactor-attention-type-informational.md
+++ b/.changes/refactor-attention-type-informational.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+**Breaking Change**: Replace `UserAttentionType::Informational => (FLASHW_TRAY | FLASHW_TIMERNOFG, 0)` with `UserAttentionType::Informational => (FLASHW_TRAY, 3)`

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -883,7 +883,7 @@ impl Window {
       let (flags, count) = request_type
         .map(|ty| match ty {
           UserAttentionType::Critical => (FLASHW_ALL | FLASHW_TIMERNOFG, u32::MAX),
-          UserAttentionType::Informational => (FLASHW_TRAY | FLASHW_TIMERNOFG, 0),
+          UserAttentionType::Informational => (FLASHW_TRAY, 3),
         })
         .unwrap_or((FLASHW_STOP, 0));
 


### PR DESCRIPTION
refactor: Modify the behavior of `UserAttentionType::Informational` in the `windows` system to make it closer to Electron in multi-window situations：https://github.com/tauri-apps/tauri/issues/8658
