### PR TITLE
fix(windows): inner_size always returns restore size for maximized undecorated window

### DIFF
--- a/.changes/undecorated-window-maximized-inner-size.md
+++ b/.changes/undecorated-window-maximized-inner-size.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On Windows, fix `Window::inner_size` always returns the restore size instead of the current size for maximized undecorated window


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Fix a regression from #1052

`WM_NCCALCSIZE` sets the client size to what we wanted already, and we just need to use it directly, I don't think we need to anything special here (the old comment says we need to account for the shadows which is not what we really needed, the shadows are not part of the rect from `GetClientRect`)