### PR TITLE
fix(windows): fix regression in setting/getting inner size

### DIFF
--- a/.changes/regression-window-set-sinner-size.md
+++ b/.changes/regression-window-set-sinner-size.md
@@ -1,0 +1,6 @@
+---
+"tao": "patch"
+---
+
+On Windows, fix `Window::set_inner_size` regression not handling borders correctly for undecorated window with shadows. 
+

--- a/.changes/regression-window-sinner-size.md
+++ b/.changes/regression-window-sinner-size.md
@@ -1,0 +1,6 @@
+---
+"tao": "patch"
+---
+
+On Windows, fix `Window::inner_size` regression returning incorrect size for window with decorations. 
+

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -95,15 +95,15 @@ pub fn adjust_size(hwnd: HWND, size: PhysicalSize<u32>, is_decorated: bool) -> P
   PhysicalSize::new((rect.right - rect.left) as _, (rect.bottom - rect.top) as _)
 }
 
-pub(crate) fn set_inner_size_physical(window: HWND, x: u32, y: u32, is_decorated: bool) {
+pub(crate) fn set_inner_size_physical(window: HWND, x: i32, y: i32, is_decorated: bool) {
   unsafe {
     let rect = adjust_window_rect(
       window,
       RECT {
         top: 0,
         left: 0,
-        bottom: y as i32,
-        right: x as i32,
+        bottom: y,
+        right: x,
       },
       is_decorated,
     )


### PR DESCRIPTION
fix tauri-apps/tauri#11644

- Fix regression for decorated window, remove borders in `inner_size` only for undecorated window with shadows
- Add borders when setting inner size for undecorated window with shadows

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
