### PR TITLE
feat: add `Window::is_always_on_top` method 

### DIFF
--- a/.changes/is-always-on-top.md
+++ b/.changes/is-always-on-top.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Add is_always_on_top method to check if a window is always on top on macOS, Linux and Windows.

--- a/.changes/is-always-on-top.md
+++ b/.changes/is-always-on-top.md
@@ -2,4 +2,4 @@
 "tao": patch
 ---
 
-Add is_always_on_top method to check if a window is always on top on macOS, Linux and Windows.
+Add `Window::is_always_on_top` method to check if a window is always on top on macOS, Linux and Windows.

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -569,6 +569,11 @@ impl Window {
     false
   }
 
+  pub fn is_always_on_top(&self) -> bool {
+    log::warn!("`Window::is_always_on_top` is ignored on Android");
+    false
+  }
+
   pub fn set_resizable(&self, _resizeable: bool) {
     warn!("`Window::set_resizable` is ignored on Android")
   }

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -77,6 +77,11 @@ impl Inner {
     false
   }
 
+  pub fn is_always_on_top(&self) -> bool {
+    log::warn!("`Window::is_always_on_top` is ignored on iOS");
+    false
+  }
+
   pub fn request_redraw(&self) {
     unsafe {
       if self.gl_or_metal_backed {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -991,6 +991,11 @@ impl UnownedWindow {
   }
 
   #[inline]
+  pub fn is_always_on_top(&self) -> bool {
+    unsafe { self.ns_window.level() == ffi::kCGFloatingWindowLevelKey }
+  }
+
+  #[inline]
   pub fn is_maximized(&self) -> bool {
     self.is_zoomed()
   }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -584,6 +584,14 @@ impl Window {
   }
 
   #[inline]
+  pub fn is_always_on_top(&self) -> bool {
+    let window_state = self.window_state.lock();
+    window_state
+      .window_flags
+      .contains(WindowFlags::ALWAYS_ON_TOP)
+  }
+
+  #[inline]
   pub fn is_minimized(&self) -> bool {
     unsafe { IsIconic(self.hwnd()) }.as_bool()
   }

--- a/src/window.rs
+++ b/src/window.rs
@@ -813,7 +813,7 @@ impl Window {
   ///
   /// ## Platform-specific
   ///
-  /// - **Linux / iOS / Android:** Unsupported.
+  /// - **iOS / Android:** Unsupported.
   #[inline]
   pub fn is_always_on_top(&self) -> bool {
     self.window.is_always_on_top()

--- a/src/window.rs
+++ b/src/window.rs
@@ -813,7 +813,7 @@ impl Window {
   ///
   /// ## Platform-specific
   ///
-  /// - **iOS / Android:** Unsupported.
+  /// - **Linux / iOS / Android:** Unsupported.
   #[inline]
   pub fn is_always_on_top(&self) -> bool {
     self.window.is_always_on_top()

--- a/src/window.rs
+++ b/src/window.rs
@@ -809,6 +809,16 @@ impl Window {
     self.window.is_focused()
   }
 
+  /// Indicates whether the window is always on top of other windows.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **iOS / Android:** Unsupported.
+  #[inline]
+  pub fn is_always_on_top(&self) -> bool {
+    self.window.is_always_on_top()
+  }
+
   /// Sets whether the window is resizable or not.
   ///
   /// Note that making the window unresizable doesn't exempt you from handling `Resized`, as that event can still be


### PR DESCRIPTION
I couldn't find a way to get the "keep above" property through GTK, so the `is_always_on_top` method is not implemented for Linux.

Relate: https://github.com/tauri-apps/tauri/issues/11078

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
