### PR TITLE
fix(macos): remove internal `From` implementation

### DIFF
--- a/.changes/remove-from-activation-policy.md
+++ b/.changes/remove-from-activation-policy.md
@@ -1,0 +1,5 @@
+---
+tao: minor
+---
+
+macOS: Remove `From<ActivationPolicy>` implementation for `cocoa::appkit::NSApplicationActivationPolicy`.


### PR DESCRIPTION
Removes `impl From<ActivationPolicy> for NSApplicationActivationPolicy`.

This is needed to avoid publicly exposing a dependency on cocoa, which will allow [using `objc2`](https://github.com/tauri-apps/wry/issues/1239) in the future.