### PR TITLE
chore: don't publish audit PDF to crates.io

### DIFF
--- a/.changes/exclude-audits-pdf.md
+++ b/.changes/exclude-audits-pdf.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Exclude audit PDF file from the crate published to crates.io

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 repository = "https://github.com/tauri-apps/tao"
 documentation = "https://docs.rs/tao"
 categories = [ "gui" ]
-exclude = ["audits/**"]
+include = ["/README.md", "src/**/*.rs", "examples/**/*.rs", "LICENSE*"]
 
 [package.metadata.docs.rs]
 features = [ "rwh_04", "rwh_05", "rwh_06", "serde", "x11" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 repository = "https://github.com/tauri-apps/tao"
 documentation = "https://docs.rs/tao"
 categories = [ "gui" ]
+exclude = ["audits/**"]
 
 [package.metadata.docs.rs]
 features = [ "rwh_04", "rwh_05", "rwh_06", "serde", "x11" ]


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Noticed this while doing an update

> Downloaded 17 crates (4.0MiB) in 5.92s (largest was `tao` at 2.3MiB)