### PR TITLE
fix(windows): use physical position when creating the window

### DIFF
--- a/.changes/inital-position-windows.md
+++ b/.changes/inital-position-windows.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+On Windows, fix regression in initial window position when using logical positions. 


### PR DESCRIPTION
closes tauri-apps/tauri#11718

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
