### PR TITLE
feat: add focusable property and Window::set_focusable

### DIFF
--- a/.changes/focusable.md
+++ b/.changes/focusable.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Added `WindowBuilder::with_focusable` to allow creating unfocusable windows.

--- a/.changes/set-focusable.md
+++ b/.changes/set-focusable.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Added `Window::set_focusable`.

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -564,6 +564,10 @@ impl Window {
     warn!("set_focus not yet implemented on Android");
   }
 
+  pub fn set_focusable(&self, _focusable: bool) {
+    warn!("set_focusable not yet implemented on Android");
+  }
+
   pub fn is_focused(&self) -> bool {
     log::warn!("`Window::is_focused` is ignored on Android");
     false

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -73,6 +73,8 @@ impl Inner {
   }
 
   pub fn set_focusable(&self, _focusable: bool) {
+    warn!("set_focusable not yet implemented on iOS");
+  }
 
   pub fn is_focused(&self) -> bool {
     warn!("`Window::is_focused` is ignored on iOS");

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -72,6 +72,8 @@ impl Inner {
     warn!("set_focus not yet implemented on iOS");
   }
 
+  pub fn set_focusable(&self, _focusable: bool) {
+
   pub fn is_focused(&self) -> bool {
     warn!("`Window::is_focused` is ignored on iOS");
     false

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -87,7 +87,7 @@ impl Window {
 
     let mut window_builder = gtk::ApplicationWindow::builder()
       .application(app)
-      .accept_focus(attributes.focused);
+      .accept_focus(attributes.focusable && attributes.focused);
     if let Parent::ChildOf(parent) = pl_attribs.parent {
       window_builder = window_builder.transient_for(&parent);
     }
@@ -231,8 +231,8 @@ impl Window {
     }
 
     // restore accept-focus after the window has been drawn
-    // if the window was initially created without focus
-    if !attributes.focused {
+    // if the window was initially created without focus and is supposed to be focusable
+    if attributes.focusable && !attributes.focused {
       let signal_id = Arc::new(RefCell::new(None));
       let signal_id_ = signal_id.clone();
       let id = window.connect_draw(move |window, _| {

--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -594,6 +594,10 @@ impl Window {
     }
   }
 
+  pub fn set_focusable(&self, focusable: bool) {
+    self.window.set_accept_focus(focusable);
+  }
+
   pub fn is_focused(&self) -> bool {
     self.window.is_active()
   }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -680,6 +680,15 @@ impl UnownedWindow {
   }
 
   #[inline]
+  pub fn set_focusable(&self, focusable: bool) {
+      #[allow(deprecated)] // TODO: Use define_class!
+    unsafe {
+      let ns_window =  Retained::into_raw(Retained::cast_unchecked::<Object>(self.ns_window.clone()));
+      *((*ns_window).get_mut_ivar::<Bool>("focusable")) = focusable.into();
+    }
+  }
+
+  #[inline]
   pub fn is_focused(&self) -> bool {
     unsafe { self.ns_window.isKeyWindow() }
   }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -415,11 +415,11 @@ lazy_static! {
     .unwrap();
     decl.add_method(
       sel!(canBecomeMainWindow),
-      util::yes as extern "C" fn(_, _) -> _,
+      is_focusable as extern "C" fn(_, _) -> _,
     );
     decl.add_method(
       sel!(canBecomeKeyWindow),
-      can_become_key_window as extern "C" fn(_, _) -> _,
+      is_focusable as extern "C" fn(_, _) -> _,
     );
     decl.add_method(sel!(sendEvent:), send_event as extern "C" fn(_, _, _));
     // progress bar states, follows ProgressState
@@ -428,7 +428,7 @@ lazy_static! {
   };
 }
 
-extern "C" fn can_become_key_window(this: &Object, _: Sel) -> Bool {
+extern "C" fn is_focusable(this: &Object, _: Sel) -> Bool {
   #[allow(deprecated)] // TODO: Use define_class!
   unsafe { *(this.get_ivar("focusable")) }
 }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -252,11 +252,10 @@ fn create_window(
     ];
 
     Retained::retain(ns_window_ptr).and_then(|r| r.downcast::<NSWindow>().ok()).map(|ns_window| {
-      #[allow(deprecated)] 
+      #[allow(deprecated)]
       {
         *((*ns_window_ptr).get_mut_ivar::<Bool>("focusable")) = attrs.focusable.into();
       }
-
 
       let title = NSString::from_str(&attrs.title);
       ns_window.setReleasedWhenClosed(false);
@@ -430,7 +429,9 @@ lazy_static! {
 
 extern "C" fn is_focusable(this: &Object, _: Sel) -> Bool {
   #[allow(deprecated)] // TODO: Use define_class!
-  unsafe { *(this.get_ivar("focusable")) }
+  unsafe {
+    *(this.get_ivar("focusable"))
+  }
 }
 
 extern "C" fn send_event(this: &Object, _sel: Sel, event: &NSEvent) {
@@ -681,9 +682,10 @@ impl UnownedWindow {
 
   #[inline]
   pub fn set_focusable(&self, focusable: bool) {
-      #[allow(deprecated)] // TODO: Use define_class!
+    #[allow(deprecated)] // TODO: Use define_class!
     unsafe {
-      let ns_window =  Retained::into_raw(Retained::cast_unchecked::<Object>(self.ns_window.clone()));
+      let ns_window =
+        Retained::into_raw(Retained::cast_unchecked::<Object>(self.ns_window.clone()));
       *((*ns_window).get_mut_ivar::<Bool>("focusable")) = focusable.into();
     }
   }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -48,7 +48,7 @@ use core_graphics::{
 use objc2::{
   msg_send,
   rc::Retained,
-  runtime::{AnyClass as Class, AnyObject as Object, ClassBuilder as ClassDecl, Sel},
+  runtime::{AnyClass as Class, AnyObject as Object, Bool, ClassBuilder as ClassDecl, Sel},
 };
 use objc2_app_kit::{
   self as appkit, NSApp, NSApplicationPresentationOptions, NSBackingStoreType, NSColor, NSEvent,
@@ -242,8 +242,8 @@ fn create_window(
       masks |= NSWindowStyleMask::FullSizeContentView;
     }
 
-    let ns_window = msg_send![WINDOW_CLASS.0, alloc];
-    let ns_window: Option<Retained<NSWindow>> = msg_send![
+    let ns_window: id = msg_send![WINDOW_CLASS.0, alloc];
+    let ns_window_ptr: id = msg_send![
       ns_window,
       initWithContentRect: frame,
       styleMask: masks,
@@ -251,7 +251,13 @@ fn create_window(
       defer: NO,
     ];
 
-    ns_window.map(|ns_window| {
+    Retained::retain(ns_window_ptr).and_then(|r| r.downcast::<NSWindow>().ok()).map(|ns_window| {
+      #[allow(deprecated)] 
+      {
+        *((*ns_window_ptr).get_mut_ivar::<Bool>("focusable")) = attrs.focusable.into();
+      }
+
+
       let title = NSString::from_str(&attrs.title);
       ns_window.setReleasedWhenClosed(false);
       ns_window.setTitle(&title);
@@ -413,11 +419,18 @@ lazy_static! {
     );
     decl.add_method(
       sel!(canBecomeKeyWindow),
-      util::yes as extern "C" fn(_, _) -> _,
+      can_become_key_window as extern "C" fn(_, _) -> _,
     );
     decl.add_method(sel!(sendEvent:), send_event as extern "C" fn(_, _, _));
+    // progress bar states, follows ProgressState
+    decl.add_ivar::<Bool>(CStr::from_bytes_with_nul(b"focusable\0").unwrap());
     WindowClass(decl.register())
   };
+}
+
+extern "C" fn can_become_key_window(this: &Object, _: Sel) -> Bool {
+  #[allow(deprecated)] // TODO: Use define_class!
+  unsafe { *(this.get_ivar("focusable")) }
 }
 
 extern "C" fn send_event(this: &Object, _sel: Sel, event: &NSEvent) {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -186,6 +186,17 @@ impl Window {
   }
 
   #[inline]
+  pub fn set_focusable(&self, focusable: bool) {
+    let window = self.window.0 .0 as isize;
+    let window_state = Arc::clone(&self.window_state);
+    self.thread_executor.execute_in_thread(move || {
+      WindowState::set_window_flags(window_state.lock(), HWND(window as _), |f| {
+        f.set(WindowFlags::FOCUSABLE, focusable)
+      });
+    });
+  }
+
+  #[inline]
   pub fn is_focused(&self) -> bool {
     let window_state = self.window_state.lock();
     window_state.has_active_focus()

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1131,6 +1131,9 @@ unsafe fn init<T: 'static>(
   // but we need to have a default for the diffing to work
   window_flags.set(WindowFlags::CLOSABLE, true);
 
+  //we need to have a default for the diffing to work
+  window_flags.set(WindowFlags::FOCUSABLE, true);
+
   window_flags.set(WindowFlags::MARKER_DONT_FOCUS, !attributes.focused);
 
   window_flags.set(WindowFlags::RIGHT_TO_LEFT_LAYOUT, pl_attribs.rtl);

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1131,8 +1131,7 @@ unsafe fn init<T: 'static>(
   // but we need to have a default for the diffing to work
   window_flags.set(WindowFlags::CLOSABLE, true);
 
-  //we need to have a default for the diffing to work
-  window_flags.set(WindowFlags::FOCUSABLE, true);
+  window_flags.set(WindowFlags::FOCUSABLE, attributes.focusable);
 
   window_flags.set(WindowFlags::MARKER_DONT_FOCUS, !attributes.focused);
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -117,6 +117,8 @@ bitflags! {
 
         const RIGHT_TO_LEFT_LAYOUT = 1 << 22;
 
+        const FOCUSABLE = 1 << 23;
+
         const EXCLUSIVE_FULLSCREEN_OR_MASK = WindowFlags::ALWAYS_ON_TOP.bits();
     }
 }
@@ -290,6 +292,9 @@ impl WindowFlags {
     }
     if self.contains(WindowFlags::RIGHT_TO_LEFT_LAYOUT) {
       style_ex |= WS_EX_LAYOUTRTL | WS_EX_RTLREADING | WS_EX_RIGHT;
+    }
+    if self.contains(WindowFlags::FOCUSABLE) {
+      style_ex |= WS_EX_NOACTIVATE;
     }
 
     (style, style_ex)

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -293,7 +293,7 @@ impl WindowFlags {
     if self.contains(WindowFlags::RIGHT_TO_LEFT_LAYOUT) {
       style_ex |= WS_EX_LAYOUTRTL | WS_EX_RTLREADING | WS_EX_RIGHT;
     }
-    if self.contains(WindowFlags::FOCUSABLE) {
+    if !self.contains(WindowFlags::FOCUSABLE) {
       style_ex |= WS_EX_NOACTIVATE;
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -249,6 +249,13 @@ pub struct WindowAttributes {
   /// **Android / iOS:** Unsupported.
   pub focused: bool,
 
+  /// Whether the window should be focusable or not.
+  ///
+  /// ## Platform-specific:
+  ///
+  /// **Android / iOS:** Unsupported.
+  pub focusable: bool,
+
   /// Prevents the window contents from being captured by other apps.
   ///
   /// ## Platform-specific
@@ -294,6 +301,7 @@ impl Default for WindowAttributes {
       window_icon: None,
       preferred_theme: None,
       focused: true,
+      focusable: true,
       content_protection: false,
       visible_on_all_workspaces: false,
       background_color: None,
@@ -538,6 +546,18 @@ impl WindowBuilder {
     self.window.focused = focused;
     self
   }
+
+  /// Whether the window will be focusable or not.
+  ///
+  /// ## Platform-specific:
+  /// **Linux / Macos:** Not implemented.
+  /// **Android / iOS:** Unsupported.
+  #[inline]
+  pub fn with_focusable(mut self, focusable: bool) -> WindowBuilder {
+    self.window.focusable = focusable;
+    self
+  }
+
   /// Prevents the window contents from being captured by other apps.
   ///
   /// ## Platform-specific

--- a/src/window.rs
+++ b/src/window.rs
@@ -550,7 +550,6 @@ impl WindowBuilder {
   /// Whether the window will be focusable or not.
   ///
   /// ## Platform-specific:
-  /// **Linux / Macos:** Not implemented.
   /// **Android / iOS:** Unsupported.
   #[inline]
   pub fn with_focusable(mut self, focusable: bool) -> WindowBuilder {

--- a/src/window.rs
+++ b/src/window.rs
@@ -844,6 +844,16 @@ impl Window {
     self.window.set_focus()
   }
 
+  /// Sets whether the window is focusable or not.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **iOS / Android:** Unsupported.
+  #[inline]
+  pub fn set_focusable(&self, focusable: bool) {
+    self.window.set_focusable(focusable)
+  }
+
   /// Is window active and focused?
   ///
   /// ## Platform-specific

--- a/src/window.rs
+++ b/src/window.rs
@@ -848,6 +848,8 @@ impl Window {
   ///
   /// ## Platform-specific
   ///
+  /// - **macOS**: If the window is already focused, it is not possible to unfocus it after calling `set_focusable(false)`.
+  ///   In this case, you might consider calling [`Window::set_focus`] but it will move the window to the back i.e. at the bottom in terms of z-order.
   /// - **iOS / Android:** Unsupported.
   #[inline]
   pub fn set_focusable(&self, focusable: bool) {


### PR DESCRIPTION
Adds the option to create non focusable windows and change that state with Window::set_focusable.

The feature was requested in https://github.com/tauri-apps/tauri/issues/11130