### PR TITLE
feat(ci): explicitly mark tao-macros as a tao dependency on covector

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -70,7 +70,8 @@
     },
     "tao": {
       "path": "./",
-      "manager": "rust"
+      "manager": "rust",
+      "dependencies": ["tao-macros"]
     }
   }
 }


### PR DESCRIPTION
In #964 I forgot to update the tao-macros dependency on the tao Cargo.toml. Let's configure covector to handle that for us.
