### PR TITLE
chore(deps): Upgrade to `ndk 0.9` and fix thread-safety interactions

### DIFF
--- a/.changes/ndk-0.9.md
+++ b/.changes/ndk-0.9.md
@@ -1,0 +1,7 @@
+---
+"tao": minor
+---
+
+**Breaking change**: Upgrade `ndk` crate to `0.9` and `ndk-sys` crate to `0.6`.  Types from the `ndk` crate are used in public API surface.
+**Breaking change**: Change `NativeKeyCode::Android(u32)` type to use `i32`, which is the native type used by all Android API.
+**Breaking change**: The `setup` function passed to `android_binding!()` must now take a `&ThreadLooper` instead of `&ForeignLooper`, matching the `wry` change in https://github.com/tauri-apps/wry/pull/1296.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,8 +97,8 @@ once_cell = "1"
 
 [target."cfg(target_os = \"android\")".dependencies]
 jni = "0.21"
-ndk = "0.7"
-ndk-sys = "0.4"
+ndk = "0.9"
+ndk-sys = "0.6"
 ndk-context = "0.1"
 tao-macros = { version = "0.1.0", path = "./tao-macros" }
 

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -2,6 +2,7 @@
 // Copyright 2021-2023 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(windows)]
 use std::{num::NonZeroU32, rc::Rc};
 
 use tao::{

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -192,7 +192,7 @@ pub enum NativeKeyCode {
 
   /// This is the android "key code" of the event as returned by
   /// `KeyEvent.getKeyCode()`
-  Android(u32),
+  Android(i32),
 }
 
 /// Represents the code of a physical key.


### PR DESCRIPTION
Closes #807
Closes #808
Closes #955

Most changes were copied over from my `wry` PR at https://github.com/tauri-apps/wry/pull/1296.  Most notably a `&ThreadLooper` is now passed to `wry::android_setup()` because we have one, and it gives important safety guarantees when it comes to registering callbacks on this looper, without (unnecessarily!) requiring `Send`.  A thread-local requirement already exists for the `JNIEnv` that is passed around anyway.

Also note that certain workarounds and illogical inverted passes around `key_code()` handling are no longer needed, as the `ndk` crate now passes an `enum` with the raw `i32` around so that the `.into()` conversion for `i32` (the correct type) now becomes lossless.

---

In the end I'm also quite surprised how many linter warnings trigger in this crate, which don't seem to be down to just linting on an older Rust toolchain?
