### PR TITLE
fix(wayland): decoration not clickable when initial visible is false

### DIFF
--- a/.changes/fix-wayland-decoration-click.md
+++ b/.changes/fix-wayland-decoration-click.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On Linux Wayland, fixed a bug where the window decoration is not clickable.

--- a/src/platform_impl/linux/wayland/header.rs
+++ b/src/platform_impl/linux/wayland/header.rs
@@ -11,7 +11,6 @@ impl WlHeader {
       .build();
 
     let event_box = EventBox::new();
-    event_box.set_above_child(true);
     event_box.set_visible(true);
     event_box.set_can_focus(false);
     event_box.add(&header);


### PR DESCRIPTION
## Problem

The decoration is not clickable if the window initial visible is `false`.

## Reproduce

1. Run the following code
2. The close button, the maximum button, and the minimum button is not clickable. 

```rs
use tao::{
  event::{Event, WindowEvent},
  event_loop::{ControlFlow, EventLoop},
  window::WindowBuilder,
};

#[allow(clippy::single_match)]
fn main() {
  env_logger::init();
  let event_loop = EventLoop::new();

  let window = WindowBuilder::new()
    .with_visible(false)
    .with_title("A fantastic window!")
    .build(&event_loop)
    .unwrap();

  window.set_visible(true);

  event_loop.run(move |event, _, control_flow| {
    *control_flow = ControlFlow::Wait;

    match event {
      Event::WindowEvent {
        event: WindowEvent::CloseRequested,
        ..
      } => *control_flow = ControlFlow::Exit,
      _ => (),
    }
  });
}

```

## Solution

Avoid setting the above child property of the `EventBox`. The default value is `false`. Seems there is no need to set it to `true`.

https://docs.gtk.org/gtk3/method.EventBox.set_above_child.html 


<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

3. If there is a related issue, reference it in the PR text, e.g. closes #123.
4. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
5. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
6. Ensure `cargo test` passes.
7. Open as a draft PR if your work is still in progress.
-->
