### PR TITLE
fix(linux):  call gtk_init to fix tauri-apps/tauri#11312

### DIFF
--- a/.changes/explicit_gtk_init.md
+++ b/.changes/explicit_gtk_init.md
@@ -2,6 +2,4 @@
 "tao": patch
 ---
 
-Explicitly call `gtk::init()` as `gtk::Application::new` does not call it reliably.
-If `gtk::init()` is not called, 'GTK may only be used from the main thread' error can occur later.
-`gtk::init()` checks if already initialized and does nothing if so.
+Call `gtk::init` when creating the eventloop to fix crashes with some gtk APIs.

--- a/.changes/explicit_gtk_init.md
+++ b/.changes/explicit_gtk_init.md
@@ -1,0 +1,7 @@
+---
+"tao": patch
+---
+
+Explicitly call `gtk::init()` as `gtk::Application::new` does not call it reliably.
+If `gtk::init()` is not called, 'GTK may only be used from the main thread' error can occur later.
+`gtk::init()` checks if already initialized and does nothing if so.

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -215,6 +215,8 @@ impl<T: 'static> EventLoop<T> {
   }
 
   fn new_gtk(app_id: Option<&str>) -> Result<EventLoop<T>, Box<dyn Error>> {
+    // This should be done by gtk::Application::new, but does not work properly
+    gtk::init()?;
     let context = MainContext::default();
     let app = gtk::Application::new(app_id, gio::ApplicationFlags::empty());
     let app_ = app.clone();


### PR DESCRIPTION
This fixes tauri-apps/tauri#11312, this issue also contains some more information regarding this change.

To summarize, on Linux a crash is seen where gtk-rs fails an assert with error message "GTK may only be used from the main thread".

In tao, `gtk::Application::new` is used which should remove the need for calling `gtk::init()`. I believe there's a bug here, in either gtk-rs or gtk itself, but I've been unable to check this so far, where `gtk::init()` is not called or gtk-rs' internal INITIALIZED variable is not updated.

Later on at attempted use of a GTK function we get the failed assert and crash afterwards.

Adding an explicit `gtk::init()` call here fixes this issue. Calling this function multiple times should have no negative side effects, as there is a check to skip initializing when already done.

There are some unknowns:
- Why was this introduced around 2.0.0? Did something previously call `gtk_init` through some (indirect) path?
- Why does `gtk::Application::new` not work as expected?

Reference documentation:
- https://docs.gtk.org/gtk3/ctor.Application.new.html
- https://docs.gtk.org/gio/method.Application.register.html
- https://github.com/gtk-rs/gtk3-rs/blob/master/gtk/src/application.rs
- https://github.com/gtk-rs/gtk3-rs/blob/master/gtk/src/rt.rs