### PR TITLE
fix(windows): initial position sets to 0

### DIFF
--- a/.changes/nagative-initial-position.md
+++ b/.changes/nagative-initial-position.md
@@ -1,0 +1,5 @@
+---
+tao: patch
+---
+
+Fix initial position gets reset to 0 on Windows if it's accounted for the shadow

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -217,7 +217,11 @@ impl MonitorHandle {
 
   #[inline]
   pub fn scale_factor(&self) -> f64 {
-    dpi_to_scale_factor(get_monitor_dpi(self.hmonitor()).unwrap_or(USER_DEFAULT_SCREEN_DPI))
+    dpi_to_scale_factor(self.dpi())
+  }
+
+  pub fn dpi(&self) -> u32 {
+    get_monitor_dpi(self.hmonitor()).unwrap_or(USER_DEFAULT_SCREEN_DPI)
   }
 
   #[inline]

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -57,7 +57,6 @@ use crate::{
 };
 
 use super::{
-  dpi::get_monitor_dpi,
   event_loop::CHANGE_THEME_MSG_ID,
   keyboard::{KeyEventBuilder, KEY_EVENT_BUILDERS},
   util::calculate_insets_for_dpi,
@@ -1165,11 +1164,20 @@ unsafe fn init<T: 'static>(
         monitor::available_monitors()
           .into_iter()
           .find_map(|monitor| {
-            let position = p.to_physical::<i32>(monitor.scale_factor());
+            let dpi = monitor.dpi();
+            let scale_factor = dpi_to_scale_factor(dpi);
+            let position = p.to_physical::<i32>(scale_factor);
             let (x, y): (i32, i32) = monitor.position().into();
             let (width, height): (i32, i32) = monitor.size().into();
 
-            if x <= position.x
+            let frame_thickness = if window_flags.contains_shadow() {
+              util::get_frame_thickness(dpi)
+            } else {
+              0
+            };
+
+            // Only the starting position x needs to be accounted
+            if x <= position.x + frame_thickness
               && position.x <= x + width
               && y <= position.y
               && position.y <= y + height
@@ -1215,7 +1223,7 @@ unsafe fn init<T: 'static>(
         w = rect.right - rect.left;
         h = rect.bottom - rect.top;
       } else if window_flags.undecorated_with_shadows() {
-        let dpi = get_monitor_dpi(target_monitor.hmonitor()).unwrap_or(USER_DEFAULT_SCREEN_DPI);
+        let dpi = target_monitor.dpi();
         let insets = calculate_insets_for_dpi(dpi);
         w += insets.left + insets.right;
         h += insets.top + insets.bottom;

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -462,6 +462,11 @@ impl WindowFlags {
     self.contains(WindowFlags::MARKER_UNDECORATED_SHADOW)
       && !self.contains(WindowFlags::MARKER_DECORATIONS)
   }
+
+  pub fn contains_shadow(&self) -> bool {
+    self.contains(WindowFlags::MARKER_UNDECORATED_SHADOW)
+      || self.contains(WindowFlags::MARKER_DECORATIONS)
+  }
 }
 
 impl CursorFlags {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Reference: #1018

The initial position is set to account for the shadows in tauri, and we need to not reset the position to default when calculating its monitor

Maybe we should rethink about how the APIs work when dealing with this in the future, currently (0, 0) doesn't put the window to the exact top left corner