### PR TITLE
feat(android): emit LoopDestroyed when exiting the event loop

### DIFF
--- a/.changes/android-loop-destroyed.md
+++ b/.changes/android-loop-destroyed.md
@@ -1,0 +1,5 @@
+---
+tao: patch
+---
+
+Emit `Event::LoopDestroyed` on activity destroy on Android.

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -346,6 +346,14 @@ impl<T: 'static> EventLoop<T> {
             start: Instant::now(),
             requested_resume: None,
           };
+
+          call_event_handler!(
+            event_handler,
+            self.window_target(),
+            control_flow,
+            event::Event::LoopDestroyed
+          );
+
           break 'event_loop code;
         }
         ControlFlow::Poll => {


### PR DESCRIPTION
follow-up for #1148 