### PR TITLE
fix(windows): gap in maximized undecorated window

### DIFF
--- a/.changes/maximize-undecorated-window.md
+++ b/.changes/maximize-undecorated-window.md
@@ -1,0 +1,5 @@
+---
+tao: patch
+---
+
+Fix maximized windows have empty edges when using auto hide task bar on Windows

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2164,31 +2164,26 @@ unsafe fn public_window_callback_inner<T: 'static>(
           {
             let mut rect = monitor_info.monitorInfo.rcWork;
 
-            let mut edges = 0;
-            for edge in [ABE_BOTTOM, ABE_LEFT, ABE_TOP, ABE_RIGHT] {
+            fn has_edge(edge: u32) -> bool {
               let mut app_data = APPBARDATA {
                 cbSize: std::mem::size_of::<APPBARDATA>() as _,
                 uEdge: edge,
                 ..Default::default()
               };
-              if SHAppBarMessage(ABM_GETAUTOHIDEBAR, &mut app_data) != 0 {
-                edges |= edge;
-              }
+              unsafe { SHAppBarMessage(ABM_GETAUTOHIDEBAR, &mut app_data) != 0 }
             }
 
             // keep a 1px for taskbar auto-hide to work
-            if edges & ABE_BOTTOM != 0 {
+            if has_edge(ABE_BOTTOM) {
               rect.bottom -= 1;
             }
-            // FIXME:
-            #[allow(clippy::bad_bit_mask)]
-            if edges & ABE_LEFT != 0 {
+            if has_edge(ABE_LEFT) {
               rect.left += 1;
             }
-            if edges & ABE_TOP != 0 {
+            if has_edge(ABE_TOP) {
               rect.top += 1;
             }
-            if edges & ABE_RIGHT != 0 {
+            if has_edge(ABE_RIGHT) {
               rect.right -= 1;
             }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Fix https://github.com/tauri-apps/tauri/issues/14025

Fix maximized windows have empty edges when using auto hide task bar on Windows
