### PR TITLE
fix(macos): treat Monitor::from_point args as physical

### DIFF
--- a/.changes/macos-monitor-from-point-physical-coordinates.md
+++ b/.changes/macos-monitor-from-point-physical-coordinates.md
@@ -1,0 +1,6 @@
+---
+"tao": patch
+---
+
+The `x` and `y` values passed to `Monitor::from_point` are now treated as physical and therefore converted to logical values on macOS.
+This makes the behavior consistent with the implementation for Windows.

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -18,6 +18,7 @@ use core_graphics::{
   display::{CGDirectDisplayID, CGDisplay, CGDisplayBounds},
   geometry::CGPoint,
 };
+use dpi::LogicalPosition;
 use objc2::{msg_send, rc::Retained};
 use objc2_app_kit::NSScreen;
 use objc2_foundation::{MainThreadMarker, NSString, NSUInteger};
@@ -164,7 +165,9 @@ pub fn from_point(x: f64, y: f64) -> Option<MonitorHandle> {
   unsafe {
     for monitor in available_monitors() {
       let bound = CGDisplayBounds(monitor.0);
-      if CGRectContainsPoint(bound, CGPoint::new(x, y)) > 0 {
+      let position =
+        LogicalPosition::from_physical::<_, f64>((x as f64, y as f64), monitor.scale_factor());
+      if CGRectContainsPoint(bound, CGPoint::new(position.x, position.y)) > 0 {
         return Some(monitor);
       }
     }


### PR DESCRIPTION
The `x` and `y` values passed to `from_point` are now treated as physical and therefore converted to logical values on macOS. This makes the behavior consistent with the Windows implementation.

Closes tauri-apps/tauri#12676.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
