### PR TITLE
fix(macos): window content protection crashing

### DIFF
--- a/.changes/fix-content-protection.md
+++ b/.changes/fix-content-protection.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix content protection on macOS crashing the app.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "bitflags 2.8.0",
  "core-foundation",


### PR DESCRIPTION
when content protection is used the app is crashing with the following error:
```
invalid message send to -[TaoWindow setSharingType:]: expected argument at index 0 to have type code 'Q', but found 'i'
```

using `ns_window.setSharingType(NSWindowSharingType::<type>)` fixes it

I've also changed other msg_send![] usage to leverage the type safe objc2-app-kit crate instead of using direct objc calls
