### PR TITLE
fix(linux): prevent firing duplicate mouse events (fixes #939)

### DIFF
--- a/.changes/bump.md
+++ b/.changes/bump.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Prevent duplicate mouse press, release, and motion events from firing on Linux (fixes #939)

--- a/.changes/bump.md
+++ b/.changes/bump.md
@@ -1,5 +1,5 @@
 ---
-"tao": patch
+"tao": "patch"
 ---
 
 Prevent duplicate mouse press, release, and motion events from firing on Linux (fixes #939)

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -640,7 +640,7 @@ impl<T: 'static> EventLoop<T> {
                   }
                 }
               }
-              glib::Propagation::Proceed
+              glib::Propagation::Stop
             });
 
             let tx_clone = event_tx.clone();
@@ -675,11 +675,11 @@ impl<T: 'static> EventLoop<T> {
                 },
               }) {
                 log::warn!(
-                  "Failed to send mouse input preseed event to event channel: {}",
+                  "Failed to send mouse input pressed event to event channel: {}",
                   e
                 );
               }
-              glib::Propagation::Proceed
+              glib::Propagation::Stop
             });
 
             let tx_clone = event_tx.clone();
@@ -705,7 +705,7 @@ impl<T: 'static> EventLoop<T> {
                   e
                 );
               }
-              glib::Propagation::Proceed
+              glib::Propagation::Stop
             });
 
             let tx_clone = event_tx.clone();


### PR DESCRIPTION
Prevents the press, release, and motion events from firing twice on Linux, fixing #939.