### PR TITLE
fix(windows): undecorated resize direction for top left and right border

### DIFF
--- a/.changes/undecorated-resize-top-left-right.md
+++ b/.changes/undecorated-resize-top-left-right.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix undecorated top left and right border resizing direction on Windows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "bitflags 2.8.0",
  "core-foundation",

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2190,20 +2190,21 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
         // if we have undecorated shadows, we only need to handle the top edge
         if window_flags.contains(WindowFlags::MARKER_UNDECORATED_SHADOW) {
+          let rect = util::client_rect(window);
           let mut cursor_pt = POINT { x: cx, y: cy };
           if ScreenToClient(window, &mut cursor_pt).as_bool()
             && cursor_pt.y >= 0
             && cursor_pt.y <= border_y
+            && cursor_pt.x >= 0
+            && cursor_pt.x <= rect.right
           {
             result = ProcResult::Value(LRESULT(HTTOP as _));
           }
-        } else {
-          //otherwise do full hit testing
+        }
+        // otherwise do full hit testing
+        else {
           let border_x = GetSystemMetricsForDpi(SM_CXFRAME, dpi);
-
-          let mut rect = RECT::default();
-          let _ = GetWindowRect(window, &mut rect);
-
+          let rect = util::window_rect(window);
           let hit_result = crate::window::hit_test(
             (rect.left, rect.top, rect.right, rect.bottom),
             cx,


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Fix a small issue introduced by #1052

Before:

![image](https://github.com/user-attachments/assets/3d52f762-a7d2-4b08-a688-7da8d943a60b)

After:

![image](https://github.com/user-attachments/assets/d1e31136-23b3-4120-afb1-80f1a47e80e3)
