### PR TITLE
Use `objc2`

### DIFF
--- a/.changes/objc2.md
+++ b/.changes/objc2.md
@@ -1,0 +1,5 @@
+---
+tao: patch
+---
+
+Use `objc2`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,10 +104,41 @@ ndk-context = "0.1"
 tao-macros = { version = "0.1.0", path = "./tao-macros" }
 
 [target."cfg(any(target_os = \"ios\", target_os = \"macos\"))".dependencies]
-objc = "0.2"
+objc2 = "0.5"
 
 [target."cfg(target_os = \"macos\")".dependencies]
-cocoa = "0.26"
+objc2-foundation = { version = "0.2", default-features = false, features = [
+  "std",
+  "NSArray",
+  "NSAttributedString",
+  "NSAutoreleasePool",
+  "NSDate",
+  "NSDictionary",
+  "NSEnumerator",
+  "NSGeometry",
+  "NSObjCRuntime",
+  "NSRange",
+  "NSString",
+  "NSThread",
+  "NSURL",
+] }
+objc2-app-kit = { version = "0.2", default-features = false, features = [
+  "std",
+  "NSApplication",
+  "NSButton",
+  "NSColor",
+  "NSControl",
+  "NSEvent",
+  "NSGraphics",
+  "NSImage",
+  "NSOpenGLView",
+  "NSPasteboard",
+  "NSResponder",
+  "NSRunningApplication",
+  "NSScreen",
+  "NSView",
+  "NSWindow",
+] }
 core-foundation = "0.10"
 core-graphics = "0.24"
 dispatch = "0.2"

--- a/src/event.rs
+++ b/src/event.rs
@@ -37,8 +37,7 @@
 //! describes what happens in what order.
 //!
 //! [event_loop_run]: crate::event_loop::EventLoop::run
-use std::path::PathBuf;
-use std::time::Instant;
+use std::{path::PathBuf, time::Instant};
 
 use crate::{
   dpi::{PhysicalPosition, PhysicalSize},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,8 +167,8 @@ extern crate serde;
 #[macro_use]
 extern crate bitflags;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-#[macro_use]
-extern crate objc;
+#[macro_use(class, msg_send, sel)]
+extern crate objc2;
 
 pub use dpi;
 

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -13,7 +13,7 @@ use std::{
   time::Instant,
 };
 
-use objc::runtime::{BOOL, YES};
+use objc2::runtime::AnyObject;
 
 use crate::{
   dpi::LogicalSize,
@@ -475,10 +475,7 @@ impl AppState {
 // retains window
 pub unsafe fn set_key_window(window: id) {
   bug_assert!(
-    {
-      let is_window: BOOL = msg_send![window, isKindOfClass: class!(UIWindow)];
-      is_window == YES
-    },
+    msg_send![window, isKindOfClass: class!(UIWindow)],
     "set_key_window called with an incorrect type"
   );
   let mut this = AppState::get_mut();
@@ -505,10 +502,7 @@ pub unsafe fn set_key_window(window: id) {
 // retains window
 pub unsafe fn queue_gl_or_metal_redraw(window: id) {
   bug_assert!(
-    {
-      let is_window: BOOL = msg_send![window, isKindOfClass: class!(UIWindow)];
-      is_window == YES
-    },
+    msg_send![window, isKindOfClass: class!(UIWindow)],
     "set_key_window called with an incorrect type"
   );
   let mut this = AppState::get_mut();
@@ -582,7 +576,7 @@ pub unsafe fn did_finish_launching() {
       let () = msg_send![window, setScreen: screen];
       let () = msg_send![screen, release];
       let controller: id = msg_send![window, rootViewController];
-      let () = msg_send![window, setRootViewController:ptr::null::<()>()];
+      let () = msg_send![window, setRootViewController: ptr::null::<AnyObject>()];
       let () = msg_send![window, setRootViewController: controller];
       let () = msg_send![window, makeKeyAndVisible];
     }
@@ -1019,7 +1013,7 @@ pub fn os_capabilities() -> OSCapabilities {
       static ref OS_CAPABILITIES: OSCapabilities = {
           let version: NSOperatingSystemVersion = unsafe {
               let process_info: id = msg_send![class!(NSProcessInfo), processInfo];
-              let atleast_ios_8: BOOL = msg_send![
+              let atleast_ios_8: bool = msg_send![
                   process_info,
                   respondsToSelector: sel!(operatingSystemVersion)
               ];
@@ -1031,7 +1025,7 @@ pub fn os_capabilities() -> OSCapabilities {
               //
               // The minimum required iOS version is likely to grow in the future.
               assert!(
-                  atleast_ios_8 == YES,
+                  atleast_ios_8,
                   "`tao` requires iOS version 8 or greater"
               );
               msg_send![process_info, operatingSystemVersion]

--- a/src/platform_impl/ios/badge.rs
+++ b/src/platform_impl/ios/badge.rs
@@ -1,10 +1,12 @@
-use objc::runtime::{Class, Object};
-use objc::{msg_send, sel, sel_impl};
+use objc2::{
+  msg_send,
+  runtime::{AnyClass, AnyObject},
+};
 
 pub fn set_badge_count(count: i32) {
   unsafe {
-    let ui_application = Class::get("UIApplication").expect("Failed to get UIApplication class");
-    let app: *mut Object = msg_send![ui_application, sharedApplication];
+    let ui_application = AnyClass::get("UIApplication").expect("Failed to get UIApplication class");
+    let app: *mut AnyObject = msg_send![ui_application, sharedApplication];
     let _: () = msg_send![app, setApplicationIconBadgeNumber:count];
   }
 }

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -143,7 +143,7 @@ impl<T: 'static> EventLoop<T> {
     F: 'static + FnMut(Event<'_, T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
   {
     unsafe {
-      let application: *mut c_void = msg_send![class!(UIApplication), sharedApplication];
+      let application: id = msg_send![class!(UIApplication), sharedApplication];
       assert_eq!(
         application,
         ptr::null_mut(),

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -66,8 +66,8 @@
 // window size/position.
 macro_rules! assert_main_thread {
     ($($t:tt)*) => {
-        let is_main_thread: ::objc::runtime::BOOL = msg_send!(class!(NSThread), isMainThread);
-        if is_main_thread == ::objc::runtime::NO {
+        let is_main_thread: bool = msg_send![class!(NSThread), isMainThread];
+        if !is_main_thread {
             panic!($($t)*);
         }
     };

--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -192,7 +192,7 @@ impl MonitorHandle {
   pub fn retained_new(uiscreen: id) -> MonitorHandle {
     unsafe {
       assert_main_thread!("`MonitorHandle` can only be cloned on the main thread on iOS");
-      let () = msg_send![uiscreen, retain];
+      let _: id = msg_send![uiscreen, retain];
     }
     MonitorHandle {
       inner: Inner { uiscreen },

--- a/src/platform_impl/macos/badge.rs
+++ b/src/platform_impl/macos/badge.rs
@@ -1,12 +1,16 @@
-use cocoa::{appkit::NSApp, base::nil, foundation::NSString};
+use super::ffi::id;
+use objc2_app_kit::NSApp;
+use objc2_foundation::{MainThreadMarker, NSString};
 
 pub fn set_badge_label(label: Option<String>) {
+  // SAFETY: TODO
+  let mtm = unsafe { MainThreadMarker::new_unchecked() };
   unsafe {
     let label = match label {
-      None => nil,
-      Some(label) => NSString::alloc(nil).init_str(&label),
+      None => None,
+      Some(label) => Some(NSString::from_str(&label)),
     };
-    let dock_tile: cocoa::base::id = msg_send![NSApp(), dockTile];
-    let _: cocoa::base::id = msg_send![dock_tile, setBadgeLabel: label];
+    let dock_tile: id = msg_send![&NSApp(mtm), dockTile];
+    let _: () = msg_send![dock_tile, setBadgeLabel: label.as_deref()];
   }
 }

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -25,7 +25,7 @@ use std::{fmt, ops::Deref, sync::Arc};
 
 pub(crate) use self::event_loop::PlatformSpecificEventLoopAttributes;
 pub use self::{
-  app_delegate::{get_aux_state_mut, AuxDelegateState},
+  app_delegate::get_aux_state_mut,
   event::KeyEventExtra,
   event_loop::{EventLoop, EventLoopWindowTarget, Proxy as EventLoopProxy},
   keycode::{keycode_from_scancode, keycode_to_scancode},

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -7,25 +7,22 @@ use std::{
   sync::{Mutex, Weak},
 };
 
-use cocoa::{
-  appkit::{CGFloat, NSScreen, NSWindow, NSWindowStyleMask},
-  base::{id, nil},
-  foundation::{NSPoint, NSSize, NSString},
-};
+use core_graphics::base::CGFloat;
 use dispatch::Queue;
-use objc::{
-  rc::autoreleasepool,
-  runtime::{BOOL, NO, YES},
-};
+use objc2::{rc::autoreleasepool, ClassType};
+use objc2_app_kit::{NSScreen, NSView, NSWindow, NSWindowStyleMask};
+use objc2_foundation::{MainThreadMarker, NSPoint, NSSize, NSString};
 
 use crate::{
   dpi::LogicalSize,
-  platform_impl::platform::{ffi, util::IdRef, window::SharedState},
+  platform_impl::platform::{
+    ffi::{self, id, NO, YES},
+    window::SharedState,
+  },
 };
 
 pub fn is_main_thread() -> bool {
-  let is: BOOL = unsafe { msg_send!(class!(NSThread), isMainThread) };
-  is == YES
+  unsafe { msg_send!(class!(NSThread), isMainThread) }
 }
 
 // Unsafe wrapper type that allows us to dispatch things that aren't Send.
@@ -51,72 +48,76 @@ fn run_on_main<R: Send>(f: impl FnOnce() -> R + Send) -> R {
   }
 }
 
-unsafe fn set_style_mask(ns_window: id, ns_view: id, mask: NSWindowStyleMask) {
-  ns_window.setStyleMask_(mask);
+unsafe fn set_style_mask(ns_window: &NSWindow, ns_view: &NSView, mask: NSWindowStyleMask) {
+  ns_window.setStyleMask(mask);
   // If we don't do this, key handling will break
   // (at least until the window is clicked again/etc.)
-  ns_window.makeFirstResponder_(ns_view);
+  ns_window.makeFirstResponder(Some(ns_view));
 }
 
 // Always use this function instead of trying to modify `styleMask` directly!
 // `setStyleMask:` isn't thread-safe, so we have to use Grand Central Dispatch.
 // Otherwise, this would vomit out errors about not being on the main thread
 // and fail to do anything.
-pub unsafe fn set_style_mask_async(ns_window: id, ns_view: id, mask: NSWindowStyleMask) {
-  let ns_window = MainThreadSafe(ns_window);
-  let ns_view = MainThreadSafe(ns_view);
+pub unsafe fn set_style_mask_async(
+  ns_window: &NSWindow,
+  ns_view: &NSView,
+  mask: NSWindowStyleMask,
+) {
+  let ns_window = MainThreadSafe(ns_window.retain());
+  let ns_view = MainThreadSafe(ns_view.retain());
   Queue::main().exec_async(move || {
-    set_style_mask(*ns_window, *ns_view, mask);
+    set_style_mask(&*ns_window, &*ns_view, mask);
   });
 }
-pub unsafe fn set_style_mask_sync(ns_window: id, ns_view: id, mask: NSWindowStyleMask) {
+pub unsafe fn set_style_mask_sync(ns_window: &NSWindow, ns_view: &NSView, mask: NSWindowStyleMask) {
   if is_main_thread() {
     set_style_mask(ns_window, ns_view, mask);
   } else {
-    let ns_window = MainThreadSafe(ns_window);
-    let ns_view = MainThreadSafe(ns_view);
+    let ns_window = MainThreadSafe(ns_window.retain());
+    let ns_view = MainThreadSafe(ns_view.retain());
     Queue::main().exec_sync(move || {
-      set_style_mask(*ns_window, *ns_view, mask);
+      set_style_mask(&*ns_window, &*ns_view, mask);
     })
   }
 }
 
 // `setContentSize:` isn't thread-safe either, though it doesn't log any errors
 // and just fails silently. Anyway, GCD to the rescue!
-pub unsafe fn set_content_size_async(ns_window: id, size: LogicalSize<f64>) {
-  let ns_window = MainThreadSafe(ns_window);
+pub unsafe fn set_content_size_async(ns_window: &NSWindow, size: LogicalSize<f64>) {
+  let ns_window = MainThreadSafe(ns_window.retain());
   Queue::main().exec_async(move || {
-    ns_window.setContentSize_(NSSize::new(size.width as CGFloat, size.height as CGFloat));
+    ns_window.setContentSize(NSSize::new(size.width as CGFloat, size.height as CGFloat));
   });
 }
 
 // `setFrameTopLeftPoint:` isn't thread-safe, but fortunately has the courtesy
 // to log errors.
-pub unsafe fn set_frame_top_left_point_async(ns_window: id, point: NSPoint) {
-  let ns_window = MainThreadSafe(ns_window);
+pub unsafe fn set_frame_top_left_point_async(ns_window: &NSWindow, point: NSPoint) {
+  let ns_window = MainThreadSafe(ns_window.retain());
   Queue::main().exec_async(move || {
-    ns_window.setFrameTopLeftPoint_(point);
+    ns_window.setFrameTopLeftPoint(point);
   });
 }
 
 // `setFrameTopLeftPoint:` isn't thread-safe, and fails silently.
-pub unsafe fn set_level_async(ns_window: id, level: ffi::NSWindowLevel) {
-  let ns_window = MainThreadSafe(ns_window);
+pub unsafe fn set_level_async(ns_window: &NSWindow, level: ffi::NSWindowLevel) {
+  let ns_window = MainThreadSafe(ns_window.retain());
   Queue::main().exec_async(move || {
-    ns_window.setLevel_(level as _);
+    ns_window.setLevel(level as _);
   });
 }
 
 // `toggleFullScreen` is thread-safe, but our additional logic to account for
 // window styles isn't.
 pub unsafe fn toggle_full_screen_async(
-  ns_window: id,
-  ns_view: id,
+  ns_window: &NSWindow,
+  ns_view: &NSView,
   not_fullscreen: bool,
   shared_state: Weak<Mutex<SharedState>>,
 ) {
-  let ns_window = MainThreadSafe(ns_window);
-  let ns_view = MainThreadSafe(ns_view);
+  let ns_window = MainThreadSafe(ns_window.retain());
+  let ns_view = MainThreadSafe(ns_view.retain());
   let shared_state = MainThreadSafe(shared_state);
   Queue::main().exec_async(move || {
     // `toggleFullScreen` doesn't work if the `StyleMask` is none, so we
@@ -124,10 +125,9 @@ pub unsafe fn toggle_full_screen_async(
     // restored in `WindowDelegate::window_did_exit_fullscreen`.
     if not_fullscreen {
       let curr_mask = ns_window.styleMask();
-      let required =
-        NSWindowStyleMask::NSTitledWindowMask | NSWindowStyleMask::NSResizableWindowMask;
+      let required = NSWindowStyleMask::Titled | NSWindowStyleMask::Resizable;
       if !curr_mask.contains(required) {
-        set_style_mask(*ns_window, *ns_view, required);
+        set_style_mask(&ns_window, &ns_view, required);
         if let Some(shared_state) = shared_state.upgrade() {
           trace!("Locked shared state in `toggle_full_screen_callback`");
           let mut shared_state_lock = shared_state.lock().unwrap();
@@ -139,8 +139,8 @@ pub unsafe fn toggle_full_screen_async(
     // Window level must be restored from `CGShieldingWindowLevel()
     // + 1` back to normal in order for `toggleFullScreen` to do
     // anything
-    ns_window.setLevel_(0);
-    ns_window.toggleFullScreen_(nil);
+    ns_window.setLevel(0);
+    ns_window.toggleFullScreen(None);
   });
 }
 
@@ -153,12 +153,12 @@ pub unsafe fn restore_display_mode_async(ns_screen: u32) {
 
 // `setMaximized` is not thread-safe
 pub unsafe fn set_maximized_async(
-  ns_window: id,
+  ns_window: &NSWindow,
   is_zoomed: bool,
   maximized: bool,
   shared_state: Weak<Mutex<SharedState>>,
 ) {
-  let ns_window = MainThreadSafe(ns_window);
+  let ns_window = MainThreadSafe(ns_window.retain());
   let shared_state = MainThreadSafe(shared_state);
   Queue::main().exec_async(move || {
     if let Some(shared_state) = shared_state.upgrade() {
@@ -167,7 +167,7 @@ pub unsafe fn set_maximized_async(
 
       // Save the standard frame sized if it is not zoomed
       if !is_zoomed {
-        shared_state_lock.standard_frame = Some(NSWindow::frame(*ns_window));
+        shared_state_lock.standard_frame = Some(NSWindow::frame(&ns_window));
       }
 
       shared_state_lock.maximized = maximized;
@@ -176,20 +176,21 @@ pub unsafe fn set_maximized_async(
       if shared_state_lock.fullscreen.is_some() {
         // Handle it in window_did_exit_fullscreen
         return;
-      } else if curr_mask.contains(NSWindowStyleMask::NSResizableWindowMask)
-        && curr_mask.contains(NSWindowStyleMask::NSTitledWindowMask)
+      } else if curr_mask.contains(NSWindowStyleMask::Resizable)
+        && curr_mask.contains(NSWindowStyleMask::Titled)
       {
         // Just use the native zoom if resizable
-        ns_window.zoom_(nil);
+        ns_window.zoom(None);
       } else {
         // if it's not resizable, we set the frame directly
         let new_rect = if maximized {
-          let screen = NSScreen::mainScreen(nil);
-          NSScreen::visibleFrame(screen)
+          let mtm = MainThreadMarker::new_unchecked();
+          let screen = NSScreen::mainScreen(mtm).unwrap();
+          NSScreen::visibleFrame(&screen)
         } else {
           shared_state_lock.saved_standard_frame()
         };
-        let _: () = msg_send![*ns_window, setFrame:new_rect display:NO animate: YES];
+        let _: () = msg_send![&*ns_window, setFrame:new_rect display:NO animate: YES];
       }
 
       trace!("Unlocked shared state in `set_maximized`");
@@ -199,38 +200,38 @@ pub unsafe fn set_maximized_async(
 
 // `orderOut:` isn't thread-safe. Calling it from another thread actually works,
 // but with an odd delay.
-pub unsafe fn order_out_sync(ns_window: id) {
-  let ns_window = MainThreadSafe(ns_window);
+pub unsafe fn order_out_sync(ns_window: &NSWindow) {
+  let ns_window = MainThreadSafe(ns_window.retain());
   run_on_main(move || {
-    ns_window.orderOut_(nil);
+    ns_window.orderOut(None);
   });
 }
 
 // `makeKeyAndOrderFront:` isn't thread-safe. Calling it from another thread
 // actually works, but with an odd delay.
-pub unsafe fn make_key_and_order_front_sync(ns_window: id) {
-  let ns_window = MainThreadSafe(ns_window);
+pub unsafe fn make_key_and_order_front_sync(ns_window: &NSWindow) {
+  let ns_window = MainThreadSafe(ns_window.retain());
   run_on_main(move || {
-    ns_window.makeKeyAndOrderFront_(nil);
+    ns_window.makeKeyAndOrderFront(None);
   });
 }
 
 // `setTitle:` isn't thread-safe. Calling it from another thread invalidates the
 // window drag regions, which throws an exception when not done in the main
 // thread
-pub unsafe fn set_title_async(ns_window: id, title: String) {
-  let ns_window = MainThreadSafe(ns_window);
+pub unsafe fn set_title_async(ns_window: &NSWindow, title: String) {
+  let ns_window = MainThreadSafe(ns_window.retain());
   Queue::main().exec_async(move || {
-    let title = IdRef::new(NSString::alloc(nil).init_str(&title));
-    ns_window.setTitle_(*title);
+    let title = NSString::from_str(&title);
+    ns_window.setTitle(&title);
   });
 }
 
 // `setFocus:` isn't thread-safe.
-pub unsafe fn set_focus(ns_window: id) {
-  let ns_window = MainThreadSafe(ns_window);
+pub unsafe fn set_focus(ns_window: &NSWindow) {
+  let ns_window = MainThreadSafe(ns_window.retain());
   run_on_main(move || {
-    ns_window.makeKeyAndOrderFront_(nil);
+    ns_window.makeKeyAndOrderFront(None);
     let app: id = msg_send![class!(NSApplication), sharedApplication];
     let () = msg_send![app, activateIgnoringOtherApps: YES];
   });
@@ -238,22 +239,19 @@ pub unsafe fn set_focus(ns_window: id) {
 
 // `close:` is thread-safe, but we want the event to be triggered from the main
 // thread. Though, it's a good idea to look into that more...
-//
-// ArturKovacs: It's important that this operation keeps the underlying window alive
-// through the `IdRef` because otherwise it would dereference free'd memory
-pub unsafe fn close_async(ns_window: IdRef) {
-  let ns_window = MainThreadSafe(ns_window);
+pub unsafe fn close_async(ns_window: &NSWindow) {
+  let ns_window = MainThreadSafe(ns_window.retain());
   run_on_main(move || {
-    autoreleasepool(move || {
+    autoreleasepool(move |_| {
       ns_window.close();
     });
   });
 }
 
 // `setIgnoresMouseEvents_:` isn't thread-safe, and fails silently.
-pub unsafe fn set_ignore_mouse_events(ns_window: id, ignore: bool) {
-  let ns_window = MainThreadSafe(ns_window);
+pub unsafe fn set_ignore_mouse_events(ns_window: &NSWindow, ignore: bool) {
+  let ns_window = MainThreadSafe(ns_window.retain());
   Queue::main().exec_async(move || {
-    ns_window.setIgnoresMouseEvents_(if ignore { YES } else { NO });
+    ns_window.setIgnoresMouseEvents(ignore);
   });
 }


### PR DESCRIPTION
I suspect it'll take a while before `winit` will be in a state where `tao` can use that directly, so in the meantime, let's slowly start transitioning `tao` to `objc2`. I tried to make this transition in a way that minimizes the amount of code changes, but it's really hard to separate things out, so it ended up being quite large anyways.

Full disclosure: The biggest reason why I'm doing this is to reduce the number of dependencies on `objc` across the ecosystem, I don't intend on fully finishing the transition in `tao` / making full use of the features offered by `objc2` (hopefully `winit` will be ready to be usable for you one day).
But I think even this initial transition can be valuable to you, as it fixes at least some of the memory leaks currently present, and makes it easier to develop new features (including [visionOS support](https://github.com/tauri-apps/tauri/issues/9969)).

I've tested every example on macOS 14.7.1, and on Mac Catalyst (works very poorly here, but at least we don't trigger any obvious encoding validation errors).

Builds upon https://github.com/tauri-apps/tao/pull/1048.
Fixes the last part of https://github.com/tauri-apps/wry/issues/1239.

CC @pewsheen since you did [the work in `wry`](https://github.com/tauri-apps/wry/pull/1316).