### PR TITLE
fix(windows): `Window::request_user_attention` not taking effect after minimizing the window by clicking the taskbar icon

### DIFF
--- a/.changes/fix-user-attention-minimized.md
+++ b/.changes/fix-user-attention-minimized.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix `Window::request_user_attention` not taking effect after minimizing the window by clicking the taskbar icon

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -875,9 +875,9 @@ impl Window {
   pub fn request_user_attention(&self, request_type: Option<UserAttentionType>) {
     let window = self.window.clone();
     let active_window_handle = unsafe { GetActiveWindow() };
-    // If the window is already active and not minimized, we don't need to do anything.
-    // but if the window is minimized, we need to attention the user.
     if window.0 == active_window_handle {
+      // active window could be minimized, so we skip requesting attention
+      // if it is not minimized
       let window_flags = self.window_state.lock().window_flags();
       let is_minimized = window_flags.contains(WindowFlags::MINIMIZED);
       if !is_minimized {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -875,8 +875,14 @@ impl Window {
   pub fn request_user_attention(&self, request_type: Option<UserAttentionType>) {
     let window = self.window.clone();
     let active_window_handle = unsafe { GetActiveWindow() };
+    // If the window is already active and not minimized, we don't need to do anything.
+    // but if the window is minimized, we need to attention the user.
     if window.0 == active_window_handle {
-      return;
+      let window_flags = self.window_state.lock().window_flags();
+      let is_minimized = window_flags.contains(WindowFlags::MINIMIZED);
+      if !is_minimized {
+        return;
+      }
     }
 
     self.thread_executor.execute_in_thread(move || unsafe {


### PR DESCRIPTION
fix(windows): When I minimize a window by clicking on the taskbar icon on Windows, calling the `requestUserAttention` function does not trigger the taskbar icon to flash. #942 
