### PR TITLE
fix(macos): make set_outer_position and set_inner_size sync operations

### DIFF
--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -99,6 +99,19 @@ pub unsafe fn set_frame_top_left_point_async(ns_window: id, point: NSPoint) {
   });
 }
 
+// `setFrameTopLeftPoint:` isn't thread-safe, but fortunately has the courtesy
+// to log errors.
+pub unsafe fn set_frame_top_left_point_sync(ns_window: id, point: NSPoint) {
+  if is_main_thread() {
+    ns_window.setFrameTopLeftPoint_(point);
+  } else {
+    let ns_window = MainThreadSafe(ns_window);
+    Queue::main().exec_sync(move || {
+      ns_window.setFrameTopLeftPoint_(point);
+    })
+  }
+}
+
 // `setFrameTopLeftPoint:` isn't thread-safe, and fails silently.
 pub unsafe fn set_level_async(ns_window: id, level: ffi::NSWindowLevel) {
   let ns_window = MainThreadSafe(ns_window);

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -90,6 +90,17 @@ pub unsafe fn set_content_size_async(ns_window: id, size: LogicalSize<f64>) {
   });
 }
 
+pub unsafe fn set_content_size_sync(ns_window: id, size: LogicalSize<f64>) {
+  if is_main_thread() {
+    ns_window.setContentSize_(NSSize::new(size.width as CGFloat, size.height as CGFloat));
+  } else {
+    let ns_window = MainThreadSafe(ns_window);
+    Queue::main().exec_sync(move || {
+      ns_window.setContentSize_(NSSize::new(size.width as CGFloat, size.height as CGFloat));
+    });
+  }
+}
+
 // `setFrameTopLeftPoint:` isn't thread-safe, but fortunately has the courtesy
 // to log errors.
 pub unsafe fn set_frame_top_left_point_async(ns_window: id, point: NSPoint) {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -715,7 +715,7 @@ impl UnownedWindow {
   pub fn set_inner_size(&self, size: Size) {
     unsafe {
       let scale_factor = self.scale_factor();
-      util::set_content_size_async(*self.ns_window, size.to_logical(scale_factor));
+      util::set_content_size_sync(*self.ns_window, size.to_logical(scale_factor));
     }
   }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -689,7 +689,7 @@ impl UnownedWindow {
     let scale_factor = self.scale_factor();
     let position = position.to_logical(scale_factor);
     unsafe {
-      util::set_frame_top_left_point_async(*self.ns_window, util::window_position(position));
+      util::set_frame_top_left_point_sync(*self.ns_window, util::window_position(position));
     }
   }
 


### PR DESCRIPTION
For code like this(this is how plugin window-state restores window state):

```
window.set_size();
window.set_position();
window.show();
```

This fix ensures that showing of the window happens after actually changing of size and position, and fixes window reposition problem on MacOS described at https://github.com/tauri-apps/plugins-workspace/issues/1663.