### PR TITLE
feat(iOS): added custom URL schemes handling in the `AppDelegate` class

### DIFF
--- a/.changes/ios-custom-url-schemes.md
+++ b/.changes/ios-custom-url-schemes.md
@@ -2,34 +2,4 @@
 "tao": patch
 ---
 
-# iOS: added custom URL schemes handling in the AppDelegate class
-
-Until now, only ["associated
-domains"](https://developer.apple.com/documentation/xcode/supporting-associated-domains)
-were handled, using the `application_continue` function, that implements [this
-Swift method from the `UIApplicationDelegate`
-class](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623072-application).
-
-For [custom URL
-schemes](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app),
-I added a new `application_open_url` function that matches the signature of
-[this other Swift
-method](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application).
-
-Most of the code of the pre-existing `application_continue` has been moved
-into a separate `handle_deep_link` function so the new `application_open_url`
-can call it as well.
-
-I believe using the same `Event::Opened` event is appropriate in both
-situations. Since the scheme is part of the URL, a listener can differentiate
-between them if needed.
-
-## Tauri:
-
-Since we are emitting the same `Event::Opened` event, this change
-works automatically with the ["Deep Linking"
-plugin](https://v2.tauri.app/plugin/deep-linking/) without further
-modifications.
-
-Custom URL schemes in mobile apps are essential, for example,
-when dealing with OAuth redirect URLs.
+On iOS, implement `application:openURL:options:` to handle custom URL schemes.

--- a/.changes/ios-custom-url-schemes.md
+++ b/.changes/ios-custom-url-schemes.md
@@ -1,0 +1,35 @@
+---
+"tao": patch
+---
+
+# iOS: added custom URL schemes handling in the AppDelegate class
+
+Until now, only ["associated
+domains"](https://developer.apple.com/documentation/xcode/supporting-associated-domains)
+were handled, using the `application_continue` function, that implements [this
+Swift method from the `UIApplicationDelegate`
+class](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623072-application).
+
+For [custom URL
+schemes](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app),
+I added a new `application_open_url` function that matches the signature of
+[this other Swift
+method](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application).
+
+Most of the code of the pre-existing `application_continue` has been moved
+into a separate `handle_deep_link` function so the new `application_open_url`
+can call it as well.
+
+I believe using the same `Event::Opened` event is appropriate in both
+situations. Since the scheme is part of the URL, a listener can differentiate
+between them if needed.
+
+## Tauri:
+
+Since we are emitting the same `Event::Opened` event, this change
+works automatically with the ["Deep Linking"
+plugin](https://v2.tauri.app/plugin/deep-linking/) without further
+modifications.
+
+Custom URL schemes in mobile apps are essential, for example,
+when dealing with OAuth redirect URLs.


### PR DESCRIPTION
Until now, only ["associated domains"](https://developer.apple.com/documentation/xcode/supporting-associated-domains) were handled, using the `application_continue` function, implementing [this Swift method from the `UIApplicationDelegate` class](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623072-application).

For [custom URL schemes](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app), I added a new `application_open_url` function that implements the signature of [this other Swift method](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application).

The code of the pre-existing `application_continue` function has been moved into a separate `handle_deep_link` function so the new `application_open_url` function can call it as well.  
For now, I believe it's appropriate to use the same `Event::Opened` event in both situations. Since the scheme is part of the URL, a listener can differentiate between them if needed.

**Tauri:** this change works automatically with the ["Deep Linking" plugin](https://v2.tauri.app/plugin/deep-linking/) without further modifications.  
Custom URL schemes in mobile apps are essential, for example, when dealing with OAuth redirect URLs.