### PR TITLE
fix: the system theme obtained is always light

### DIFF
--- a/.changes/fix-macos-theme.md
+++ b/.changes/fix-macos-theme.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix `Window::theme()` always returning `Theme::Light` and `WindowEvent::ThemeChanged()` not delivered on macOS.

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -332,7 +332,7 @@ pub(super) fn get_ns_theme() -> Theme {
     let app_class = class!(NSApplication);
     let app: id = msg_send![app_class, sharedApplication];
     let has_theme: bool = msg_send![app, respondsToSelector: sel!(effectiveAppearance)];
-    if has_theme {
+    if !has_theme {
       return Theme::Light;
     }
     let appearance: id = msg_send![app, effectiveAppearance];


### PR DESCRIPTION
After updating to the latest version of `tauri` on macOS, getting the system theme always returns `light` . The `onThemeChanged` api also doesn't fire when the system theme changes.

Close https://github.com/tauri-apps/tauri/issues/12894

According to the code and recent commit records, this problem should be caused by negligence during the migration process of `objc2`. 😄  

> Although the problem is trivial, I still hope it can help you save some time.
