### PR TITLE
fix(windows): fix appcrash on windows where darkmode is not supported

### DIFF
--- a/.changes/dark-mode.md
+++ b/.changes/dark-mode.md
@@ -2,4 +2,4 @@
 "tao": "patch"
 ---
 
-Windows: Executing the function allow_dark_mode_for_app only if darkmode is supported.
+On Windows, fix crash on older windows versions that doesn't support dark mode.

--- a/.changes/dark-mode.md
+++ b/.changes/dark-mode.md
@@ -1,0 +1,5 @@
+---
+"tao": "patch"
+---
+
+Windows: Executing the function allow_dark_mode_for_app only if darkmode is supported.

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -79,10 +79,14 @@ pub fn allow_dark_mode_for_app(is_dark_mode: bool) {
   });
 
   if let Some(ver) = *WIN10_BUILD_VERSION {
+    // in case Windows 10 Build version < 18362, we have to call a special command (_allow_dark_mode_for_app)
     if ver < 18362 {
-      if let Some(_allow_dark_mode_for_app) = *ALLOW_DARK_MODE_FOR_APP {
-        unsafe { _allow_dark_mode_for_app(is_dark_mode) };
-      }
+        // but only call that command if the dark mode is supported...
+        if *DARK_MODE_SUPPORTED {
+            if let Some(_allow_dark_mode_for_app) = *ALLOW_DARK_MODE_FOR_APP {
+                unsafe { _allow_dark_mode_for_app(is_dark_mode) };
+            }
+        }
     } else if let Some(_set_preferred_app_mode) = *SET_PREFERRED_APP_MODE {
       let mode = if is_dark_mode {
         PreferredAppMode::AllowDark

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -42,62 +42,60 @@ static DARK_MODE_SUPPORTED: Lazy<bool> = Lazy::new(|| {
 });
 
 pub fn allow_dark_mode_for_app(is_dark_mode: bool) {
-  const UXTHEME_ALLOWDARKMODEFORAPP_ORDINAL: u16 = 135;
-  type AllowDarkModeForApp = unsafe extern "system" fn(bool) -> bool;
-  static ALLOW_DARK_MODE_FOR_APP: Lazy<Option<AllowDarkModeForApp>> = Lazy::new(|| unsafe {
-    if HMODULE(*HUXTHEME as _).is_invalid() {
-      return None;
+  if *DARK_MODE_SUPPORTED {
+    const UXTHEME_ALLOWDARKMODEFORAPP_ORDINAL: u16 = 135;
+    type AllowDarkModeForApp = unsafe extern "system" fn(bool) -> bool;
+    static ALLOW_DARK_MODE_FOR_APP: Lazy<Option<AllowDarkModeForApp>> = Lazy::new(|| unsafe {
+      if HMODULE(*HUXTHEME as _).is_invalid() {
+        return None;
+      }
+
+      GetProcAddress(
+        HMODULE(*HUXTHEME as _),
+        PCSTR::from_raw(UXTHEME_ALLOWDARKMODEFORAPP_ORDINAL as usize as *mut _),
+      )
+      .map(|handle| std::mem::transmute(handle))
+    });
+
+    #[repr(C)]
+    enum PreferredAppMode {
+      Default,
+      AllowDark,
+      // ForceDark,
+      // ForceLight,
+      // Max,
     }
+    const UXTHEME_SETPREFERREDAPPMODE_ORDINAL: u16 = 135;
+    type SetPreferredAppMode = unsafe extern "system" fn(PreferredAppMode) -> PreferredAppMode;
+    static SET_PREFERRED_APP_MODE: Lazy<Option<SetPreferredAppMode>> = Lazy::new(|| unsafe {
+      if HMODULE(*HUXTHEME as _).is_invalid() {
+        return None;
+      }
 
-    GetProcAddress(
-      HMODULE(*HUXTHEME as _),
-      PCSTR::from_raw(UXTHEME_ALLOWDARKMODEFORAPP_ORDINAL as usize as *mut _),
-    )
-    .map(|handle| std::mem::transmute(handle))
-  });
+      GetProcAddress(
+        HMODULE(*HUXTHEME as _),
+        PCSTR::from_raw(UXTHEME_SETPREFERREDAPPMODE_ORDINAL as usize as *mut _),
+      )
+      .map(|handle| std::mem::transmute(handle))
+    });
 
-  #[repr(C)]
-  enum PreferredAppMode {
-    Default,
-    AllowDark,
-    // ForceDark,
-    // ForceLight,
-    // Max,
-  }
-  const UXTHEME_SETPREFERREDAPPMODE_ORDINAL: u16 = 135;
-  type SetPreferredAppMode = unsafe extern "system" fn(PreferredAppMode) -> PreferredAppMode;
-  static SET_PREFERRED_APP_MODE: Lazy<Option<SetPreferredAppMode>> = Lazy::new(|| unsafe {
-    if HMODULE(*HUXTHEME as _).is_invalid() {
-      return None;
-    }
-
-    GetProcAddress(
-      HMODULE(*HUXTHEME as _),
-      PCSTR::from_raw(UXTHEME_SETPREFERREDAPPMODE_ORDINAL as usize as *mut _),
-    )
-    .map(|handle| std::mem::transmute(handle))
-  });
-
-  if let Some(ver) = *WIN10_BUILD_VERSION {
-    // in case Windows 10 Build version < 18362, we have to call a special command (_allow_dark_mode_for_app)
-    if ver < 18362 {
-        // but only call that command if the dark mode is supported...
-        if *DARK_MODE_SUPPORTED {
-            if let Some(_allow_dark_mode_for_app) = *ALLOW_DARK_MODE_FOR_APP {
-                unsafe { _allow_dark_mode_for_app(is_dark_mode) };
-            }
+    if let Some(ver) = *WIN10_BUILD_VERSION {
+      if ver < 18362 {
+        if let Some(_allow_dark_mode_for_app) = *ALLOW_DARK_MODE_FOR_APP {
+          unsafe { _allow_dark_mode_for_app(is_dark_mode) };
         }
-    } else if let Some(_set_preferred_app_mode) = *SET_PREFERRED_APP_MODE {
-      let mode = if is_dark_mode {
-        PreferredAppMode::AllowDark
-      } else {
-        PreferredAppMode::Default
-      };
-      unsafe { _set_preferred_app_mode(mode) };
+      } else if let Some(_set_preferred_app_mode) = *SET_PREFERRED_APP_MODE {
+        let mode = if is_dark_mode {
+          PreferredAppMode::AllowDark
+        } else {
+          PreferredAppMode::Default
+        };
+        unsafe { _set_preferred_app_mode(mode) };
+      }
     }
-  }
 
-  refresh_immersive_color_policy_state();
+    refresh_immersive_color_policy_state();
+  }
 }
 
 fn refresh_immersive_color_policy_state() {


### PR DESCRIPTION
The changes resolve this bug: https://github.com/tauri-apps/tauri/issues/11674 where Tauri2 crashes immediately on Windows 10 LTSC 2016

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

closes tauri-apps/tauri#11674