### PR TITLE
fix(macos): handle None return from standardWindowButton (fix #1081)

### DIFF
--- a/.changes/fix-macos-window-buttons.md
+++ b/.changes/fix-macos-window-buttons.md
@@ -1,5 +1,6 @@
 ---
 "tao": patch
+tag: "bug"
 ---
 
 Fixed application crash during startup when certain window buttons are disabled in the configuration on macOS. The crash occurred because the code unconditionally called `unwrap()` on an Option value returned by `standardWindowButton`, which becomes `None` when window buttons are disabled.

--- a/.changes/fix-macos-window-buttons.md
+++ b/.changes/fix-macos-window-buttons.md
@@ -1,6 +1,5 @@
 ---
 "tao": patch
-tag: "bug"
 ---
 
 Fixed application crash during startup when certain window buttons are disabled in the configuration on macOS. The crash occurred because the code unconditionally called `unwrap()` on an Option value returned by `standardWindowButton`, which becomes `None` when window buttons are disabled.

--- a/.changes/fix-macos-window-buttons.md
+++ b/.changes/fix-macos-window-buttons.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fixed application crash during startup when certain window buttons are disabled in the configuration on macOS. The crash occurred because the code unconditionally called `unwrap()` on an Option value returned by `standardWindowButton`, which becomes `None` when window buttons are disabled.

--- a/.changes/fix-macos-window-buttons.md
+++ b/.changes/fix-macos-window-buttons.md
@@ -2,4 +2,4 @@
 "tao": patch
 ---
 
-Fixed application crash during startup when certain window buttons are disabled in the configuration on macOS. The crash occurred because the code unconditionally called `unwrap()` on an Option value returned by `standardWindowButton`, which becomes `None` when window buttons are disabled.
+Fixed application crash during startup when certain window buttons are disabled on macOS.

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -964,7 +964,7 @@ impl UnownedWindow {
     let mask = self.saved_style(&mut *shared_state_lock);
 
     drop(shared_state_lock);
-    trace!("Unocked shared state in `restore_state_from_fullscreen`");
+    trace!("Unlocked shared state in `restore_state_from_fullscreen`");
 
     self.set_style_mask_async(mask);
     self.set_maximized(maximized);

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -262,8 +262,9 @@ fn create_window(
           NSWindowButton::CloseButton,
           NSWindowButton::ZoomButton,
         ] {
-          let button = ns_window.standardWindowButton(*titlebar_button).unwrap();
-          let _: () = msg_send![&button, setHidden: true];
+          if let Some(button) = ns_window.standardWindowButton(*titlebar_button) {
+            button.setHidden(true);
+          }
         }
       }
       if pl_attrs.movable_by_window_background {
@@ -283,10 +284,10 @@ fn create_window(
       }
 
       if !attrs.maximizable {
-        let button = ns_window
-          .standardWindowButton(NSWindowButton::ZoomButton)
-          .unwrap();
-        button.setEnabled(false);
+        if let Some(button) = ns_window
+          .standardWindowButton(NSWindowButton::ZoomButton) {
+            button.setEnabled(false);
+          }
       }
 
       if let Some(increments) = pl_attrs.resize_increments {
@@ -769,11 +770,12 @@ impl UnownedWindow {
   #[inline]
   pub fn set_maximizable(&self, maximizable: bool) {
     unsafe {
-      let button = self
+      if let Some(button) = self
         .ns_window
         .standardWindowButton(NSWindowButton::ZoomButton)
-        .unwrap();
-      button.setEnabled(maximizable);
+      {
+        button.setEnabled(maximizable);
+      }
     }
   }
 
@@ -1040,15 +1042,16 @@ impl UnownedWindow {
 
   #[inline]
   pub fn is_maximizable(&self) -> bool {
-    let is_maximizable: bool;
     unsafe {
-      let button = self
+      if let Some(button) = self
         .ns_window
         .standardWindowButton(NSWindowButton::ZoomButton)
-        .unwrap();
-      is_maximizable = msg_send![&button, isEnabled];
+      {
+        button.isEnabled()
+      } else {
+        false
+      }
     }
-    is_maximizable
   }
 
   #[inline]


### PR DESCRIPTION
## Description
This PR fixes an application crash on macOS when certain window buttons are disabled in the configuration. The crash occurs because the code in `window.rs` (line 288) unconditionally calls `unwrap()` on an Option value returned by `standardWindowButton`, which becomes `None` when window buttons are disabled.

## Related Issue
Closes #1081

## Changes Made
- Modified the code to safely handle cases where `standardWindowButton` returns `None`
- Added proper pattern matching instead of unconditionally unwrapping the returned value
- Ensured the application doesn't panic when window buttons are disabled

## Testing
- Created a macOS application with various window button configurations (disabled minimizable, maximizable, etc.)
- Verified the application now starts successfully without crashing

## Additional Notes
According to Apple's documentation, `standardWindowButton(_:)` can return nil when buttons are not available, which is what happens when buttons are disabled in the configuration. This PR updates the implementation to properly handle this case.