### PR TITLE
fix(wayland): fix the wrong initial window inner size on GTK + Wayland.

### DIFF
--- a/.changes/wayland-inner-size.md
+++ b/.changes/wayland-inner-size.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On Linux Wayland, fixed the inaccurately initial `inner_size` when creating a new window.

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -185,7 +185,6 @@ impl Window {
         window.fullscreen();
       }
     }
-    window.set_visible(attributes.visible);
     window.set_decorated(attributes.decorations);
 
     if attributes.always_on_bottom {


### PR DESCRIPTION
## Purpose

Fix the wrong initial window inner size on GTK + Wayland. Fixes #929 

Related: #984

## Troubleshooting

I write a minimal GTK app with a custom title bar using the `gtk-rs` crate to reproduce the issue. And found that the initial window inner size is correct on Wayland. So I assume the issue is related to the Tao's usage of GTK.

By bisecting the Tao's code in `platform_impl::linux::Window::new()` method, I found that the issue is related to the `window.set_visible(attributes.visible);` line. If I comment out this line, the initial window inner size is correct on Wayland.

Then I tried to add this line to the GTK app I wrote before, and found that the issue is reproduced. So I think the issue is related to the `set_visible` method call on window.

Below is the minimal code I used to reproduce the issue. Toggle the `win.set_visible(true)` to see the difference between the two.

```rust
use gtk::{prelude::*, HeaderBar};
use gtk::{Application, ApplicationWindow};

fn main() {
  let app = Application::builder()
    .application_id("org.example.HelloWorld")
    .build();

  app.connect_activate(|app| {
    // We create the main window.
    let win = ApplicationWindow::builder()
      .application(app)
      .default_width(240)
      .default_height(240)
      .title("Hello, World!")
      .build();

    // Toggle the code below to see the difference between the two.
    // win.set_visible(true);

    let headerbar = HeaderBar::builder()
      .title("HeaderBar example")
      .build();

    win.set_titlebar(Some(&headerbar));

    println!("window size before show_all: {:?}", win.size());
    win.show_all();

    println!("window size after show_all: {:?}", win.size());
  });

  app.run();
}
```

## Solution

Looks like the `set_visible` call is unnecessary, because the `show_all` method will show the window. So, we can remove the `set_visible` call to fix the issue.