### PR TITLE
fix(windows): decoupling the effects of switching between `fullscreen` and `maximized`.

### DIFF
--- a/.changes/allow-fullscreen-and-maximized-work-together.md
+++ b/.changes/allow-fullscreen-and-maximized-work-together.md
@@ -1,0 +1,11 @@
+---
+"tao": patch
+---
+
+When we maximize a window or switch to fullscreen, we must consider the window status
+values ​​after returning to normal window, such as size, position, and whether it is maximized.
+
+This commit fixes the error that occurs when switching between fullscreen and maximized.
+
+In summary, borderless-fullscreen and maximized can be toggled without considering
+each other's status.

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -767,9 +767,10 @@ impl Window {
           let placement = unsafe {
             let mut placement = WINDOWPLACEMENT::default();
             let _ = GetWindowPlacement(hwnd, &mut placement);
+            // set the `showCmd` to your needs when you use this placement below.
+            placement.showCmd = SW_NORMAL.0 as u32;
             placement
           };
-
           window_state.lock().saved_window = Some(SavedWindow { placement });
 
           let monitor = match &fullscreen {
@@ -798,7 +799,13 @@ impl Window {
         }
         None => {
           let mut window_state_lock = window_state.lock();
-          if let Some(SavedWindow { placement }) = window_state_lock.saved_window.take() {
+          if let Some(SavedWindow { mut placement }) = window_state_lock.saved_window.take() {
+            if window_state_lock
+              .window_flags
+              .contains(WindowFlags::MAXIMIZED)
+            {
+              placement.showCmd = SW_MAXIMIZE.0 as u32;
+            }
             drop(window_state_lock);
             unsafe {
               let _ = SetWindowPlacement(hwnd, &placement);

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -369,15 +369,18 @@ impl WindowFlags {
       }
     }
 
-    if diff.contains(WindowFlags::MAXIMIZED) || new.contains(WindowFlags::MAXIMIZED) {
-      unsafe {
-        let _ = ShowWindow(
-          window,
-          match new.contains(WindowFlags::MAXIMIZED) {
-            true => SW_MAXIMIZE,
-            false => SW_RESTORE,
-          },
-        );
+    if diff.contains(WindowFlags::MAXIMIZED) {
+      if new.contains(WindowFlags::MAXIMIZED) {
+        let _ = unsafe { ShowWindow(window, SW_MAXIMIZE) };
+      } else {
+        if self.contains(WindowFlags::MARKER_BORDERLESS_FULLSCREEN) {
+          let (style, _) = self.to_window_styles();
+          // not to set SW_RESTORE to restore the size, we keep it for borderless fullscreen
+          let unmaximized_style = style & !WS_MAXIMIZE;
+          unsafe { SetWindowLongW(window, GWL_STYLE, unmaximized_style.0 as i32) };
+        } else {
+          let _ = unsafe { ShowWindow(window, SW_RESTORE) };
+        }
       }
     }
 


### PR DESCRIPTION
## Problem
As mentioned [here](https://github.com/tauri-apps/tao/issues/1087)

## Detials
`set_maximized(false)` will fire the `SW_RESTORE`, and it disturbs the state of the `borderless fullscreen`.
To be precise, the window size that should have kept the full screen has been changed (to normal window size).

## Solution
1. Use `SetWindowLongW(... !WS_MAXIMIZE ...)` instead of `ShowWindow(..., SW_RESTORE)` to set the maximized state off.
2. Use placement.showCmd to make it correct for `set_fullscreen(false)` when the window is maximized or not.