### PR TITLE
fix(macos): Fix color mappings in window.rs

### DIFF
--- a/.changes/fix-macos-bg-color.md
+++ b/.changes/fix-macos-bg-color.md
@@ -1,0 +1,5 @@
+---
+tao: patch
+---
+
+On macOS, fixed an issue that caused the window background color to be applied incorrectly (typically black).

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -2,8 +2,7 @@
 // Copyright 2021-2023 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use tao::{
   event::{Event, StartCause, WindowEvent},

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -13,8 +13,7 @@
 //! [create_proxy]: crate::event_loop::EventLoop::create_proxy
 //! [event_loop_proxy]: crate::event_loop::EventLoopProxy
 //! [send_event]: crate::event_loop::EventLoopProxy::send_event
-use std::time::Instant;
-use std::{error, fmt, marker::PhantomData, ops::Deref};
+use std::{error, fmt, marker::PhantomData, ops::Deref, time::Instant};
 
 use crate::{
   dpi::PhysicalPosition,

--- a/src/platform_impl/android/ndk_glue.rs
+++ b/src/platform_impl/android/ndk_glue.rs
@@ -47,6 +47,7 @@ pub static PACKAGE: OnceCell<&str> = OnceCell::new();
 ///       - `private external fun focus(focus: Boolean)`
 /// 4. a one time setup function that will be ran once after tao has created its event loop in the `create` function above.
 /// 5. the main entry point of your android application.
+#[rustfmt::skip]
 #[macro_export]
 macro_rules! android_binding {
   ($domain:ident, $package:ident, $activity:ident, $setup:path, $main:ident) => {

--- a/src/platform_impl/android/ndk_glue.rs
+++ b/src/platform_impl/android/ndk_glue.rs
@@ -54,7 +54,7 @@ macro_rules! android_binding {
   };
   ($domain:ident, $package:ident, $activity:ident, $setup:path, $main:ident, $tao:path) => {{
     // NOTE: be careful when changing how this use statement is written
-    use $tao::{platform::android::prelude::android_fn, platform::android::prelude::*};
+    use $tao::platform::android::prelude::{android_fn, *};
     fn _____tao_store_package_name__() {
       PACKAGE.get_or_init(move || generate_package_name!($domain, $package));
     }

--- a/src/platform_impl/android/ndk_glue.rs
+++ b/src/platform_impl/android/ndk_glue.rs
@@ -54,7 +54,7 @@ macro_rules! android_binding {
   };
   ($domain:ident, $package:ident, $activity:ident, $setup:path, $main:ident, $tao:path) => {{
     // NOTE: be careful when changing how this use statement is written
-    use $tao::platform::android::prelude::{android_fn, *};
+    use $tao::{platform::android::prelude::android_fn, platform::android::prelude::*};
     fn _____tao_store_package_name__() {
       PACKAGE.get_or_init(move || generate_package_name!($domain, $package));
     }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -550,7 +550,12 @@ impl UnownedWindow {
         let color = win_attribs
           .background_color
           .map(|(r, g, b, a)| {
-            NSColor::colorWithRed_green_blue_alpha(r as f64 / 255.0, g as f64 / 255.0, b as f64 / 255.0, a as f64 / 255.0)
+            NSColor::colorWithRed_green_blue_alpha(
+              r as f64 / 255.0,
+              g as f64 / 255.0,
+              b as f64 / 255.0,
+              a as f64 / 255.0,
+            )
           })
           .unwrap_or_else(|| NSColor::clearColor());
         ns_window.setBackgroundColor(Some(&color));

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -550,7 +550,7 @@ impl UnownedWindow {
         let color = win_attribs
           .background_color
           .map(|(r, g, b, a)| {
-            NSColor::colorWithRed_green_blue_alpha(r as f64, g as f64, b as f64, a as f64 / 255.0)
+            NSColor::colorWithRed_green_blue_alpha(r as f64 / 255.0, g as f64 / 255.0, b as f64 / 255.0, a as f64 / 255.0)
           })
           .unwrap_or_else(|| NSColor::clearColor());
         ns_window.setBackgroundColor(Some(&color));
@@ -906,9 +906,9 @@ impl UnownedWindow {
       let color = color
         .map(|(r, g, b, a)| {
           Some(NSColor::colorWithRed_green_blue_alpha(
-            r as f64,
-            g as f64,
-            b as f64,
+            r as f64 / 255.0,
+            g as f64 / 255.0,
+            b as f64 / 255.0,
             a as f64 / 255.0,
           ))
         })


### PR DESCRIPTION
The color conversion from [u8;4] to [f64;4] was missing the division by 255.0. 

Fixes #1127.
