### PR TITLE
refactor(android): call WindowEvent::Destroyed on activity destroy

### DIFF
--- a/.changes/android-destroy.md
+++ b/.changes/android-destroy.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Trigger `WindowEvent::Destroyed` when the Android activity is destroyed. In this case, the app should either exit by setting the control flow to `ControlFlow::ExitWithCode` or NOT call the create() external function when the activity is recreated and `onCreate` is called, handling how to recreate the app window via a separate hook that can leverage the existing tao event loop.

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -184,6 +184,17 @@ impl<T: 'static> EventLoop<T> {
               }
             );
           }
+          Event::Destroy => {
+            call_event_handler!(
+              event_handler,
+              self.window_target(),
+              control_flow,
+              event::Event::WindowEvent {
+                window_id: window::WindowId(WindowId),
+                event: event::WindowEvent::Destroyed,
+              }
+            );
+          }
           _ => {}
         },
         Some(EventSource::InputQueue) => {


### PR DESCRIPTION
currently the Rust lifecycle is partially tied to the Android activity lifecycle:
- when the activity is created we initialize the event loop: https://github.com/tauri-apps/wry/blob/84b0ec2e35236e0b43150e37b55c7b6d2e5cf7e9/src/android/kotlin/WryActivity.kt#L61 https://github.com/tauri-apps/tao/blob/fda48e80ef0600079666c19146eb01bdfc4dd3c4/src/platform_impl/android/ndk_glue.rs#L196
- on destroy we are not doing anything in particular now, but we should let the app exit the event loop so it can properly restart when the activity gets recreated

to reproduce this, open a Tauri app and press the back button - it will destroy the activity, and reopening the app will crash due to some global state trying to reinitialize (like a log plugin initialization or any other global singleton values)

closes https://github.com/tauri-apps/tauri/issues/13568
