### PR TITLE
fix(windows): calculate accurate window insets for undecorated shadows

### DIFF
--- a/.changes/windows-undecorated-insets.md
+++ b/.changes/windows-undecorated-insets.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On Windows, fix regression `Window::inner_size` reporting larger size than what's visible for undecorated window.

--- a/.changes/windows-undecorated-resizing.md
+++ b/.changes/windows-undecorated-resizing.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On Windows, undecorated window with shadows, now have native resize handles outside of the window client area.

--- a/src/platform_impl/windows/dpi.rs
+++ b/src/platform_impl/windows/dpi.rs
@@ -64,9 +64,8 @@ pub fn get_monitor_dpi(hmonitor: HMONITOR) -> Option<u32> {
   None
 }
 
-pub const BASE_DPI: u32 = 96;
 pub fn dpi_to_scale_factor(dpi: u32) -> f64 {
-  dpi as f64 / BASE_DPI as f64
+  dpi as f64 / USER_DEFAULT_SCREEN_DPI as f64
 }
 
 pub unsafe fn hwnd_dpi(hwnd: HWND) -> u32 {
@@ -77,14 +76,14 @@ pub unsafe fn hwnd_dpi(hwnd: HWND) -> u32 {
   if let Some(GetDpiForWindow) = *GET_DPI_FOR_WINDOW {
     // We are on Windows 10 Anniversary Update (1607) or later.
     match GetDpiForWindow(hwnd) {
-      0 => BASE_DPI, // 0 is returned if hwnd is invalid
+      0 => USER_DEFAULT_SCREEN_DPI, // 0 is returned if hwnd is invalid
       dpi => dpi as u32,
     }
   } else if let Some(GetDpiForMonitor) = *GET_DPI_FOR_MONITOR {
     // We are on Windows 8.1 or later.
     let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
     if monitor.is_invalid() {
-      return BASE_DPI;
+      return USER_DEFAULT_SCREEN_DPI;
     }
 
     let mut dpi_x = 0;
@@ -92,7 +91,7 @@ pub unsafe fn hwnd_dpi(hwnd: HWND) -> u32 {
     if GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y).is_ok() {
       dpi_x as u32
     } else {
-      BASE_DPI
+      USER_DEFAULT_SCREEN_DPI
     }
   } else {
     // We are on Vista or later.
@@ -104,7 +103,7 @@ pub unsafe fn hwnd_dpi(hwnd: HWND) -> u32 {
       // If the process is DPI unaware, then scaling is performed by the OS; we thus return
       // 96 (scale factor 1.0) to prevent the window from being re-scaled by both the
       // application and the WM.
-      BASE_DPI
+      USER_DEFAULT_SCREEN_DPI
     }
   }
 }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -33,6 +33,7 @@ use windows::{
     },
     UI::{
       Controls::{self as win32c, HOVER_DEFAULT},
+      HiDpi::GetSystemMetricsForDpi,
       Input::{KeyboardAndMouse::*, Pointer::*, Touch::*, *},
       Shell::{
         DefSubclassProc, RemoveWindowSubclass, SHAppBarMessage, SetWindowSubclass, ABE_BOTTOM,
@@ -65,6 +66,8 @@ use crate::{
   window::{Fullscreen, Theme, WindowId as RootWindowId},
 };
 use runner::{EventLoopRunner, EventLoopRunnerShared};
+
+use super::dpi::hwnd_dpi;
 
 type GetPointerFrameInfoHistory = unsafe extern "system" fn(
   pointerId: u32,
@@ -2167,9 +2170,8 @@ unsafe fn public_window_callback_inner<T: 'static>(
       let window_state = subclass_input.window_state.lock();
       let window_flags = window_state.window_flags();
 
-      // Allow resizing unmaximized non-fullscreen undecorated window without shadows
+      // Allow resizing unmaximized non-fullscreen undecorated window
       if !window_flags.contains(WindowFlags::MARKER_DECORATIONS)
-        && !window_flags.contains(WindowFlags::MARKER_UNDECORATED_SHADOW)
         && window_flags.contains(WindowFlags::RESIZABLE)
         && window_state.fullscreen.is_none()
         && !util::is_maximized(window).unwrap_or(false)
@@ -2180,25 +2182,38 @@ unsafe fn public_window_callback_inner<T: 'static>(
           util::GET_Y_LPARAM(lparam) as i32,
         );
 
-        let mut rect = RECT::default();
-        let _ = GetWindowRect(window, &mut rect);
+        let dpi = hwnd_dpi(window);
+        let border_y = GetSystemMetricsForDpi(SM_CYFRAME, dpi);
 
-        let padded_border = GetSystemMetrics(SM_CXPADDEDBORDER);
-        let border_x = GetSystemMetrics(SM_CXFRAME) + padded_border;
-        let border_y = GetSystemMetrics(SM_CYFRAME) + padded_border;
+        // if we have undecorated shadows, we only need to handle the top edge
+        if window_flags.contains(WindowFlags::MARKER_UNDECORATED_SHADOW) {
+          let mut cursor_pt = POINT { x: cx, y: cy };
+          if ScreenToClient(window, &mut cursor_pt).as_bool()
+            && cursor_pt.y >= 0
+            && cursor_pt.y <= border_y
+          {
+            result = ProcResult::Value(LRESULT(HTTOP as _));
+          }
+        } else {
+          //otherwise do full hit testing
+          let border_x = GetSystemMetricsForDpi(SM_CXFRAME, dpi);
 
-        let hit_result = crate::window::hit_test(
-          (rect.left, rect.top, rect.right, rect.bottom),
-          cx,
-          cy,
-          border_x,
-          border_y,
-        )
-        .map(|d| d.to_win32());
+          let mut rect = RECT::default();
+          let _ = GetWindowRect(window, &mut rect);
 
-        result = hit_result
-          .map(|r| ProcResult::Value(LRESULT(r as _)))
-          .unwrap_or(ProcResult::DefSubclassProc);
+          let hit_result = crate::window::hit_test(
+            (rect.left, rect.top, rect.right, rect.bottom),
+            cx,
+            cy,
+            border_x,
+            border_y,
+          )
+          .map(|d| d.to_win32());
+
+          result = hit_result
+            .map(|r| ProcResult::Value(LRESULT(r as _)))
+            .unwrap_or(ProcResult::DefSubclassProc);
+        }
       } else {
         result = ProcResult::DefSubclassProc;
       }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2151,10 +2151,13 @@ unsafe fn public_window_callback_inner<T: 'static>(
           }
         } else if window_flags.contains(WindowFlags::MARKER_UNDECORATED_SHADOW) && !is_fullscreen {
           let params = &mut *(lparam.0 as *mut NCCALCSIZE_PARAMS);
-          params.rgrc[0].top += 1;
-          params.rgrc[0].bottom += 1;
-          params.rgrc[0].left += 1;
-          params.rgrc[0].right += 1;
+
+          let insets = util::calculate_window_insets(window);
+
+          params.rgrc[0].left += insets.left;
+          params.rgrc[0].top += insets.top;
+          params.rgrc[0].right -= insets.right;
+          params.rgrc[0].bottom -= insets.bottom;
         }
         result = ProcResult::Value(LRESULT(0)); // return 0 here to make the window borderless
       }
@@ -2164,8 +2167,9 @@ unsafe fn public_window_callback_inner<T: 'static>(
       let window_state = subclass_input.window_state.lock();
       let window_flags = window_state.window_flags();
 
-      // Allow resizing unmaximized non-fullscreen undecorated window
+      // Allow resizing unmaximized non-fullscreen undecorated window without shadows
       if !window_flags.contains(WindowFlags::MARKER_DECORATIONS)
+        && !window_flags.contains(WindowFlags::MARKER_UNDECORATED_SHADOW)
         && window_flags.contains(WindowFlags::RESIZABLE)
         && window_state.fullscreen.is_none()
         && !util::is_maximized(window).unwrap_or(false)

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -7,6 +7,7 @@ use windows::{
   Win32::{
     Foundation::{BOOL, HWND, LPARAM, POINT, RECT},
     Graphics::Gdi::*,
+    UI::WindowsAndMessaging::USER_DEFAULT_SCREEN_DPI,
   },
 };
 
@@ -216,7 +217,7 @@ impl MonitorHandle {
 
   #[inline]
   pub fn scale_factor(&self) -> f64 {
-    dpi_to_scale_factor(get_monitor_dpi(self.hmonitor()).unwrap_or(96))
+    dpi_to_scale_factor(get_monitor_dpi(self.hmonitor()).unwrap_or(USER_DEFAULT_SCREEN_DPI))
   }
 
   #[inline]

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -17,6 +17,7 @@ use crate::{
   window::CursorIcon,
 };
 
+use once_cell::sync::Lazy;
 use windows::{
   core::{HRESULT, PCSTR, PCWSTR},
   Win32::{
@@ -424,4 +425,73 @@ pub fn get_instance_handle() -> windows::Win32::Foundation::HMODULE {
   }
 
   windows::Win32::Foundation::HMODULE(unsafe { &__ImageBase as *const _ as _ })
+}
+
+pub static WIN_VERSION: Lazy<windows_version::OsVersion> =
+  Lazy::new(windows_version::OsVersion::current);
+
+pub fn get_frame_thickness(dpi: u32) -> i32 {
+  let resize_frame_thickness = unsafe { GetSystemMetricsForDpi(SM_CXSIZEFRAME, dpi) };
+  let padding_thickness = unsafe { GetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi) };
+  resize_frame_thickness + padding_thickness
+}
+
+pub fn calculate_insets_for_dpi(dpi: u32) -> RECT {
+  // - On Windows 10
+  // The top inset must be zero, since if there is any nonclient area, Windows will draw
+  // a full native titlebar outside the client area. (This doesn't occur in the maximized
+  // case.)
+  //
+  // - On Windows 11
+  // The top inset is calculated using an empirical formula that I derived through various
+  // tests. Without this, the top 1-2 rows of pixels in our window would be obscured.
+
+  let frame_thickness = get_frame_thickness(dpi);
+
+  let top_inset = match WIN_VERSION.build {
+    v if v >= 2200 => (dpi as f32 / USER_DEFAULT_SCREEN_DPI as f32).round() as i32,
+    _ => 0,
+  };
+
+  RECT {
+    left: frame_thickness,
+    top: top_inset,
+    right: frame_thickness,
+    bottom: frame_thickness,
+  }
+}
+
+/// Calcuclate window insets, used in WM_NCCALCSIZE
+///
+/// Derived of GPUI implementation
+/// see <https://github.com/zed-industries/zed/blob/7bddb390cabefb177d9996dc580749d64e6ca3b6/crates/gpui/src/platform/windows/events.rs#L1418-L1454>
+pub fn calculate_window_insets(window: HWND) -> RECT {
+  let dpi = unsafe { super::dpi::hwnd_dpi(window) };
+  calculate_insets_for_dpi(dpi)
+}
+
+pub fn window_rect(hwnd: HWND) -> RECT {
+  unsafe {
+    let mut rect = RECT::default();
+    if GetWindowRect(hwnd, &mut rect).is_err() {
+      panic!(
+        "Unexpected GetWindowRect failure: please report this error to \
+               tauri-apps/tao"
+      )
+    }
+    rect
+  }
+}
+
+pub fn client_rect(hwnd: HWND) -> RECT {
+  unsafe {
+    let mut rect = RECT::default();
+    if GetClientRect(hwnd, &mut rect).is_err() {
+      panic!(
+        "Unexpected GetClientRect failure: please report this error to \
+               tauri-apps/tao"
+      )
+    }
+    rect
+  }
 }

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -449,7 +449,7 @@ pub fn calculate_insets_for_dpi(dpi: u32) -> RECT {
   let frame_thickness = get_frame_thickness(dpi);
 
   let top_inset = match WIN_VERSION.build {
-    v if v >= 2200 => (dpi as f32 / USER_DEFAULT_SCREEN_DPI as f32).round() as i32,
+    v if v >= 22000 => (dpi as f32 / USER_DEFAULT_SCREEN_DPI as f32).round() as i32,
     _ => 0,
   };
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -457,6 +457,11 @@ impl WindowFlags {
       }
     }
   }
+
+  pub fn undecorated_with_shadows(&self) -> bool {
+    self.contains(WindowFlags::MARKER_UNDECORATED_SHADOW)
+      && !self.contains(WindowFlags::MARKER_DECORATIONS)
+  }
 }
 
 impl CursorFlags {


### PR DESCRIPTION
ref: https://github.com/zed-industries/zed/blob/7bddb390cabefb177d9996dc580749d64e6ca3b6/crates/gpui/src/platform/windows/events.rs#L1418-L1454

closes #905

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
