### PR TITLE
fix(windows): fix monitor from_point retunring invalid handle

### DIFF
--- a/.changes/fix-monitor-from-point-handle.md
+++ b/.changes/fix-monitor-from-point-handle.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On Windows, fix `Window::monitor_from_point` and `EventLoopTargetWindow::monitor_from_point` returning invalid monitor handle.

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -133,7 +133,7 @@ pub fn from_point(x: f64, y: f64) -> Option<MonitorHandle> {
       MONITOR_DEFAULTTONULL,
     )
   };
-  if hmonitor.is_invalid() {
+  if !hmonitor.is_invalid() {
     Some(MonitorHandle::new(hmonitor))
   } else {
     None


### PR DESCRIPTION
closes tauri-apps/plugins-workspace#1714

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
