### PR TITLE
fix(windows): emit LoopDestroyed on WM_ENDSESSION

### DIFF
--- a/.changes/wm-endsession.md
+++ b/.changes/wm-endsession.md
@@ -1,0 +1,5 @@
+---
+tao: patch
+---
+
+Emit `Event::LoopDestroyed` on receiving `WM_ENDSESSION` message on Windows

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -22,7 +22,9 @@ use std::{
 use windows::{
   core::{s, BOOL, PCWSTR},
   Win32::{
-    Foundation::{HANDLE, HINSTANCE, HWND, LPARAM, LRESULT, POINT, RECT, WAIT_TIMEOUT, WPARAM},
+    Foundation::{
+      HANDLE, HINSTANCE, HWND, LPARAM, LRESULT, POINT, RECT, TRUE, WAIT_TIMEOUT, WPARAM,
+    },
     Graphics::Gdi::*,
     System::{
       LibraryLoader::GetModuleHandleW,
@@ -642,7 +644,7 @@ lazy_static! {
       RegisterWindowMessageA(s!("TaskbarCreated"))
     };
     static ref THREAD_EVENT_TARGET_WINDOW_CLASS: Vec<u16> = unsafe {
-        let class_name= util::encode_wide("Tao Thread Event Target");
+        let class_name = util::encode_wide("Tao Thread Event Target");
 
         let class = WNDCLASSEXW {
             cbSize: mem::size_of::<WNDCLASSEXW>() as u32,
@@ -650,7 +652,7 @@ lazy_static! {
             lpfnWndProc: Some(util::call_default_window_proc),
             cbClsExtra: 0,
             cbWndExtra: 0,
-            hInstance:HINSTANCE(GetModuleHandleW(PCWSTR::null()).unwrap_or_default().0),
+            hInstance: HINSTANCE(GetModuleHandleW(PCWSTR::null()).unwrap_or_default().0),
             hIcon: HICON::default(),
             hCursor: HCURSOR::default(), // must be null in order for cursor state to work properly
             hbrBackground: HBRUSH::default(),
@@ -2378,6 +2380,18 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
       }
 
       DefSubclassProc(window, msg, wparam, lparam)
+    }
+
+    // We don't process `WM_QUERYENDSESSION` yet until we introduce the same mechanism as Tauri's `ExitRequested` event
+    // win32wm::WM_QUERYENDSESSION => {}
+    win32wm::WM_ENDSESSION => {
+      // `wParam` is `FALSE` is for if the shutdown gets canceled,
+      // and we don't need to handle that case since we didn't do anything prior in response to `WM_QUERYENDSESSION`
+      if wparam.0 == TRUE.0 as usize {
+        subclass_input.event_loop_runner.loop_destroyed();
+      }
+      // Note: after we return 0 here, Windows will shut us down
+      LRESULT(0)
     }
 
     _ if msg == *USER_EVENT_MSG_ID => {

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -291,6 +291,7 @@ pub type GetDpiForMonitor = unsafe extern "system" fn(
 type GetSystemMetricsForDpi =
   unsafe extern "system" fn(nindex: SYSTEM_METRICS_INDEX, dpi: u32) -> i32;
 pub type EnableNonClientDpiScaling = unsafe extern "system" fn(hwnd: HWND) -> BOOL;
+#[allow(non_snake_case)]
 pub type AdjustWindowRectExForDpi = unsafe extern "system" fn(
   rect: *mut RECT,
   dwStyle: WINDOW_STYLE,


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Reference: #1115

Emit `Event::LoopDestroyed` on receiving `WM_ENDSESSION` message on Windows

Previously, we run the default `DefSubclassProc` here which will also return `0` and causing the app to terminate without a chance to save its states on `Event::LoopDestroyed`