### PR TITLE
feat: add focusable property to tauri.conf.json (platform:windows) #11130

### DIFF
--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1131,6 +1131,9 @@ unsafe fn init<T: 'static>(
   // but we need to have a default for the diffing to work
   window_flags.set(WindowFlags::CLOSABLE, true);
 
+  //we need to have a default for the diffing to work
+  window_flags.set(WindowFlags::FOCUSABLE, true);
+
   window_flags.set(WindowFlags::MARKER_DONT_FOCUS, !attributes.focused);
 
   window_flags.set(WindowFlags::RIGHT_TO_LEFT_LAYOUT, pl_attribs.rtl);

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1131,8 +1131,7 @@ unsafe fn init<T: 'static>(
   // but we need to have a default for the diffing to work
   window_flags.set(WindowFlags::CLOSABLE, true);
 
-  //we need to have a default for the diffing to work
-  window_flags.set(WindowFlags::FOCUSABLE, true);
+  window_flags.set(WindowFlags::FOCUSABLE, attributes.focusable);
 
   window_flags.set(WindowFlags::MARKER_DONT_FOCUS, !attributes.focused);
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -117,6 +117,8 @@ bitflags! {
 
         const RIGHT_TO_LEFT_LAYOUT = 1 << 22;
 
+        const FOCUSABLE = 1 << 23;
+
         const EXCLUSIVE_FULLSCREEN_OR_MASK = WindowFlags::ALWAYS_ON_TOP.bits();
     }
 }
@@ -290,6 +292,9 @@ impl WindowFlags {
     }
     if self.contains(WindowFlags::RIGHT_TO_LEFT_LAYOUT) {
       style_ex |= WS_EX_LAYOUTRTL | WS_EX_RTLREADING | WS_EX_RIGHT;
+    }
+    if self.contains(WindowFlags::FOCUSABLE) {
+      style_ex |= WS_EX_NOACTIVATE;
     }
 
     (style, style_ex)

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -293,7 +293,7 @@ impl WindowFlags {
     if self.contains(WindowFlags::RIGHT_TO_LEFT_LAYOUT) {
       style_ex |= WS_EX_LAYOUTRTL | WS_EX_RTLREADING | WS_EX_RIGHT;
     }
-    if self.contains(WindowFlags::FOCUSABLE) {
+    if !self.contains(WindowFlags::FOCUSABLE) {
       style_ex |= WS_EX_NOACTIVATE;
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -249,6 +249,13 @@ pub struct WindowAttributes {
   /// **Android / iOS:** Unsupported.
   pub focused: bool,
 
+  /// Whether the window should be focusable or not.
+  ///
+  /// ## Platform-specific:
+  ///
+  /// **Android / iOS:** Unsupported.
+  pub focusable: bool,
+
   /// Prevents the window contents from being captured by other apps.
   ///
   /// ## Platform-specific
@@ -294,6 +301,7 @@ impl Default for WindowAttributes {
       window_icon: None,
       preferred_theme: None,
       focused: true,
+      focusable: true,
       content_protection: false,
       visible_on_all_workspaces: false,
       background_color: None,
@@ -538,6 +546,18 @@ impl WindowBuilder {
     self.window.focused = focused;
     self
   }
+
+  /// Whether the window will be focusable or not.
+  ///
+  /// ## Platform-specific:
+  /// **Linux / Macos:** Not implemented.
+  /// **Android / iOS:** Unsupported.
+  #[inline]
+  pub fn with_focusable(mut self, focusable: bool) -> WindowBuilder {
+    self.window.focusable = focusable;
+    self
+  }
+
   /// Prevents the window contents from being captured by other apps.
   ///
   /// ## Platform-specific


### PR DESCRIPTION
Added focusable property, only for windows platform.

By default is true, when is passed as false creates the window not focusable.
