### PR TITLE
fix(windows): apply scroll lines per wheel setting

### DIFF
--- a/.changes/windows-scroll-line-settings.md
+++ b/.changes/windows-scroll-line-settings.md
@@ -2,4 +2,4 @@
 tao: patch
 ---
 
-Fix `WindowEvent::MouseWheel` doesnt' account for mouse wheel speed settings
+Fix `WindowEvent::MouseWheel` doesn't account for mouse wheel speed settings

--- a/.changes/windows-scroll-line-settings.md
+++ b/.changes/windows-scroll-line-settings.md
@@ -1,0 +1,5 @@
+---
+tao: patch
+---
+
+Fix `WindowEvent::MouseWheel` doesnt' account for mouse wheel speed settings

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -66,6 +66,13 @@ use runner::{EventLoopRunner, EventLoopRunnerShared};
 
 use super::{dpi::hwnd_dpi, util::get_system_metrics_for_dpi};
 
+// This is defined in `winuser.h` as a macro that expands to `UINT_MAX`
+const WHEEL_PAGESCROLL: u32 = u32::MAX;
+// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-systemparametersinfoa#:~:text=SPI_GETWHEELSCROLLLINES
+const DEFAULT_SCROLL_LINES_PER_WHEEL_DELTA: isize = 3;
+// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-systemparametersinfoa#:~:text=SPI_GETWHEELSCROLLCHARS
+const DEFAULT_SCROLL_CHARACTERS_PER_WHEEL_DELTA: isize = 3;
+
 type GetPointerFrameInfoHistory = unsafe extern "system" fn(
   pointerId: u32,
   entriesCount: *mut u32,
@@ -1376,11 +1383,25 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
       let modifiers = update_modifiers(window, subclass_input);
 
+      let mut scroll_lines = DEFAULT_SCROLL_LINES_PER_WHEEL_DELTA;
+
+      let _ = SystemParametersInfoW(
+        SPI_GETWHEELSCROLLLINES,
+        0,
+        Some(&mut scroll_lines as *mut isize as *mut c_void),
+        SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS(0),
+      );
+
+      if scroll_lines as u32 == WHEEL_PAGESCROLL {
+        // TODO: figure out how to handle page scrolls
+        scroll_lines = DEFAULT_SCROLL_LINES_PER_WHEEL_DELTA;
+      }
+
       subclass_input.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: WindowEvent::MouseWheel {
           device_id: DEVICE_ID,
-          delta: LineDelta(0.0, value),
+          delta: LineDelta(0.0, value * scroll_lines as f32),
           phase: TouchPhase::Moved,
           modifiers,
         },
@@ -1397,11 +1418,20 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
       let modifiers = update_modifiers(window, subclass_input);
 
+      let mut scroll_characters = DEFAULT_SCROLL_CHARACTERS_PER_WHEEL_DELTA;
+
+      let _ = SystemParametersInfoW(
+        SPI_GETWHEELSCROLLCHARS,
+        0,
+        Some(&mut scroll_characters as *mut isize as *mut c_void),
+        SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS(0),
+      );
+
       subclass_input.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: WindowEvent::MouseWheel {
           device_id: DEVICE_ID,
-          delta: LineDelta(value, 0.0),
+          delta: LineDelta(value * scroll_characters as f32, 0.0),
           phase: TouchPhase::Moved,
           modifiers,
         },


### PR DESCRIPTION
Fix `WindowEvent::MouseWheel` doesn't account for mouse wheel speed settings

Reference docs: https://learn.microsoft.com/en-us/windows/win32/inputdev/about-mouse-input#determining-the-number-of-scroll-lines
Reference winit PR: https://github.com/rust-windowing/winit/pull/4268