### PR TITLE
fix(windows): fix appcrash on windows where darkmode is not supported

### DIFF
--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -79,9 +79,13 @@ pub fn allow_dark_mode_for_app(is_dark_mode: bool) {
   });
 
   if let Some(ver) = *WIN10_BUILD_VERSION {
+    // in case Windows 10 Build version < 18362, we have to call a special command (_allow_dark_mode_for_app)
     if ver < 18362 {
-      if let Some(_allow_dark_mode_for_app) = *ALLOW_DARK_MODE_FOR_APP {
-        unsafe { _allow_dark_mode_for_app(is_dark_mode) };
+      // but only call that command if the dark mode is supported...
+      if *DARK_MODE_SUPPORTED {
+        if let Some(_allow_dark_mode_for_app) = *ALLOW_DARK_MODE_FOR_APP {
+          unsafe { _allow_dark_mode_for_app(is_dark_mode) };
+        }
       }
     } else if let Some(_set_preferred_app_mode) = *SET_PREFERRED_APP_MODE {
       let mode = if is_dark_mode {


### PR DESCRIPTION
The changes resolve this bug: tauri-apps/tauri#11674 where Tauri2 crashes immediately on Windows 10 LTSC 2016

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
