### PR TITLE
fix(windows): remove `WS_CAPTION` and `WS_THICKFRAME` when calculating adjust window rect

### DIFF
--- a/.changes/adjusted-rect.md
+++ b/.changes/adjusted-rect.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+On Windows, fix regression caused undecorated window with shadows to be slightly larger on creation.

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1208,8 +1208,23 @@ unsafe fn init<T: 'static>(
         bottom: h,
       };
       unsafe {
-        AdjustWindowRectEx(&mut rect, style, pl_attribs.menu.is_some(), ex_style)?;
+        AdjustWindowRectEx(
+          &mut rect,
+          window_flags.to_adjusted_window_styles().0,
+          pl_attribs.menu.is_some(),
+          ex_style,
+        )?;
       }
+
+      // account for the 1px we add on each side in WM_NCCALCSIZE
+      // to add shadow for undecorated windows
+      if window_flags.contains(WindowFlags::MARKER_UNDECORATED_SHADOW)
+        && !window_flags.contains(WindowFlags::MARKER_DECORATIONS)
+      {
+        rect.right += 2;
+        rect.bottom += 2;
+      }
+
       (rect.right - rect.left, rect.bottom - rect.top)
     };
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -295,6 +295,17 @@ impl WindowFlags {
     (style, style_ex)
   }
 
+  /// Returns the appropriate window styles for `AdjustWindowRectEx`
+  pub fn to_adjusted_window_styles(self) -> (WINDOW_STYLE, WINDOW_EX_STYLE) {
+    let (mut style, style_ex) = self.to_window_styles();
+
+    if !self.contains(WindowFlags::MARKER_DECORATIONS) {
+      style &= !(WS_CAPTION | WS_THICKFRAME)
+    }
+
+    (style, style_ex)
+  }
+
   /// Adjust the window client rectangle to the return value, if present.
   fn apply_diff(mut self, window: HWND, mut new: WindowFlags) {
     self = self.mask();


### PR DESCRIPTION
closes tauri-apps/tauri#11695

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
