### PR TITLE
fix(macos): check monitor from window initial position to determine size

### DIFF
--- a/.github/fix-window-size.md
+++ b/.github/fix-window-size.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Properly check target monitor from window initial position to determine its size with the proper scale factor on macOS.

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -174,13 +174,21 @@ fn create_window(
         let monitor_screen = monitor.ns_screen();
         Some(monitor_screen.unwrap_or_else(|| appkit::NSScreen::mainScreen(mtm).unwrap()))
       }
-      Some(Fullscreen::Borderless(None)) => Some(appkit::NSScreen::mainScreen(mtm).unwrap()),
+      Some(Fullscreen::Borderless(None)) => Some(
+        attrs
+          .position
+          .and_then(screen_from_position)
+          .unwrap_or_else(|| appkit::NSScreen::mainScreen(mtm).unwrap()),
+      ),
       None => None,
     };
     let frame = match &screen {
       Some(screen) => NSScreen::frame(screen),
       None => {
-        let screen = NSScreen::mainScreen(mtm).unwrap();
+        let screen = attrs
+          .position
+          .and_then(screen_from_position)
+          .unwrap_or_else(|| appkit::NSScreen::mainScreen(mtm).unwrap());
         let scale_factor = NSScreen::backingScaleFactor(&screen) as f64;
         let desired_size = attrs
           .inner_size
@@ -321,6 +329,25 @@ fn create_window(
       ns_window
     })
   }
+}
+
+fn screen_from_position(position: Position) -> Option<Retained<NSScreen>> {
+  for m in monitor::available_monitors() {
+    let monitor_pos = m.position();
+    let monitor_size = m.size();
+
+    // type annotations required for 32bit targets.
+    let window_position = position.to_physical::<i32>(m.scale_factor());
+
+    let is_in_monitor = monitor_pos.x <= window_position.x
+      && window_position.x < monitor_pos.x + monitor_size.width as i32
+      && monitor_pos.y <= window_position.y
+      && window_position.y < monitor_pos.y + monitor_size.height as i32;
+    if is_in_monitor {
+      return m.ns_screen();
+    }
+  }
+  None
 }
 
 pub(super) fn get_ns_theme() -> Theme {


### PR DESCRIPTION
properly determine the target monitor scale factor

fixes a bug where when you create a window with a position set to a particular monitor, the scale factor will be read from the main screen instead

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
