### PR TITLE
feat(mobile): add multi window support

### DIFF
--- a/.changes/android-breaking-changes.md
+++ b/.changes/android-breaking-changes.md
@@ -1,0 +1,16 @@
+---
+"tao": minor
+---
+
+**Breaking change:** The Android activity should now reference and call the following external functions:
+
+```
+private external fun onActivityCreate(activity)
+private external fun start()
+private external fun resume()
+private external fun pause()
+private external fun stop()
+private external fun onActivitySaveInstanceState()
+private external fun onActivityDestroy(activity)
+private external fun onActivityLowMemory()
+```

--- a/.changes/multi-window-mobile.md
+++ b/.changes/multi-window-mobile.md
@@ -1,0 +1,18 @@
+---
+"tao": minor
+---
+
+Added multi-window support for iOS and Android.
+
+Leverages [scenes](https://developer.apple.com/documentation/uikit/scenes) on iOS and [Activity embedding](https://developer.android.com/develop/ui/views/layout/activity-embedding) on Android.
+
+iOS:
+
+- Added Event::SceneRequested (on iPad the user can request a new window to be open - e.g. by long pressing the app icon and selecting "New window")
+- Request new scene to be created on Window::new (if needed, main scene is detected automatically) and assign the window instance later when it gets connected
+
+Android:
+
+- Create new activity on Window::new (if needed, main activity is detected automatically)
+- Added builder methods to determine the activity to be created
+- System determines what to do with the activity (new stack, next to another one.. based on the embedding rules)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2405,6 +2405,7 @@ dependencies = [
  "objc2-app-kit",
  "objc2-foundation 0.3.0",
  "objc2-ui-kit",
+ "once_cell",
  "parking_lot",
  "raw-window-handle 0.4.3",
  "raw-window-handle 0.5.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,12 +1436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
 name = "ndk-sys"
 version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,7 +2239,6 @@ dependencies = [
  "libc",
  "log",
  "ndk",
- "ndk-context",
  "ndk-sys",
  "objc2 0.6.0",
  "objc2-app-kit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,6 +1575,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c1948a9be5f469deadbd6bcb86ad7ff9e47b4f632380139722f7d9840c0d42c"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2 0.6.0",
+ "objc2-foundation 0.3.0",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f860f8e841f6d32f754836f51e6bc7777cd7e7053cf18528233f6811d3eceb4"
+dependencies = [
+ "objc2 0.6.0",
+ "objc2-foundation 0.3.0",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1603,38 @@ checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
 dependencies = [
  "bitflags 2.8.0",
  "objc2 0.6.0",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dca602628b65356b6513290a21a6405b4d4027b8b250f0b98dddbb28b7de02"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2 0.6.0",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ffa6bea72bf42c78b0b34e89c0bafac877d5f80bf91e159a5d96ea7f693ca56"
+dependencies = [
+ "objc2 0.6.0",
+ "objc2-foundation 0.3.0",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d31f4c5b5192304996badc466aeadffe1411d73a9bbd3b18b6b2ee9d048b07bd"
+dependencies = [
+ "objc2 0.6.0",
+ "objc2-foundation 0.3.0",
 ]
 
 [[package]]
@@ -1614,6 +1667,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-surface"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161a8b87e32610086e1a7a9e9ec39f84459db7b3a0881c1f16ca5a2605581c19"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2 0.6.0",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-metal"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,6 +1700,48 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb3794501bb1bee12f08dcad8c61f2a5875791ad1c6f47faa71a0f033f20071"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2 0.6.0",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.0",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777a571be14a42a3990d4ebedaeb8b54cd17377ec21b92e8200ac03797b3bee1"
+dependencies = [
+ "bitflags 2.8.0",
+ "block2 0.6.0",
+ "objc2 0.6.0",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation 0.3.0",
+ "objc2-quartz-core 0.3.0",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fe793adbf3b5e93686d48a05a7ed7ee53dfa65d106ced4805fae8969059b2"
+dependencies = [
+ "objc2 0.6.0",
+ "objc2-foundation 0.3.0",
 ]
 
 [[package]]
@@ -2152,7 +2258,7 @@ dependencies = [
  "memmap2",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "raw-window-handle 0.6.2",
  "redox_syscall",
  "rustix",
@@ -2243,6 +2349,7 @@ dependencies = [
  "objc2 0.6.0",
  "objc2-app-kit",
  "objc2-foundation 0.3.0",
+ "objc2-ui-kit",
  "once_cell",
  "parking_lot",
  "raw-window-handle 0.4.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,9 @@ objc2-ui-kit = { version = "0.3", features = [
   "UISceneOptions",
   "UIOpenURLContext",
 ] }
-objc2-foundation = { version = "0.3", default-features = false }
+objc2-foundation = { version = "0.3", default-features = false, features = [
+  "NSProcessInfo",
+] }
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 gtk = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,11 @@ core-graphics = "0.24"
 dispatch = "0.2"
 scopeguard = "1.2"
 
+[target."cfg(target_os = \"ios\")".dependencies]
+objc2-ui-kit = { version = "0.3", features = ["UIResponder"] }
+objc2-foundation = { version = "0.3", default-features = false }
+dispatch = "0.2"
+
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 gtk = "0.18"
 gdkx11-sys = { version = "0.18", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,12 @@ dispatch = "0.2"
 scopeguard = "1.2"
 
 [target."cfg(target_os = \"ios\")".dependencies]
-objc2-ui-kit = { version = "0.3", features = ["UIResponder"] }
+objc2-ui-kit = { version = "0.3", features = [
+  "UIResponder",
+  "UIScene",
+  "UISceneOptions",
+  "UIOpenURLContext",
+] }
 objc2-foundation = { version = "0.3", default-features = false }
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,6 @@ scopeguard = "1.2"
 [target."cfg(target_os = \"ios\")".dependencies]
 objc2-ui-kit = { version = "0.3", features = ["UIResponder"] }
 objc2-foundation = { version = "0.3", default-features = false }
-dispatch = "0.2"
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 gtk = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = ["tao-macros"]
 [dependencies]
 libc = "0.2"
 log = "0.4"
+once_cell = "1"
 serde = { version = "1", optional = true, features = ["serde_derive"] }
 rwh_04 = { package = "raw-window-handle", version = "0.4", optional = true }
 rwh_05 = { package = "raw-window-handle", version = "0.5", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,48 +4,52 @@ version = "0.34.5"
 description = "Cross-platform window manager library."
 authors = [
   "Tauri Programme within The Commons Conservancy",
-  "The winit contributors"
+  "The winit contributors",
 ]
 edition = "2021"
 rust-version = "1.74"
-keywords = [ "windowing" ]
+keywords = ["windowing"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/tauri-apps/tao"
 documentation = "https://docs.rs/tao"
-categories = [ "gui" ]
+categories = ["gui"]
 include = ["/README.md", "src/**/*.rs", "examples/**/*.rs", "LICENSE*"]
 
 [package.metadata.docs.rs]
-features = [ "rwh_04", "rwh_05", "rwh_06", "serde", "x11" ]
+features = ["rwh_04", "rwh_05", "rwh_06", "serde", "x11"]
 default-target = "x86_64-unknown-linux-gnu"
 targets = [
   "i686-pc-windows-msvc",
   "x86_64-pc-windows-msvc",
   "i686-unknown-linux-gnu",
   "x86_64-unknown-linux-gnu",
-  "x86_64-apple-darwin"
+  "x86_64-apple-darwin",
 ]
 
 [features]
-default = [ "rwh_06", "x11" ]
-serde = [ "dep:serde", "dpi/serde" ]
-rwh_04 = [ "dep:rwh_04" ]
-rwh_05 = [ "dep:rwh_05" ]
-rwh_06 = [ "dep:rwh_06" ]
-x11 = [ "dep:gdkx11-sys", "dep:x11-dl" ]
+default = ["rwh_06", "x11"]
+serde = ["dep:serde", "dpi/serde"]
+rwh_04 = ["dep:rwh_04"]
+rwh_05 = ["dep:rwh_05"]
+rwh_06 = ["dep:rwh_06"]
+x11 = ["dep:gdkx11-sys", "dep:x11-dl"]
 
 [workspace]
-members = [ "tao-macros" ]
+members = ["tao-macros"]
 
 [dependencies]
 lazy_static = "1"
 libc = "0.2"
 log = "0.4"
-serde = { version = "1", optional = true, features = [ "serde_derive" ] }
+serde = { version = "1", optional = true, features = ["serde_derive"] }
 rwh_04 = { package = "raw-window-handle", version = "0.4", optional = true }
-rwh_05 = { package = "raw-window-handle", version = "0.5", features = [ "std" ], optional = true }
-rwh_06 = { package = "raw-window-handle", version = "0.6", features = [ "std" ], optional = true }
+rwh_05 = { package = "raw-window-handle", version = "0.5", features = [
+  "std",
+], optional = true }
+rwh_06 = { package = "raw-window-handle", version = "0.6", features = [
+  "std",
+], optional = true }
 bitflags = "2"
 crossbeam-channel = "0.5"
 url = "2"
@@ -64,9 +68,9 @@ unicode-segmentation = "1.11"
 windows-version = "0.1"
 windows-core = "0.61"
 
-  [target."cfg(target_os = \"windows\")".dependencies.windows]
-  version = "0.61"
-  features = [
+[target."cfg(target_os = \"windows\")".dependencies.windows]
+version = "0.61"
+features = [
   "Win32_Devices_HumanInterfaceDevice",
   "Win32_Foundation",
   "Win32_Globalization",
@@ -92,7 +96,7 @@ windows-core = "0.61"
   "Win32_UI_Input_Touch",
   "Win32_UI_Shell",
   "Win32_UI_TextServices",
-  "Win32_UI_WindowsAndMessaging"
+  "Win32_UI_WindowsAndMessaging",
 ]
 
 [target."cfg(any(target_os = \"android\", target_os = \"windows\"))".dependencies]
@@ -102,7 +106,6 @@ once_cell = "1"
 jni = "0.21"
 ndk = "0.9"
 ndk-sys = "0.6"
-ndk-context = "0.1"
 tao-macros = { version = "0.1.0", path = "./tao-macros" }
 
 [target."cfg(any(target_os = \"ios\", target_os = \"macos\"))".dependencies]
@@ -142,7 +145,7 @@ objc2-app-kit = { version = "0.3", default-features = false, features = [
   "NSScreen",
   "NSView",
   "NSWindow",
-  "NSUserActivity"
+  "NSUserActivity",
 ] }
 core-foundation = "0.10"
 core-graphics = "0.24"

--- a/src/event.rs
+++ b/src/event.rs
@@ -142,6 +142,21 @@ pub enum Event<'a, T: 'static> {
   /// - **Other**: Unsupported.
   #[non_exhaustive]
   Reopen { has_visible_windows: bool },
+
+  /// Emitted when a scene is requested by the system.
+  ///
+  /// This event is emitted when a scene is requested by the system.
+  /// Scenes created by [`Window::new`] are not emitted with this event.
+  /// It is also not emitted for the main scene.
+  #[cfg(target_os = "ios")]
+  SceneRequested {
+    /// Scene that was requested by the system.
+    scene: objc2::rc::Retained<objc2_ui_kit::UIScene>,
+    /// Options that were used to request the scene.
+    ///
+    /// This lets you determine why the scene was requested.
+    options: objc2::rc::Retained<objc2_ui_kit::UISceneConnectionOptions>,
+  },
 }
 
 impl<T: Clone> Clone for Event<'static, T> {
@@ -170,6 +185,11 @@ impl<T: Clone> Clone for Event<'static, T> {
       } => Reopen {
         has_visible_windows: *has_visible_windows,
       },
+      #[cfg(target_os = "ios")]
+      SceneRequested { scene, options } => SceneRequested {
+        scene: scene.clone(),
+        options: options.clone(),
+      },
     }
   }
 }
@@ -194,6 +214,8 @@ impl<'a, T> Event<'a, T> {
       } => Ok(Reopen {
         has_visible_windows,
       }),
+      #[cfg(target_os = "ios")]
+      SceneRequested { scene, options } => Ok(SceneRequested { scene, options }),
     }
   }
 
@@ -220,6 +242,8 @@ impl<'a, T> Event<'a, T> {
       } => Some(Reopen {
         has_visible_windows,
       }),
+      #[cfg(target_os = "ios")]
+      SceneRequested { scene, options } => Some(SceneRequested { scene, options }),
     }
   }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -146,7 +146,7 @@ pub enum Event<'a, T: 'static> {
   /// Emitted when a scene is requested by the system.
   ///
   /// This event is emitted when a scene is requested by the system.
-  /// Scenes created by [`Window::new`] are not emitted with this event.
+  /// Scenes created by tao's window builder are not emitted with this event.
   /// It is also not emitted for the main scene.
   #[cfg(target_os = "ios")]
   SceneRequested {

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -51,29 +51,29 @@ impl<T> EventLoopWindowTargetExtAndroid for EventLoopWindowTarget<T> {}
 /// Additional methods on `WindowBuilder` that are specific to Android.
 pub trait WindowBuilderExtAndroid {
   /// The name of the activity class to create.
-  fn activity_name(self, activity_name: String) -> Self;
+  fn with_activity_name(self, activity_name: String) -> Self;
 
   /// The id of the created activity to use.
-  fn activity_id(self, activity_id: ActivityId) -> Self;
+  fn with_activity_id(self, activity_id: ActivityId) -> Self;
 
   /// The name of the activity class that created this window.
   ///
   /// This is important to define which stack the activity will be created on.
-  fn created_by_activity_name(self, created_by_activity_name: String) -> Self;
+  fn with_created_by_activity_name(self, created_by_activity_name: String) -> Self;
 }
 
 impl WindowBuilderExtAndroid for WindowBuilder {
-  fn activity_name(mut self, activity_name: String) -> Self {
+  fn with_activity_name(mut self, activity_name: String) -> Self {
     self.platform_specific.activity_name = Some(activity_name);
     self
   }
 
-  fn activity_id(mut self, activity_id: ActivityId) -> Self {
+  fn with_activity_id(mut self, activity_id: ActivityId) -> Self {
     self.platform_specific.activity_id = Some(activity_id);
     self
   }
 
-  fn created_by_activity_name(mut self, created_by_activity_name: String) -> Self {
+  fn with_created_by_activity_name(mut self, created_by_activity_name: String) -> Self {
     self.platform_specific.created_by_activity_name = Some(created_by_activity_name);
     self
   }

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -10,7 +10,7 @@ pub mod prelude {
 }
 use crate::{
   event_loop::{EventLoop, EventLoopWindowTarget},
-  platform_impl::ndk_glue::Rect,
+  platform_impl::ndk_glue::{ActivityId, Rect},
   window::{Window, WindowBuilder},
 };
 use ndk::configuration::Configuration;
@@ -28,6 +28,8 @@ pub trait WindowExtAndroid {
   fn content_rect(&self) -> Rect;
 
   fn config(&self) -> Configuration;
+
+  fn activity_name(&self) -> String;
 }
 
 impl WindowExtAndroid for Window {
@@ -38,11 +40,41 @@ impl WindowExtAndroid for Window {
   fn config(&self) -> Configuration {
     self.window.config()
   }
+
+  fn activity_name(&self) -> String {
+    self.window.activity_name().to_string()
+  }
 }
 
 impl<T> EventLoopWindowTargetExtAndroid for EventLoopWindowTarget<T> {}
 
 /// Additional methods on `WindowBuilder` that are specific to Android.
-pub trait WindowBuilderExtAndroid {}
+pub trait WindowBuilderExtAndroid {
+  /// The name of the activity class to create.
+  fn activity_name(self, activity_name: String) -> Self;
 
-impl WindowBuilderExtAndroid for WindowBuilder {}
+  /// The id of the created activity to use.
+  fn activity_id(self, activity_id: ActivityId) -> Self;
+
+  /// The name of the activity class that created this window.
+  ///
+  /// This is important to define which stack the activity will be created on.
+  fn created_by_activity_name(self, created_by_activity_name: String) -> Self;
+}
+
+impl WindowBuilderExtAndroid for WindowBuilder {
+  fn activity_name(mut self, activity_name: String) -> Self {
+    self.platform_specific.activity_name = Some(activity_name);
+    self
+  }
+
+  fn activity_id(mut self, activity_id: ActivityId) -> Self {
+    self.platform_specific.activity_id = Some(activity_id);
+    self
+  }
+
+  fn created_by_activity_name(mut self, created_by_activity_name: String) -> Self {
+    self.platform_specific.created_by_activity_name = Some(created_by_activity_name);
+    self
+  }
+}

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -10,7 +10,7 @@ pub mod prelude {
 }
 use crate::{
   event_loop::{EventLoop, EventLoopWindowTarget},
-  platform_impl::ndk_glue::{ActivityId, Rect},
+  platform_impl::ndk_glue::Rect,
   window::{Window, WindowBuilder},
 };
 use ndk::configuration::Configuration;
@@ -53,9 +53,6 @@ pub trait WindowBuilderExtAndroid {
   /// The name of the activity class to create.
   fn with_activity_name(self, activity_name: String) -> Self;
 
-  /// The id of the created activity to use.
-  fn with_activity_id(self, activity_id: ActivityId) -> Self;
-
   /// The name of the activity class that created this window.
   ///
   /// This is important to define which stack the activity will be created on.
@@ -65,11 +62,6 @@ pub trait WindowBuilderExtAndroid {
 impl WindowBuilderExtAndroid for WindowBuilder {
   fn with_activity_name(mut self, activity_name: String) -> Self {
     self.platform_specific.activity_name = Some(activity_name);
-    self
-  }
-
-  fn with_activity_id(mut self, activity_id: ActivityId) -> Self {
-    self.platform_specific.activity_id = Some(activity_id);
     self
   }
 

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -102,6 +102,9 @@ pub trait WindowExtIOS {
 
   /// Sets the badge count on iOS launcher. 0 hides the count
   fn set_badge_count(&self, count: i32);
+
+  /// Returns the identifier of the UIScene tied to this UIWindow.
+  fn scene_identifier(&self) -> String;
 }
 
 impl WindowExtIOS for Window {
@@ -150,6 +153,11 @@ impl WindowExtIOS for Window {
   #[inline]
   fn set_badge_count(&self, count: i32) {
     self.window.set_badge_count(count)
+  }
+
+  #[inline]
+  fn scene_identifier(&self) -> String {
+    self.window.scene_identifier()
   }
 }
 
@@ -219,6 +227,12 @@ pub trait WindowBuilderExtIOS {
   /// This sets the initial value returned by
   /// [`-[UIViewController prefersStatusBarHidden]`](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621440-prefersstatusbarhidden?language=objc).
   fn with_prefers_status_bar_hidden(self, hidden: bool) -> WindowBuilder;
+
+  /// Sets the identifier of the UIScene that is requesting the creation of this new scene,
+  /// establishing a relationship between the two scenes.
+  ///
+  /// By default the system uses the foreground scene.
+  fn with_requesting_scene_identifier(self, identifier: String) -> WindowBuilder;
 }
 
 impl WindowBuilderExtIOS for WindowBuilder {
@@ -260,6 +274,15 @@ impl WindowBuilderExtIOS for WindowBuilder {
   #[inline]
   fn with_prefers_status_bar_hidden(mut self, hidden: bool) -> WindowBuilder {
     self.platform_specific.prefers_status_bar_hidden = hidden;
+    self
+  }
+
+  #[inline]
+  fn with_requesting_scene_identifier(mut self, identifier: String) -> WindowBuilder {
+    self
+      .platform_specific
+      .requesting_scene_identifier
+      .replace(identifier);
     self
   }
 }

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -366,3 +366,13 @@ bitflags! {
             | ScreenEdge::BOTTOM.bits() | ScreenEdge::RIGHT.bits();
     }
 }
+
+pub(crate) fn operating_system_version() -> (isize, isize, isize) {
+  let process_info = objc2_foundation::NSProcessInfo::processInfo();
+  let version = process_info.operatingSystemVersion();
+  (
+    version.majorVersion,
+    version.minorVersion,
+    version.patchVersion,
+  )
+}

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -32,17 +32,6 @@ lazy_static! {
 pub enum OsError {
   JniError(jni::errors::Error),
   NoAvailableActivity,
-  ActivityNotFound {
-    activity_id: ActivityId,
-  },
-  ActivityAlreadyCreated {
-    activity_id: ActivityId,
-  },
-  ActivityClassMismatch {
-    activity_id: ActivityId,
-    expected_class_name: String,
-    actual_class_name: String,
-  },
 }
 
 impl std::error::Error for OsError {}
@@ -51,20 +40,6 @@ impl std::fmt::Display for OsError {
     match self {
       OsError::JniError(e) => write!(f, "JNI error: {e}"),
       OsError::NoAvailableActivity => write!(f, "no available activity"),
-      OsError::ActivityNotFound { activity_id } => write!(f, "activity not found: {activity_id}"),
-      OsError::ActivityAlreadyCreated { activity_id } => {
-        write!(f, "activity already created: {activity_id}")
-      }
-      OsError::ActivityClassMismatch {
-        activity_id,
-        expected_class_name,
-        actual_class_name,
-      } => {
-        write!(
-          f,
-          "activity class mismatch: {activity_id}, expected {expected_class_name} but got {actual_class_name}"
-        )
-      }
     }
   }
 }
@@ -553,39 +528,8 @@ impl Window {
   ) -> Result<Self, error::OsError> {
     // FIXME this ignores requested window attributes
 
-    let (activity_id, activity_name) = match (pl_attrs.activity_id, pl_attrs.activity_name) {
-      (Some(activity_id), Some(activity_name)) => ndk_glue::CONTEXTS
-        .lock()
-        .unwrap()
-        .get(&activity_id)
-        .ok_or_else(|| os_error!(OsError::ActivityNotFound { activity_id }))
-        .and_then(|ctx| {
-          if ctx.window_created {
-            Err(os_error!(OsError::ActivityAlreadyCreated { activity_id }))
-          } else if ctx.activity_name != activity_name {
-            Err(os_error!(OsError::ActivityClassMismatch {
-              activity_id,
-              expected_class_name: activity_name,
-              actual_class_name: ctx.activity_name.clone(),
-            }))
-          } else {
-            Ok((activity_id, ctx.activity_name.clone()))
-          }
-        })?,
-      // expect the activity to be already setup, without window
-      (Some(activity_id), None) => ndk_glue::CONTEXTS
-        .lock()
-        .unwrap()
-        .get(&activity_id)
-        .ok_or_else(|| os_error!(OsError::ActivityNotFound { activity_id }))
-        .and_then(|ctx| {
-          if ctx.window_created {
-            Err(os_error!(OsError::ActivityAlreadyCreated { activity_id }))
-          } else {
-            Ok((activity_id, ctx.activity_name.clone()))
-          }
-        })?,
-      (None, Some(activity_name)) => {
+    let (activity_id, activity_name) = match pl_attrs.activity_name {
+      Some(activity_name) => {
         let ctx = if let Some(created_by_activity_name) = pl_attrs.created_by_activity_name {
           ndk_glue::CONTEXTS
             .lock()
@@ -602,7 +546,7 @@ impl Window {
           .map_err(|error| os_error!(OsError::JniError(error)))?;
         (activity_id, activity_name)
       }
-      (None, None) => ndk_glue::next_available_activity()
+      None => ndk_glue::next_available_activity()
         .map(|(activity_id, ctx)| (activity_id, ctx.activity_name.clone()))
         .ok_or_else(|| os_error!(OsError::NoAvailableActivity))?,
     };

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -28,6 +28,47 @@ lazy_static! {
   static ref CONFIG: RwLock<Configuration> = RwLock::new(Configuration::new());
 }
 
+#[derive(Debug)]
+pub enum OsError {
+  JniError(jni::errors::Error),
+  NoAvailableActivity,
+  ActivityNotFound {
+    activity_id: ActivityId,
+  },
+  ActivityAlreadyCreated {
+    activity_id: ActivityId,
+  },
+  ActivityClassMismatch {
+    activity_id: ActivityId,
+    expected_class_name: String,
+    actual_class_name: String,
+  },
+}
+
+impl std::error::Error for OsError {}
+impl std::fmt::Display for OsError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      OsError::JniError(e) => write!(f, "JNI error: {e}"),
+      OsError::NoAvailableActivity => write!(f, "no available activity"),
+      OsError::ActivityNotFound { activity_id } => write!(f, "activity not found: {activity_id}"),
+      OsError::ActivityAlreadyCreated { activity_id } => {
+        write!(f, "activity already created: {activity_id}")
+      }
+      OsError::ActivityClassMismatch {
+        activity_id,
+        expected_class_name,
+        actual_class_name,
+      } => {
+        write!(
+          f,
+          "activity class mismatch: {activity_id}, expected {expected_class_name} but got {actual_class_name}"
+        )
+      }
+    }
+  }
+}
+
 enum EventSource {
   Callback,
   InputQueue,
@@ -492,22 +533,82 @@ impl DeviceId {
   }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct PlatformSpecificWindowBuilderAttributes;
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PlatformSpecificWindowBuilderAttributes {
+  pub activity_id: Option<ActivityId>,
+  pub activity_name: Option<String>,
+  pub created_by_activity_name: Option<String>,
+}
 
 pub struct Window {
   activity_id: ActivityId,
+  activity_name: String,
 }
 
 impl Window {
   pub fn new<T: 'static>(
     _el: &EventLoopWindowTarget<T>,
     _window_attrs: window::WindowAttributes,
-    _: PlatformSpecificWindowBuilderAttributes,
+    pl_attrs: PlatformSpecificWindowBuilderAttributes,
   ) -> Result<Self, error::OsError> {
     // FIXME this ignores requested window attributes
+
+    let (activity_id, activity_name) = match (pl_attrs.activity_id, pl_attrs.activity_name) {
+      (Some(activity_id), Some(activity_name)) => ndk_glue::CONTEXTS
+        .lock()
+        .unwrap()
+        .get(&activity_id)
+        .ok_or_else(|| os_error!(OsError::ActivityNotFound { activity_id }))
+        .and_then(|ctx| {
+          if ctx.window_created {
+            Err(os_error!(OsError::ActivityAlreadyCreated { activity_id }))
+          } else if ctx.activity_name != activity_name {
+            Err(os_error!(OsError::ActivityClassMismatch {
+              activity_id,
+              expected_class_name: activity_name,
+              actual_class_name: ctx.activity_name.clone(),
+            }))
+          } else {
+            Ok((activity_id, ctx.activity_name.clone()))
+          }
+        })?,
+      // expect the activity to be already setup, without window
+      (Some(activity_id), None) => ndk_glue::CONTEXTS
+        .lock()
+        .unwrap()
+        .get(&activity_id)
+        .ok_or_else(|| os_error!(OsError::ActivityNotFound { activity_id }))
+        .and_then(|ctx| {
+          if ctx.window_created {
+            Err(os_error!(OsError::ActivityAlreadyCreated { activity_id }))
+          } else {
+            Ok((activity_id, ctx.activity_name.clone()))
+          }
+        })?,
+      (None, Some(activity_name)) => {
+        let ctx = if let Some(created_by_activity_name) = pl_attrs.created_by_activity_name {
+          ndk_glue::CONTEXTS
+            .lock()
+            .unwrap()
+            .values()
+            .find(|ctx| ctx.activity_name == created_by_activity_name)
+            .cloned()
+        } else {
+          ndk_glue::main_android_context()
+        }
+        .ok_or_else(|| os_error!(OsError::NoAvailableActivity))?;
+        let activity_id = ctx
+          .create_activity(&activity_name)
+          .map_err(|error| os_error!(OsError::JniError(error)))?;
+        (activity_id, activity_name)
+      }
+      (None, None) => ndk_glue::next_available_activity()
+        .map(|(activity_id, ctx)| (activity_id, ctx.activity_name.clone()))
+        .ok_or_else(|| os_error!(OsError::NoAvailableActivity))?,
+    };
     Ok(Self {
-      activity_id: ndk_glue::last_activity_id().expect("no available activity"),
+      activity_id,
+      activity_name,
     })
   }
 
@@ -727,7 +828,7 @@ impl Window {
   pub fn raw_window_handle_rwh_04(&self) -> rwh_04::RawWindowHandle {
     // TODO: Use main activity instead?
     let mut handle = rwh_04::AndroidNdkHandle::empty();
-    if let Some(w) = ndk_glue::main_window_manager().as_ref() {
+    if let Some(w) = ndk_glue::activity_window_manager(self.activity_id).as_ref() {
       handle.a_native_window = w.as_obj().as_raw() as *mut _;
     } else {
       panic!("Cannot get the native window, it's null and will always be null before Event::Resumed and after Event::Suspended. Make sure you only call this function between those events.");
@@ -739,7 +840,7 @@ impl Window {
   pub fn raw_window_handle_rwh_05(&self) -> rwh_05::RawWindowHandle {
     // TODO: Use main activity instead?
     let mut handle = rwh_05::AndroidNdkWindowHandle::empty();
-    if let Some(w) = ndk_glue::main_window_manager().as_ref() {
+    if let Some(w) = ndk_glue::activity_window_manager(self.activity_id).as_ref() {
       handle.a_native_window = w.as_obj().as_raw() as *mut _;
     } else {
       panic!("Cannot get the native window, it's null and will always be null before Event::Resumed and after Event::Suspended. Make sure you only call this function between those events.");
@@ -755,7 +856,7 @@ impl Window {
   #[cfg(feature = "rwh_06")]
   pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
     // TODO: Use main activity instead?
-    if let Some(w) = ndk_glue::main_window_manager().as_ref() {
+    if let Some(w) = ndk_glue::activity_window_manager(self.activity_id).as_ref() {
       let native_window =
         unsafe { std::ptr::NonNull::new_unchecked(w.as_obj().as_raw() as *mut _) };
       // native_window shuldn't be null
@@ -780,18 +881,12 @@ impl Window {
     ndk_glue::content_rect()
   }
 
+  pub fn activity_name(&self) -> &str {
+    &self.activity_name
+  }
+
   pub fn theme(&self) -> Theme {
     Theme::Light
-  }
-}
-
-#[derive(Default, Clone, Debug)]
-pub struct OsError;
-
-use std::fmt::{self, Display, Formatter};
-impl Display for OsError {
-  fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-    write!(fmt, "Android OS Error")
   }
 }
 
@@ -806,6 +901,8 @@ impl MonitorHandle {
   }
 
   pub fn size(&self) -> PhysicalSize<u32> {
+    // TODO: support multi-window (main_window_manager might be incorrect)
+
     // TODO decide how to get JNIENV
     let window_manager = ndk_glue::main_window_manager();
     let Some(w) = window_manager.as_ref() else {

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -2,19 +2,17 @@
 // Copyright 2021-2023 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(target_os = "android")]
 use crate::{
   dpi::{PhysicalPosition, PhysicalSize, Position, Size},
   error, event,
   event_loop::{self, ControlFlow},
-  keyboard::{Key, KeyCode, KeyLocation, NativeKeyCode},
+  keyboard::{KeyCode, NativeKeyCode},
   monitor,
   window::{self, ResizeDirection, Theme, WindowSizeConstraints},
 };
 use crossbeam_channel::{Receiver, Sender};
 use ndk::{
   configuration::Configuration,
-  event::{InputEvent, KeyAction, MotionAction},
   looper::{ForeignLooper, Poll, ThreadLooper},
 };
 use std::{
@@ -24,7 +22,7 @@ use std::{
 };
 
 pub mod ndk_glue;
-use ndk_glue::{Event, Rect};
+use ndk_glue::{ActivityId, Event, Rect, WindowEvent};
 
 lazy_static! {
   static ref CONFIG: RwLock<Configuration> = RwLock::new(Configuration::new());
@@ -118,8 +116,8 @@ impl<T: 'static> EventLoop<T> {
         event::Event::NewEvents(self.start_cause)
       );
 
-      let mut redraw = false;
-      let mut resized = false;
+      let mut redraw_window_id = None;
+      let mut resized_window_id = None;
 
       match self.first_event.take() {
         Some(EventSource::Callback) => match ndk_glue::poll_events().unwrap() {
@@ -131,8 +129,36 @@ impl<T: 'static> EventLoop<T> {
               event::Event::Resumed
             );
           }
-          Event::WindowResized => resized = true,
-          Event::WindowRedrawNeeded => redraw = true,
+          Event::WindowEvent {
+            id: window_id,
+            event,
+          } => match event {
+            WindowEvent::Resized => resized_window_id = Some(window_id),
+            WindowEvent::RedrawNeeded => redraw_window_id = Some(window_id),
+            WindowEvent::Focused(focused) => {
+              call_event_handler!(
+                event_handler,
+                self.window_target(),
+                control_flow,
+                event::Event::WindowEvent {
+                  window_id,
+                  event: event::WindowEvent::Focused(focused)
+                }
+              );
+            }
+            WindowEvent::Destroyed => {
+              call_event_handler!(
+                event_handler,
+                self.window_target(),
+                control_flow,
+                event::Event::WindowEvent {
+                  window_id,
+                  event: event::WindowEvent::Destroyed,
+                }
+              );
+            }
+            _ => {}
+          },
           Event::Pause => {
             call_event_handler!(
               event_handler,
@@ -143,155 +169,125 @@ impl<T: 'static> EventLoop<T> {
           }
           Event::Stop => self.running = false,
           Event::Start => self.running = true,
-          Event::ConfigChanged => {
-            // #[allow(deprecated)] // TODO: use ndk-context instead
-            // let am = ndk_glue::native_activity().asset_manager();
-            // let config = Configuration::from_asset_manager(&am);
-            // let old_scale_factor = MonitorHandle.scale_factor();
-            // *CONFIG.write().unwrap() = config;
-            // let scale_factor = MonitorHandle.scale_factor();
-            // if (scale_factor - old_scale_factor).abs() < f64::EPSILON {
-            //   let mut size = MonitorHandle.size();
-            //   let event = event::Event::WindowEvent {
-            //     window_id: window::WindowId(WindowId),
-            //     event: event::WindowEvent::ScaleFactorChanged {
-            //       new_inner_size: &mut size,
-            //       scale_factor,
-            //     },
-            //   };
-            //   call_event_handler!(event_handler, self.window_target(), control_flow, event);
-            // }
-          }
-          Event::WindowHasFocus => {
-            call_event_handler!(
-              event_handler,
-              self.window_target(),
-              control_flow,
-              event::Event::WindowEvent {
-                window_id: window::WindowId(WindowId),
-                event: event::WindowEvent::Focused(true),
-              }
-            );
-          }
-          Event::WindowLostFocus => {
-            call_event_handler!(
-              event_handler,
-              self.window_target(),
-              control_flow,
-              event::Event::WindowEvent {
-                window_id: window::WindowId(WindowId),
-                event: event::WindowEvent::Focused(false),
-              }
-            );
-          }
-          Event::Destroy => {
-            call_event_handler!(
-              event_handler,
-              self.window_target(),
-              control_flow,
-              event::Event::WindowEvent {
-                window_id: window::WindowId(WindowId),
-                event: event::WindowEvent::Destroyed,
-              }
-            );
-          }
+          //Event::ConfigChanged => {
+          // #[allow(deprecated)] // TODO: use ndk-context instead
+          // let am = ndk_glue::native_activity().asset_manager();
+          // let config = Configuration::from_asset_manager(&am);
+          // let old_scale_factor = MonitorHandle.scale_factor();
+          // *CONFIG.write().unwrap() = config;
+          // let scale_factor = MonitorHandle.scale_factor();
+          // if (scale_factor - old_scale_factor).abs() < f64::EPSILON {
+          //   let mut size = MonitorHandle.size();
+          //   let event = event::Event::WindowEvent {
+          //     window_id: window::WindowId(WindowId),
+          //     event: event::WindowEvent::ScaleFactorChanged {
+          //       new_inner_size: &mut size,
+          //       scale_factor,
+          //     },
+          //   };
+          //   call_event_handler!(event_handler, self.window_target(), control_flow, event);
+          // }
+          //}
           _ => {}
         },
+
         Some(EventSource::InputQueue) => {
-          if let Some(input_queue) = ndk_glue::input_queue().as_ref() {
-            while let Ok(Some(event)) = input_queue.event() {
-              if let Some(event) = input_queue.pre_dispatch(event) {
-                let mut handled = true;
-                let window_id = window::WindowId(WindowId);
-                let device_id = event::DeviceId(DeviceId);
-                match &event {
-                  InputEvent::MotionEvent(motion_event) => {
-                    let phase = match motion_event.action() {
-                      MotionAction::Down | MotionAction::PointerDown => {
-                        Some(event::TouchPhase::Started)
-                      }
-                      MotionAction::Up | MotionAction::PointerUp => Some(event::TouchPhase::Ended),
-                      MotionAction::Move => Some(event::TouchPhase::Moved),
-                      MotionAction::Cancel => Some(event::TouchPhase::Cancelled),
-                      _ => {
-                        handled = false;
-                        None // TODO mouse events
-                      }
-                    };
-                    if let Some(phase) = phase {
-                      let pointers: Box<dyn Iterator<Item = ndk::event::Pointer<'_>>> = match phase
-                      {
-                        event::TouchPhase::Started | event::TouchPhase::Ended => {
-                          Box::new(std::iter::once(
-                            motion_event.pointer_at_index(motion_event.pointer_index()),
-                          ))
+          /*
+            if let Some(input_queue) = ndk_glue::input_queue().as_ref() {
+              while let Ok(Some(event)) = input_queue.event() {
+                if let Some(event) = input_queue.pre_dispatch(event) {
+                  let mut handled = true;
+                  let window_id = window::WindowId(WindowId);
+                  let device_id = event::DeviceId(DeviceId);
+                  match &event {
+                    InputEvent::MotionEvent(motion_event) => {
+                      let phase = match motion_event.action() {
+                        MotionAction::Down | MotionAction::PointerDown => {
+                          Some(event::TouchPhase::Started)
                         }
-                        event::TouchPhase::Moved | event::TouchPhase::Cancelled => {
-                          Box::new(motion_event.pointers())
+                        MotionAction::Up | MotionAction::PointerUp => Some(event::TouchPhase::Ended),
+                        MotionAction::Move => Some(event::TouchPhase::Moved),
+                        MotionAction::Cancel => Some(event::TouchPhase::Cancelled),
+                        _ => {
+                          handled = false;
+                          None // TODO mouse events
                         }
                       };
+                      if let Some(phase) = phase {
+                        let pointers: Box<dyn Iterator<Item = ndk::event::Pointer<'_>>> = match phase
+                        {
+                          event::TouchPhase::Started | event::TouchPhase::Ended => {
+                            Box::new(std::iter::once(
+                              motion_event.pointer_at_index(motion_event.pointer_index()),
+                            ))
+                          }
+                          event::TouchPhase::Moved | event::TouchPhase::Cancelled => {
+                            Box::new(motion_event.pointers())
+                          }
+                        };
 
-                      for pointer in pointers {
-                        let location = PhysicalPosition {
-                          x: pointer.x() as _,
-                          y: pointer.y() as _,
-                        };
-                        let event = event::Event::WindowEvent {
-                          window_id,
-                          event: event::WindowEvent::Touch(event::Touch {
-                            device_id,
-                            phase,
-                            location,
-                            id: pointer.pointer_id() as u64,
-                            force: None,
-                          }),
-                        };
-                        call_event_handler!(
-                          event_handler,
-                          self.window_target(),
-                          control_flow,
-                          event
-                        );
+                        for pointer in pointers {
+                          let location = PhysicalPosition {
+                            x: pointer.x() as _,
+                            y: pointer.y() as _,
+                          };
+                          let event = event::Event::WindowEvent {
+                            window_id,
+                            event: event::WindowEvent::Touch(event::Touch {
+                              device_id,
+                              phase,
+                              location,
+                              id: pointer.pointer_id() as u64,
+                              force: None,
+                            }),
+                          };
+                          call_event_handler!(
+                            event_handler,
+                            self.window_target(),
+                            control_flow,
+                            event
+                          );
+                        }
                       }
                     }
-                  }
-                  InputEvent::KeyEvent(key) => {
-                    let state = match key.action() {
-                      KeyAction::Down => event::ElementState::Pressed,
-                      KeyAction::Up => event::ElementState::Released,
-                      _ => event::ElementState::Released,
-                    };
+                    InputEvent::KeyEvent(key) => {
+                      let state = match key.action() {
+                        KeyAction::Down => event::ElementState::Pressed,
+                        KeyAction::Up => event::ElementState::Released,
+                        _ => event::ElementState::Released,
+                      };
 
-                    let keycode = key.key_code();
-                    let native = NativeKeyCode::Android(keycode.into());
-                    let physical_key = KeyCode::Unidentified(native);
-                    let logical_key = keycode_to_logical(keycode, native);
-                    // TODO: maybe use getUnicodeChar to get the logical key
+                      let keycode = key.key_code();
+                      let native = NativeKeyCode::Android(keycode.into());
+                      let physical_key = KeyCode::Unidentified(native);
+                      let logical_key = keycode_to_logical(keycode, native);
+                      // TODO: maybe use getUnicodeChar to get the logical key
 
-                    let event = event::Event::WindowEvent {
-                      window_id,
-                      event: event::WindowEvent::KeyboardInput {
-                        device_id,
-                        event: event::KeyEvent {
-                          state,
-                          physical_key,
-                          logical_key,
-                          location: keycode_to_location(keycode),
-                          repeat: key.repeat_count() > 0,
-                          text: None,
-                          platform_specific: KeyEventExtra {},
+                      let event = event::Event::WindowEvent {
+                        window_id,
+                        event: event::WindowEvent::KeyboardInput {
+                          device_id,
+                          event: event::KeyEvent {
+                            state,
+                            physical_key,
+                            logical_key,
+                            location: keycode_to_location(keycode),
+                            repeat: key.repeat_count() > 0,
+                            text: None,
+                            platform_specific: KeyEventExtra {},
+                          },
+                          is_synthetic: false,
                         },
-                        is_synthetic: false,
-                      },
-                    };
-                    call_event_handler!(event_handler, self.window_target(), control_flow, event);
-                  }
-                  _ => {}
-                };
-                input_queue.finish_event(event, handled);
+                      };
+                      call_event_handler!(event_handler, self.window_target(), control_flow, event);
+                    }
+                    _ => {}
+                  };
+                  input_queue.finish_event(event, handled);
+                }
               }
             }
-          }
+          */
         }
         Some(EventSource::User) => {
           while let Ok(event) = self.receiver.try_recv() {
@@ -313,18 +309,22 @@ impl<T: 'static> EventLoop<T> {
         event::Event::MainEventsCleared
       );
 
-      if resized && self.running {
-        let size = MonitorHandle.size();
-        let event = event::Event::WindowEvent {
-          window_id: window::WindowId(WindowId),
-          event: event::WindowEvent::Resized(size),
-        };
-        call_event_handler!(event_handler, self.window_target(), control_flow, event);
+      if let Some(window_id) = resized_window_id {
+        if self.running {
+          let size = MonitorHandle.size();
+          let event = event::Event::WindowEvent {
+            window_id,
+            event: event::WindowEvent::Resized(size),
+          };
+          call_event_handler!(event_handler, self.window_target(), control_flow, event);
+        }
       }
 
-      if redraw && self.running {
-        let event = event::Event::RedrawRequested(window::WindowId(WindowId));
-        call_event_handler!(event_handler, self.window_target(), control_flow, event);
+      if let Some(window_id) = redraw_window_id {
+        if self.running {
+          let event = event::Event::RedrawRequested(window_id);
+          call_event_handler!(event_handler, self.window_target(), control_flow, event);
+        }
       }
 
       call_event_handler!(
@@ -445,7 +445,7 @@ impl<T: 'static> EventLoopWindowTarget<T> {
   #[inline]
   pub fn monitor_from_point(&self, _x: f64, _y: f64) -> Option<MonitorHandle> {
     warn!("`Window::monitor_from_point` is ignored on Android");
-    return None;
+    None
   }
 
   pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
@@ -475,11 +475,11 @@ impl<T: 'static> EventLoopWindowTarget<T> {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct WindowId;
+pub struct WindowId(ActivityId);
 
 impl WindowId {
   pub fn dummy() -> Self {
-    WindowId
+    WindowId(0)
   }
 }
 
@@ -495,7 +495,9 @@ impl DeviceId {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PlatformSpecificWindowBuilderAttributes;
 
-pub struct Window;
+pub struct Window {
+  activity_id: ActivityId,
+}
 
 impl Window {
   pub fn new<T: 'static>(
@@ -504,11 +506,13 @@ impl Window {
     _: PlatformSpecificWindowBuilderAttributes,
   ) -> Result<Self, error::OsError> {
     // FIXME this ignores requested window attributes
-    Ok(Self)
+    Ok(Self {
+      activity_id: ndk_glue::last_activity_id().expect("no available activity"),
+    })
   }
 
   pub fn id(&self) -> WindowId {
-    WindowId
+    WindowId(self.activity_id)
   }
 
   pub fn primary_monitor(&self) -> Option<monitor::MonitorHandle> {
@@ -723,7 +727,7 @@ impl Window {
   pub fn raw_window_handle_rwh_04(&self) -> rwh_04::RawWindowHandle {
     // TODO: Use main activity instead?
     let mut handle = rwh_04::AndroidNdkHandle::empty();
-    if let Some(w) = ndk_glue::window_manager().as_ref() {
+    if let Some(w) = ndk_glue::main_window_manager().as_ref() {
       handle.a_native_window = w.as_obj().as_raw() as *mut _;
     } else {
       panic!("Cannot get the native window, it's null and will always be null before Event::Resumed and after Event::Suspended. Make sure you only call this function between those events.");
@@ -735,7 +739,7 @@ impl Window {
   pub fn raw_window_handle_rwh_05(&self) -> rwh_05::RawWindowHandle {
     // TODO: Use main activity instead?
     let mut handle = rwh_05::AndroidNdkWindowHandle::empty();
-    if let Some(w) = ndk_glue::window_manager().as_ref() {
+    if let Some(w) = ndk_glue::main_window_manager().as_ref() {
       handle.a_native_window = w.as_obj().as_raw() as *mut _;
     } else {
       panic!("Cannot get the native window, it's null and will always be null before Event::Resumed and after Event::Suspended. Make sure you only call this function between those events.");
@@ -751,7 +755,7 @@ impl Window {
   #[cfg(feature = "rwh_06")]
   pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
     // TODO: Use main activity instead?
-    if let Some(w) = ndk_glue::window_manager().as_ref() {
+    if let Some(w) = ndk_glue::main_window_manager().as_ref() {
       let native_window =
         unsafe { std::ptr::NonNull::new_unchecked(w.as_obj().as_raw() as *mut _) };
       // native_window shuldn't be null
@@ -803,40 +807,42 @@ impl MonitorHandle {
 
   pub fn size(&self) -> PhysicalSize<u32> {
     // TODO decide how to get JNIENV
-    if let Some(w) = ndk_glue::window_manager().as_ref() {
-      let ctx = ndk_context::android_context();
-      let vm = unsafe { jni::JavaVM::from_raw(ctx.vm().cast()) }.unwrap();
-      let mut env = vm.attach_current_thread().unwrap();
-      let window_manager = w.as_obj();
-      let metrics = env
-        .call_method(
-          window_manager,
-          "getCurrentWindowMetrics",
-          "()Landroid/view/WindowMetrics;",
-          &[],
-        )
-        .unwrap()
-        .l()
-        .unwrap();
-      let rect = env
-        .call_method(&metrics, "getBounds", "()Landroid/graphics/Rect;", &[])
-        .unwrap()
-        .l()
-        .unwrap();
-      let width = env
-        .call_method(&rect, "width", "()I", &[])
-        .unwrap()
-        .i()
-        .unwrap();
-      let height = env
-        .call_method(&rect, "height", "()I", &[])
-        .unwrap()
-        .i()
-        .unwrap();
-      PhysicalSize::new(width as u32, height as u32)
-    } else {
-      PhysicalSize::new(0, 0)
-    }
+    let window_manager = ndk_glue::main_window_manager();
+    let Some(w) = window_manager.as_ref() else {
+      return PhysicalSize::new(0, 0);
+    };
+    let Some(ctx) = ndk_glue::main_android_context() else {
+      return PhysicalSize::new(0, 0);
+    };
+    let vm = unsafe { jni::JavaVM::from_raw(ctx.java_vm.cast()) }.unwrap();
+    let mut env = vm.attach_current_thread().unwrap();
+    let window_manager = w.as_obj();
+    let metrics = env
+      .call_method(
+        window_manager,
+        "getCurrentWindowMetrics",
+        "()Landroid/view/WindowMetrics;",
+        &[],
+      )
+      .unwrap()
+      .l()
+      .unwrap();
+    let rect = env
+      .call_method(&metrics, "getBounds", "()Landroid/graphics/Rect;", &[])
+      .unwrap()
+      .l()
+      .unwrap();
+    let width = env
+      .call_method(&rect, "width", "()I", &[])
+      .unwrap()
+      .i()
+      .unwrap();
+    let height = env
+      .call_method(&rect, "height", "()I", &[])
+      .unwrap()
+      .i()
+      .unwrap();
+    PhysicalSize::new(width as u32, height as u32)
   }
 
   pub fn position(&self) -> PhysicalPosition<i32> {
@@ -853,17 +859,17 @@ impl MonitorHandle {
 
   pub fn video_modes(&self) -> impl Iterator<Item = monitor::VideoMode> {
     let size = self.size().into();
-    let mut v = Vec::new();
     // FIXME this is not the real refresh rate
     // (it is guarunteed to support 32 bit color though)
-    v.push(monitor::VideoMode {
+    let v = vec![monitor::VideoMode {
       video_mode: VideoMode {
         size,
         bit_depth: 32,
         refresh_rate: 60,
         monitor: self.clone(),
       },
-    });
+    }];
+
     v.into_iter()
   }
 }
@@ -896,6 +902,7 @@ impl VideoMode {
   }
 }
 
+/*
 fn keycode_to_logical(keycode: ndk::event::Keycode, native: NativeKeyCode) -> Key<'static> {
   use ndk::event::Keycode::*;
 
@@ -1270,6 +1277,7 @@ fn keycode_to_location(keycode: ndk::event::Keycode) -> KeyLocation {
     _ => KeyLocation::Standard,
   }
 }
+*/
 
 // FIXME: Implement android
 pub fn keycode_to_scancode(_code: KeyCode) -> Option<u32> {

--- a/src/platform_impl/android/ndk_glue.rs
+++ b/src/platform_impl/android/ndk_glue.rs
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::window::WindowId;
+use crossbeam_channel::Sender;
 pub use jni::{
   self,
+  errors::Result as JniResult,
   objects::{GlobalRef, JClass, JMap, JObject, JString},
   sys::jobject,
   JNIEnv,
@@ -24,6 +26,7 @@ use std::{
   os::unix::prelude::*,
   sync::{Arc, Condvar, Mutex, RwLock, RwLockReadGuard},
   thread,
+  time::Duration,
 };
 
 /// Android pacakge name that could be used to reference classes
@@ -116,10 +119,64 @@ pub fn android_log(level: Level, tag: &CStr, msg: &CStr) {
   }
 }
 
-#[derive(Clone, Copy, Debug)]
+fn find_class<'a>(
+  env: &mut JNIEnv<'a>,
+  activity: &JObject<'_>,
+  name: String,
+) -> JniResult<JClass<'a>> {
+  let class_name = env.new_string(name.replace('/', "."))?;
+  let my_class = env
+    .call_method(
+      activity,
+      "getAppClass",
+      "(Ljava/lang/String;)Ljava/lang/Class;",
+      &[(&class_name).into()],
+    )?
+    .l()?;
+  Ok(my_class.into())
+}
+
+#[derive(Clone, Debug)]
 pub struct AndroidContext {
   pub java_vm: *mut c_void,
   pub context_jobject: *mut c_void,
+  pub activity_name: String,
+  pub window_created: bool,
+}
+
+impl AndroidContext {
+  pub fn create_activity(&self, activity_name: &str) -> JniResult<ActivityId> {
+    let vm = unsafe { jni::JavaVM::from_raw(self.java_vm.cast()) }?;
+    let mut env = vm.attach_current_thread_as_daemon()?;
+    let main_activity = unsafe { JObject::from_raw(self.context_jobject.cast()) };
+
+    let activity_class = find_class(
+      &mut env,
+      &main_activity,
+      format!("{}/{activity_name}", PACKAGE.get().unwrap()),
+    )?;
+
+    let activity_id = env
+      .call_method(
+        &main_activity,
+        "startActivity",
+        "(Ljava/lang/Class;)I",
+        &[(&activity_class).into()],
+      )?
+      .i()?;
+
+    let (tx, rx) = crossbeam_channel::bounded(1);
+    ACTIVITY_CREATED_SENDERS
+      .lock()
+      .unwrap()
+      .insert(activity_id, tx);
+    rx.recv_timeout(Duration::from_secs(5)).map_err(|e| {
+      log::error!("failed to create activity {activity_name}: {e}");
+      jni::errors::Error::JniCall(jni::errors::JniError::Unknown)
+    })?;
+
+    Ok(activity_id)
+  }
 }
 
 unsafe impl Send for AndroidContext {}
@@ -128,8 +185,9 @@ unsafe impl Sync for AndroidContext {}
 pub type ActivityId = i32;
 
 lazy_static::lazy_static! {
-  static ref CONTEXTS: Mutex<BTreeMap<ActivityId, AndroidContext>> = Mutex::new(Default::default());
+  pub(crate) static ref CONTEXTS: Mutex<BTreeMap<ActivityId, AndroidContext>> = Mutex::new(Default::default());
   static ref WINDOW_MANAGER: Mutex<BTreeMap<ActivityId, GlobalRef>> = Mutex::new(Default::default());
+  pub(crate) static ref ACTIVITY_CREATED_SENDERS: Mutex<BTreeMap<ActivityId, Sender<()>>> = Mutex::new(Default::default());
 }
 
 static INPUT_QUEUE: Lazy<RwLock<Option<InputQueue>>> = Lazy::new(Default::default);
@@ -138,6 +196,10 @@ static LOOPER: Lazy<Mutex<Option<ForeignLooper>>> = Lazy::new(Default::default);
 
 pub fn main_window_manager() -> Option<GlobalRef> {
   WINDOW_MANAGER.lock().unwrap().values().next().cloned()
+}
+
+pub fn activity_window_manager(activity_id: ActivityId) -> Option<GlobalRef> {
+  WINDOW_MANAGER.lock().unwrap().get(&activity_id).cloned()
 }
 
 pub fn window_manager(activity_id: ActivityId) -> Option<GlobalRef> {
@@ -156,8 +218,14 @@ pub fn main_android_context() -> Option<AndroidContext> {
   CONTEXTS.lock().unwrap().values().next().cloned()
 }
 
-pub fn last_activity_id() -> Option<ActivityId> {
-  CONTEXTS.lock().unwrap().keys().next_back().cloned()
+pub fn next_available_activity() -> Option<(ActivityId, AndroidContext)> {
+  CONTEXTS
+    .lock()
+    .unwrap()
+    .iter()
+    .filter(|(_, ctx)| !ctx.window_created)
+    .next()
+    .map(|(id, ctx)| (*id, ctx.clone()))
 }
 
 pub static PIPE: Lazy<[OwnedFd; 2]> = Lazy::new(|| {
@@ -288,6 +356,18 @@ pub unsafe fn onActivityCreate(
     .i()
     .unwrap();
 
+  let activity_name: JString = env
+    .call_method(&activity, "getLocalClassName", "()Ljava/lang/String;", &[])
+    .unwrap()
+    .l()
+    .unwrap()
+    .into();
+  let activity_name = env
+    .get_string(&activity_name)
+    .unwrap()
+    .to_string_lossy()
+    .to_string();
+
   // Initialize global context
   let window_manager = env
     .call_method(
@@ -313,10 +393,20 @@ pub unsafe fn onActivityCreate(
     AndroidContext {
       java_vm: vm.get_java_vm_pointer() as *mut _,
       context_jobject: activity.as_obj().as_raw() as *mut _,
+      activity_name,
+      window_created: false,
     },
   );
   let looper = ThreadLooper::for_thread().unwrap();
   setup(PACKAGE.get().unwrap(), env, &looper, activity);
+
+  if let Some(tx) = ACTIVITY_CREATED_SENDERS
+    .lock()
+    .unwrap()
+    .remove(&activity_id)
+  {
+    let _ = tx.send(());
+  }
 }
 
 pub unsafe fn resume(_: JNIEnv, _: JClass, _: JObject) {

--- a/src/platform_impl/android/ndk_glue.rs
+++ b/src/platform_impl/android/ndk_glue.rs
@@ -184,11 +184,11 @@ unsafe impl Sync for AndroidContext {}
 
 pub type ActivityId = i32;
 
-lazy_static::lazy_static! {
-  pub(crate) static ref CONTEXTS: Mutex<BTreeMap<ActivityId, AndroidContext>> = Mutex::new(Default::default());
-  static ref WINDOW_MANAGER: Mutex<BTreeMap<ActivityId, GlobalRef>> = Mutex::new(Default::default());
-  pub(crate) static ref ACTIVITY_CREATED_SENDERS: Mutex<BTreeMap<ActivityId, Sender<()>>> = Mutex::new(Default::default());
-}
+pub(crate) static CONTEXTS: Lazy<Mutex<BTreeMap<ActivityId, AndroidContext>>> =
+  Lazy::new(Default::default);
+static WINDOW_MANAGER: Lazy<Mutex<BTreeMap<ActivityId, GlobalRef>>> = Lazy::new(Default::default);
+pub(crate) static ACTIVITY_CREATED_SENDERS: Lazy<Mutex<BTreeMap<ActivityId, Sender<()>>>> =
+  Lazy::new(Default::default);
 
 static INPUT_QUEUE: Lazy<RwLock<Option<InputQueue>>> = Lazy::new(Default::default);
 static CONTENT_RECT: Lazy<RwLock<Rect>> = Lazy::new(Default::default);

--- a/src/platform_impl/android/ndk_glue.rs
+++ b/src/platform_impl/android/ndk_glue.rs
@@ -2,6 +2,7 @@
 // Copyright 2021-2023 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::window::WindowId;
 pub use jni::{
   self,
   objects::{GlobalRef, JClass, JMap, JObject, JString},
@@ -16,8 +17,8 @@ use ndk::{
 };
 use once_cell::sync::{Lazy, OnceCell};
 use std::{
-  cell::RefCell,
-  ffi::{CStr, CString},
+  collections::BTreeMap,
+  ffi::{c_void, CStr, CString},
   fs::File,
   io::{BufRead, BufReader},
   os::unix::prelude::*,
@@ -36,24 +37,24 @@ pub static PACKAGE: OnceCell<&str> = OnceCell::new();
 /// 1. android app domain name in reverse snake_case as an ident (for ex: com_example)
 /// 2. android package anme (for ex: wryapp)
 /// 3. the android activity that has external linking for the following functions and calls them:
-///       - `private external fun create(activity: WryActivity)``
+///       - `private external fun onActivityCreate(activity: WryActivity)``
 ///       - `private external fun start()`
 ///       - `private external fun resume()`
 ///       - `private external fun pause()`
 ///       - `private external fun stop()`
-///       - `private external fun save()`
-///       - `private external fun destroy()`
-///       - `private external fun memory()`
-///       - `private external fun focus(focus: Boolean)`
-/// 4. a one time setup function that will be ran once after tao has created its event loop in the `create` function above.
+///       - `private external fun onActivitySaveInstanceState()`
+///       - `private external fun onActivityDestroy(activity: WryActivity)`
+///       - `private external fun onActivityLowMemory()`
+///       - `private external fun onWindowFocusChanged(activity: WryActivity, focus: Boolean)`
+/// 4. a on_activity_create function that will be ran once after the `onActivityCreate` function above.
 /// 5. the main entry point of your android application.
 #[rustfmt::skip]
 #[macro_export]
 macro_rules! android_binding {
-  ($domain:ident, $package:ident, $activity:ident, $setup:path, $main:ident) => {
+  ($domain:ident, $package:ident, $activity:ident, $on_activity_create:path, $main:ident) => {
     ::tao::android_binding!($domain, $package, $activity, $setup, $main, ::tao)
   };
-  ($domain:ident, $package:ident, $activity:ident, $setup:path, $main:ident, $tao:path) => {{
+  ($domain:ident, $package:ident, $activity:ident, $on_activity_create:path, $main:ident, $tao:path) => {{
     // NOTE: be careful when changing how this use statement is written
     use $tao::{platform::android::prelude::android_fn, platform::android::prelude::*};
     fn _____tao_store_package_name__() {
@@ -67,17 +68,26 @@ macro_rules! android_binding {
       create,
       [JObject],
       __VOID__,
-      [$setup, $main],
+      [$main],
+    );
+    android_fn!(
+      $domain,
+      $package,
+      $activity,
+      onActivityCreate,
+      [JObject],
+      __VOID__,
+      [$on_activity_create],
       _____tao_store_package_name__,
     );
     android_fn!($domain, $package, $activity, start, [JObject]);
     android_fn!($domain, $package, $activity, stop, [JObject]);
     android_fn!($domain, $package, $activity, resume, [JObject]);
     android_fn!($domain, $package, $activity, pause, [JObject]);
-    android_fn!($domain, $package, $activity, save, [JObject]);
-    android_fn!($domain, $package, $activity, destroy, [JObject]);
-    android_fn!($domain, $package, $activity, memory, [JObject]);
-    android_fn!($domain, $package, $activity, focus, [i32]);
+    android_fn!($domain, $package, $activity, onActivitySaveInstanceState, [JObject]);
+    android_fn!($domain, $package, $activity, onActivityDestroy, [JObject]);
+    android_fn!($domain, $package, $activity, onActivityLowMemory, [JObject]);
+    android_fn!($domain, $package, $activity, onWindowFocusChanged, [JObject,i32]);
   }};
 }
 
@@ -106,26 +116,32 @@ pub fn android_log(level: Level, tag: &CStr, msg: &CStr) {
   }
 }
 
-pub(crate) struct StaticCell<T>(RefCell<T>);
-
-unsafe impl<T> Send for StaticCell<T> {}
-unsafe impl<T> Sync for StaticCell<T> {}
-
-impl<T> std::ops::Deref for StaticCell<T> {
-  type Target = RefCell<T>;
-
-  fn deref(&self) -> &Self::Target {
-    &self.0
-  }
+#[derive(Clone, Copy, Debug)]
+pub struct AndroidContext {
+  pub java_vm: *mut c_void,
+  pub context_jobject: *mut c_void,
 }
 
-static WINDOW_MANAGER: StaticCell<Option<GlobalRef>> = StaticCell(RefCell::new(None));
-static INPUT_QUEUE: Lazy<RwLock<Option<InputQueue>>> = Lazy::new(|| Default::default());
-static CONTENT_RECT: Lazy<RwLock<Rect>> = Lazy::new(|| Default::default());
-static LOOPER: Lazy<Mutex<Option<ForeignLooper>>> = Lazy::new(|| Default::default());
+unsafe impl Send for AndroidContext {}
+unsafe impl Sync for AndroidContext {}
 
-pub fn window_manager() -> std::cell::Ref<'static, Option<GlobalRef>> {
-  WINDOW_MANAGER.0.borrow()
+pub type ActivityId = i32;
+
+lazy_static::lazy_static! {
+  static ref CONTEXTS: Mutex<BTreeMap<ActivityId, AndroidContext>> = Mutex::new(Default::default());
+  static ref WINDOW_MANAGER: Mutex<BTreeMap<ActivityId, GlobalRef>> = Mutex::new(Default::default());
+}
+
+static INPUT_QUEUE: Lazy<RwLock<Option<InputQueue>>> = Lazy::new(Default::default);
+static CONTENT_RECT: Lazy<RwLock<Rect>> = Lazy::new(Default::default);
+static LOOPER: Lazy<Mutex<Option<ForeignLooper>>> = Lazy::new(Default::default);
+
+pub fn main_window_manager() -> Option<GlobalRef> {
+  WINDOW_MANAGER.lock().unwrap().values().next().cloned()
+}
+
+pub fn window_manager(activity_id: ActivityId) -> Option<GlobalRef> {
+  WINDOW_MANAGER.lock().unwrap().get(&activity_id).cloned()
 }
 
 pub fn input_queue() -> RwLockReadGuard<'static, Option<InputQueue>> {
@@ -134,6 +150,14 @@ pub fn input_queue() -> RwLockReadGuard<'static, Option<InputQueue>> {
 
 pub fn content_rect() -> Rect {
   CONTENT_RECT.read().unwrap().clone()
+}
+
+pub fn main_android_context() -> Option<AndroidContext> {
+  CONTEXTS.lock().unwrap().values().next().cloned()
+}
+
+pub fn last_activity_id() -> Option<ActivityId> {
+  CONTEXTS.lock().unwrap().keys().next_back().cloned()
 }
 
 pub static PIPE: Lazy<[OwnedFd; 2]> = Lazy::new(|| {
@@ -176,55 +200,24 @@ pub struct Rect {
 pub enum Event {
   Start,
   Resume,
-  SaveInstanceState,
   Pause,
   Stop,
-  Destroy,
-  ConfigChanged,
   LowMemory,
-  WindowLostFocus,
-  WindowHasFocus,
-  WindowCreated,
-  WindowResized,
-  WindowRedrawNeeded,
-  WindowDestroyed,
-  InputQueueCreated,
-  InputQueueDestroyed,
+  WindowEvent { id: WindowId, event: WindowEvent },
   ContentRectChanged,
 }
 
-pub unsafe fn create(
-  mut env: JNIEnv,
-  _jclass: JClass,
-  jobject: JObject,
-  setup: unsafe fn(&str, JNIEnv, &ThreadLooper, GlobalRef),
-  main: fn(),
-) {
-  //-> jobjectArray {
-  // Initialize global context
-  let window_manager = env
-    .call_method(
-      &jobject,
-      "getWindowManager",
-      "()Landroid/view/WindowManager;",
-      &[],
-    )
-    .unwrap()
-    .l()
-    .unwrap();
-  let window_manager = env.new_global_ref(window_manager).unwrap();
-  WINDOW_MANAGER.replace(Some(window_manager));
-  let activity = env.new_global_ref(jobject).unwrap();
-  let vm = env.get_java_vm().unwrap();
-  let env = vm.attach_current_thread_as_daemon().unwrap();
-  ndk_context::initialize_android_context(
-    vm.get_java_vm_pointer() as *mut _,
-    activity.as_obj().as_raw() as *mut _,
-  );
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum WindowEvent {
+  Focused(bool),
+  Created,
+  Resized,
+  RedrawNeeded,
+  Destroyed,
+}
 
-  let looper = ThreadLooper::for_thread().unwrap();
-  setup(PACKAGE.get().unwrap(), env, &looper, activity);
-
+pub unsafe fn create(_env: JNIEnv, _: JClass, _: JObject, main: fn()) {
   let logpipe = {
     let mut logpipe: [RawFd; 2] = Default::default();
     libc::pipe(logpipe.as_mut_ptr());
@@ -271,17 +264,59 @@ pub unsafe fn create(
       signal_looper_ready.notify_one();
     }
 
-    main()
+    main();
   });
 
   // Don't return from this function (`ANativeActivity_onCreate`) until the thread
-  // has created its `ThreadLooper` and assigned it to the static `LOOPER`
-  // variable. It will be used from `on_input_queue_created` as soon as this
-  // function returns.
+  // has created its `ThreadLooper` and assigned it to the static `LOOPER` variable.
   let locked_looper = LOOPER.lock().unwrap();
   let _mutex_guard = looper_ready
     .wait_while(locked_looper, |looper| looper.is_none())
     .unwrap();
+}
+
+#[allow(non_snake_case)]
+pub unsafe fn onActivityCreate(
+  mut env: JNIEnv,
+  _jclass: JClass,
+  activity: JObject,
+  setup: unsafe fn(&str, JNIEnv, &ThreadLooper, GlobalRef),
+) {
+  let activity_id = env
+    .call_method(&activity, "getId", "()I", &[])
+    .unwrap()
+    .i()
+    .unwrap();
+
+  // Initialize global context
+  let window_manager = env
+    .call_method(
+      &activity,
+      "getWindowManager",
+      "()Landroid/view/WindowManager;",
+      &[],
+    )
+    .unwrap()
+    .l()
+    .unwrap();
+  let window_manager = env.new_global_ref(window_manager).unwrap();
+  WINDOW_MANAGER
+    .lock()
+    .unwrap()
+    .insert(activity_id, window_manager);
+  let activity = env.new_global_ref(activity).unwrap();
+  let vm = env.get_java_vm().unwrap();
+  let env = vm.attach_current_thread_as_daemon().unwrap();
+
+  CONTEXTS.lock().unwrap().insert(
+    activity_id,
+    AndroidContext {
+      java_vm: vm.get_java_vm_pointer() as *mut _,
+      context_jobject: activity.as_obj().as_raw() as *mut _,
+    },
+  );
+  let looper = ThreadLooper::for_thread().unwrap();
+  setup(PACKAGE.get().unwrap(), env, &looper, activity);
 }
 
 pub unsafe fn resume(_: JNIEnv, _: JClass, _: JObject) {
@@ -292,11 +327,21 @@ pub unsafe fn pause(_: JNIEnv, _: JClass, _: JObject) {
   wake(Event::Pause);
 }
 
-pub unsafe fn focus(_: JNIEnv, _: JClass, has_focus: libc::c_int) {
-  let event = if has_focus == 0 {
-    Event::WindowLostFocus
-  } else {
-    Event::WindowHasFocus
+#[allow(non_snake_case)]
+pub unsafe fn onWindowFocusChanged(
+  mut env: JNIEnv,
+  _: JClass,
+  activity: JObject,
+  has_focus: libc::c_int,
+) {
+  let activity_id = env
+    .call_method(&activity, "getId", "()I", &[])
+    .unwrap()
+    .i()
+    .unwrap();
+  let event = Event::WindowEvent {
+    id: WindowId(super::WindowId(activity_id)),
+    event: WindowEvent::Focused(has_focus != 0),
   };
   wake(event);
 }
@@ -309,29 +354,45 @@ pub unsafe fn stop(_: JNIEnv, _: JClass, _: JObject) {
   wake(Event::Stop);
 }
 
+#[allow(non_snake_case)]
+pub unsafe fn onActivityDestroy(mut env: JNIEnv, _: JClass, activity: JObject) {
+  let activity_id = env
+    .call_method(&activity, "getId", "()I", &[])
+    .unwrap()
+    .i()
+    .unwrap();
+
+  let is_changing_configurations = env
+    .call_method(&activity, "isChangingConfigurations", "()Z", &[])
+    .unwrap()
+    .z()
+    .unwrap();
+
+  // keep our Rust window references alive when the activity is going to be recreated due to configuration changes
+  // e.g. rotation, multi window mode change etc
+  if !is_changing_configurations {
+    wake(Event::WindowEvent {
+      id: WindowId(super::WindowId(activity_id)),
+      event: WindowEvent::Destroyed,
+    });
+    CONTEXTS.lock().unwrap().remove(&activity_id);
+    WINDOW_MANAGER.lock().unwrap().remove(&activity_id);
+  }
+}
+
 ///////////////////////////////////////////////
 // Events below are not used by event loop yet.
 ///////////////////////////////////////////////
 
-pub unsafe fn save(_: JNIEnv, _: JClass, _: JObject) {
-  wake(Event::SaveInstanceState);
-}
+#[allow(non_snake_case)]
+pub unsafe fn onActivitySaveInstanceState(_: JNIEnv, _: JClass, _: JObject) {}
 
-pub unsafe fn destroy(_: JNIEnv, _: JClass, _: JObject) {
-  wake(Event::Destroy);
-  ndk_context::release_android_context();
-  WINDOW_MANAGER.take();
-}
-
-pub unsafe fn memory(_: JNIEnv, _: JClass, _: JObject) {
+#[allow(non_snake_case)]
+pub unsafe fn onActivityLowMemory(_: JNIEnv, _: JClass, _: JObject) {
   wake(Event::LowMemory);
 }
 
 /*
-unsafe extern "C" fn on_configuration_changed(activity: *mut ANativeActivity) {
-  wake(activity, Event::ConfigChanged);
-}
-
 unsafe extern "C" fn on_window_resized(
   activity: *mut ANativeActivity,
   _window: *mut ANativeWindow,

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -21,7 +21,7 @@ use crate::{
   event::{Event, StartCause, WindowEvent},
   event_loop::ControlFlow,
   platform_impl::platform::{
-    event_loop::{EventHandler, EventProxy, EventWrapper, Never},
+    event_loop::{EventHandler, EventProxy, EventWrapper},
     ffi::{
       id, kCFRunLoopCommonModes, CFAbsoluteTimeGetCurrent, CFRelease, CFRunLoopAddTimer,
       CFRunLoopGetMain, CFRunLoopRef, CFRunLoopTimerCreate, CFRunLoopTimerInvalidate,
@@ -54,12 +54,6 @@ enum UserCallbackTransitionResult<'a> {
   ReentrancyPrevented {
     queued_events: &'a mut Vec<EventWrapper>,
   },
-}
-
-impl Event<'static, Never> {
-  fn is_redraw(&self) -> bool {
-    matches!(self, Event::RedrawRequested(_))
-  }
 }
 
 // this is the state machine for the app lifecycle
@@ -504,7 +498,6 @@ pub unsafe fn scene_by_id(id: &str) -> Option<Retained<UIScene>> {
 }
 
 pub unsafe fn connect_scene(scene: &UIScene) {
-  eprintln!("connect scene");
   let did_first_scene_connect = AppState::get_mut().did_first_scene_connect;
   // on scene mode, we run on_app_ready() when the main scene is connected
   // instead of on AppDelegate::didFinishLaunching
@@ -525,7 +518,8 @@ pub unsafe fn connect_scene(scene: &UIScene) {
       }
     };
     if let Some(window) = window {
-      let _: () = msg_send![window, setWindowScene: window_scene];
+      let () = msg_send![window, setWindowScene: window_scene];
+      let () = msg_send![window, release];
     }
   }
 }
@@ -715,14 +709,6 @@ pub unsafe fn handle_nonuser_events<I: IntoIterator<Item = EventWrapper>>(events
   for wrapper in events {
     match wrapper {
       EventWrapper::StaticEvent(event) => {
-        if !processing_redraws && event.is_redraw() {
-          log::info!("processing `RedrawRequested` during the main event loop");
-        } else if processing_redraws && !event.is_redraw() {
-          log::warn!(
-            "processing non `RedrawRequested` event after the main event loop: {:#?}",
-            event
-          );
-        }
         event_handler.handle_nonuser_event(event, &mut control_flow)
       }
       EventWrapper::EventProxy(proxy) => {
@@ -772,14 +758,6 @@ pub unsafe fn handle_nonuser_events<I: IntoIterator<Item = EventWrapper>>(events
     for wrapper in queued_events {
       match wrapper {
         EventWrapper::StaticEvent(event) => {
-          if !processing_redraws && event.is_redraw() {
-            log::info!("processing `RedrawRequested` during the main event loop");
-          } else if processing_redraws && !event.is_redraw() {
-            log::warn!(
-              "processing non-`RedrawRequested` event after the main event loop: {:#?}",
-              event
-            );
-          }
           event_handler.handle_nonuser_event(event, &mut control_flow)
         }
         EventWrapper::EventProxy(proxy) => {

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -13,7 +13,8 @@ use std::{
   time::Instant,
 };
 
-use objc2::runtime::AnyObject;
+use objc2::{rc::Retained, runtime::AnyObject, MainThreadMarker, Message};
+use objc2_ui_kit::{UIApplication, UIScene, UIWindowScene};
 
 use crate::{
   dpi::LogicalSize,
@@ -27,6 +28,7 @@ use crate::{
       CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate, CGRect, CGSize, NSInteger,
       NSOperatingSystemVersion, NSUInteger,
     },
+    scene::app_supports_multiple_scenes,
   },
   window::WindowId as RootWindowId,
 };
@@ -104,6 +106,8 @@ struct AppState {
   app_state: Option<AppStateImpl>,
   control_flow: ControlFlow,
   waker: EventLoopWaker,
+  windows: Vec<id>,
+  did_first_scene_connect: bool,
 }
 
 impl Drop for AppState {
@@ -155,6 +159,8 @@ impl AppState {
           }),
           control_flow: ControlFlow::default(),
           waker,
+          windows: Vec::new(),
+          did_first_scene_connect: false,
         });
       }
       init_guard(&mut guard)
@@ -467,6 +473,50 @@ impl AppState {
   }
 }
 
+pub unsafe fn pending_scene() -> Option<Retained<UIWindowScene>> {
+  let mtm = MainThreadMarker::new().unwrap();
+  let application = UIApplication::sharedApplication(mtm);
+  for scene in application.connectedScenes().iter() {
+    if let Some(window_scene) = scene.downcast_ref::<UIWindowScene>() {
+      if window_scene.windows().count() == 0 {
+        return Some(window_scene.retain());
+      }
+    }
+  }
+
+  None
+}
+
+pub unsafe fn connect_scene(scene: &UIScene) {
+  let did_first_scene_connect = AppState::get_mut().did_first_scene_connect;
+  // on scene mode, we run on_app_ready() when the main scene is connected
+  // instead of on AppDelegate::didFinishLaunching
+  // this optimizes app startup, since the first created window can immediately see the main scene
+  // instead of having to create a new one (since it can't synchronously wait for it to be connected)
+  if !did_first_scene_connect {
+    on_app_ready();
+    AppState::get_mut().did_first_scene_connect = true;
+  }
+
+  if let Some(window_scene) = scene.downcast_ref::<UIWindowScene>() {
+    let window = {
+      let mut this = AppState::get_mut();
+      if this.windows.is_empty() {
+        None
+      } else {
+        Some(this.windows.remove(0))
+      }
+    };
+    if let Some(window) = window {
+      let _: () = msg_send![window, setWindowScene: window_scene];
+    }
+  }
+}
+
+pub unsafe fn register_window_for_scene(window: id) {
+  AppState::get_mut().windows.push(msg_send![window, retain]);
+}
+
 // requires main thread and window is a UIWindow
 // retains window
 pub unsafe fn set_key_window(window: id) {
@@ -536,6 +586,13 @@ pub unsafe fn will_launch(queued_event_handler: Box<dyn EventHandler>) {
 
 // requires main thread
 pub unsafe fn did_finish_launching() {
+  // when app supports multiple scenes, we defer the did_finish_launching call to the first scene setup
+  if !app_supports_multiple_scenes() {
+    on_app_ready();
+  }
+}
+
+unsafe fn on_app_ready() {
   let mut this = AppState::get_mut();
   let windows = match this.state_mut() {
     AppStateImpl::Launching { queued_windows, .. } => mem::take(queued_windows),
@@ -563,7 +620,7 @@ pub unsafe fn did_finish_launching() {
       //
       // relevant iOS log:
       // ```
-      // [ApplicationLifecycle] Windows were created before application initialzation
+      // [ApplicationLifecycle] Windows were created before application initialization
       // completed. This may result in incorrect visual appearance.
       // ```
       let screen: id = msg_send![window, screen];
@@ -589,6 +646,7 @@ pub unsafe fn did_finish_launching() {
 
   // the above window dance hack, could possibly trigger new windows to be created.
   // we can just set those windows up normally, as they were created after didFinishLaunching
+  // so the app window can attach to it directly
   for window in windows {
     let count: NSUInteger = msg_send![window, retainCount];
     // make sure the window is still referenced

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -1068,6 +1068,7 @@ impl NSOperatingSystemVersion {
 }
 
 pub fn os_capabilities() -> OSCapabilities {
+  use once_cell::sync::Lazy;
   static OS_CAPABILITIES: Lazy<OSCapabilities> = Lazy::new(|| {
     let version: NSOperatingSystemVersion = unsafe {
       let process_info: id = msg_send![class!(NSProcessInfo), processInfo];

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -106,7 +106,10 @@ struct AppState {
   app_state: Option<AppStateImpl>,
   control_flow: ControlFlow,
   waker: EventLoopWaker,
-  windows: Vec<id>,
+  // Stores the UIWindow instances that do not have a scene assigned yet
+  // Window::new might create a window before a scene is ready for it,
+  // requesting a new scene to be activated and deferring the setWindowScene call to the scene delegate
+  windows_for_next_scenes: Vec<id>,
   did_first_scene_connect: bool,
 }
 
@@ -159,7 +162,7 @@ impl AppState {
           }),
           control_flow: ControlFlow::default(),
           waker,
-          windows: Vec::new(),
+          windows_for_next_scenes: Vec::new(),
           did_first_scene_connect: false,
         });
       }
@@ -473,7 +476,8 @@ impl AppState {
   }
 }
 
-pub unsafe fn pending_scene() -> Option<Retained<UIWindowScene>> {
+// tries to find an unitialized scene (no windows)
+pub unsafe fn unitialized_scene() -> Option<Retained<UIWindowScene>> {
   let mtm = MainThreadMarker::new().unwrap();
   let application = UIApplication::sharedApplication(mtm);
   for scene in application.connectedScenes().iter() {
@@ -487,6 +491,18 @@ pub unsafe fn pending_scene() -> Option<Retained<UIWindowScene>> {
   None
 }
 
+pub unsafe fn scene_by_id(id: &str) -> Option<Retained<UIScene>> {
+  let mtm = MainThreadMarker::new().unwrap();
+  let application = UIApplication::sharedApplication(mtm);
+  for scene in application.connectedScenes().iter() {
+    let scene_id = scene.session().persistentIdentifier().to_string();
+    if scene_id == id {
+      return Some(scene);
+    }
+  }
+  None
+}
+
 pub unsafe fn connect_scene(scene: &UIScene) {
   let did_first_scene_connect = AppState::get_mut().did_first_scene_connect;
   // on scene mode, we run on_app_ready() when the main scene is connected
@@ -494,17 +510,20 @@ pub unsafe fn connect_scene(scene: &UIScene) {
   // this optimizes app startup, since the first created window can immediately see the main scene
   // instead of having to create a new one (since it can't synchronously wait for it to be connected)
   if !did_first_scene_connect {
-    on_app_ready();
     AppState::get_mut().did_first_scene_connect = true;
+    // run it a bit later so the scene is actually marked as connected
+    // otherwise UIWindowScene::windows returns 0, never connects the window
+    // and the main scene gets in a weird state where it can't snapshot when we create additional windows
+    dispatch::Queue::main().exec_async(|| unsafe { on_app_ready() });
   }
 
   if let Some(window_scene) = scene.downcast_ref::<UIWindowScene>() {
     let window = {
       let mut this = AppState::get_mut();
-      if this.windows.is_empty() {
+      if this.windows_for_next_scenes.is_empty() {
         None
       } else {
-        Some(this.windows.remove(0))
+        Some(this.windows_for_next_scenes.remove(0))
       }
     };
     if let Some(window) = window {
@@ -514,7 +533,9 @@ pub unsafe fn connect_scene(scene: &UIScene) {
 }
 
 pub unsafe fn register_window_for_scene(window: id) {
-  AppState::get_mut().windows.push(msg_send![window, retain]);
+  AppState::get_mut()
+    .windows_for_next_scenes
+    .push(msg_send![window, retain]);
 }
 
 // requires main thread and window is a UIWindow

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use objc2::{rc::Retained, runtime::AnyObject, MainThreadMarker, Message};
-use objc2_ui_kit::{UIApplication, UIScene, UIWindowScene};
+use objc2_ui_kit::{UIApplication, UIScene, UISceneConnectionOptions, UIWindowScene};
 
 use crate::{
   dpi::LogicalSize,
@@ -497,8 +497,9 @@ pub unsafe fn scene_by_id(id: &str) -> Option<Retained<UIScene>> {
   None
 }
 
-pub unsafe fn connect_scene(scene: &UIScene) {
+pub unsafe fn connect_scene(scene: &UIScene, options: &UISceneConnectionOptions) {
   let did_first_scene_connect = AppState::get_mut().did_first_scene_connect;
+  let is_first_scene = !did_first_scene_connect;
   // on scene mode, we run on_app_ready() when the main scene is connected
   // instead of on AppDelegate::didFinishLaunching
   // this optimizes app startup, since the first created window can immediately see the main scene
@@ -520,6 +521,13 @@ pub unsafe fn connect_scene(scene: &UIScene) {
     if let Some(window) = window {
       let () = msg_send![window, setWindowScene: window_scene];
       let () = msg_send![window, release];
+    } else if !is_first_scene {
+      // only emit the SceneRequest event for scenes that were not requested by a tao window
+      // also ignore the main scene
+      handle_nonuser_event(EventWrapper::StaticEvent(Event::SceneRequested {
+        scene: scene.retain(),
+        options: options.retain(),
+      }));
     }
   }
 }

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -28,7 +28,7 @@ use crate::{
       CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate, CGRect, CGSize, NSInteger,
       NSOperatingSystemVersion, NSUInteger,
     },
-    scene::app_supports_multiple_scenes,
+    scene::multiple_scenes_enabled,
   },
   window::WindowId as RootWindowId,
 };
@@ -504,6 +504,7 @@ pub unsafe fn scene_by_id(id: &str) -> Option<Retained<UIScene>> {
 }
 
 pub unsafe fn connect_scene(scene: &UIScene) {
+  eprintln!("connect scene");
   let did_first_scene_connect = AppState::get_mut().did_first_scene_connect;
   // on scene mode, we run on_app_ready() when the main scene is connected
   // instead of on AppDelegate::didFinishLaunching
@@ -511,10 +512,7 @@ pub unsafe fn connect_scene(scene: &UIScene) {
   // instead of having to create a new one (since it can't synchronously wait for it to be connected)
   if !did_first_scene_connect {
     AppState::get_mut().did_first_scene_connect = true;
-    // run it a bit later so the scene is actually marked as connected
-    // otherwise UIWindowScene::windows returns 0, never connects the window
-    // and the main scene gets in a weird state where it can't snapshot when we create additional windows
-    dispatch::Queue::main().exec_async(|| unsafe { on_app_ready() });
+    on_app_ready();
   }
 
   if let Some(window_scene) = scene.downcast_ref::<UIWindowScene>() {
@@ -607,8 +605,8 @@ pub unsafe fn will_launch(queued_event_handler: Box<dyn EventHandler>) {
 
 // requires main thread
 pub unsafe fn did_finish_launching() {
-  // when app supports multiple scenes, we defer the did_finish_launching call to the first scene setup
-  if !app_supports_multiple_scenes() {
+  // when app is run in scenes lifecycle mode, we defer the did_finish_launching call to the first scene setup
+  if !multiple_scenes_enabled() {
     on_app_ready();
   }
 }

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -77,6 +77,7 @@ mod event_loop;
 mod ffi;
 mod keycode;
 mod monitor;
+mod scene;
 mod view;
 mod window;
 

--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -8,9 +8,14 @@ use objc2_foundation::{
 };
 use objc2_ui_kit::{
   UIOpenURLContext, UIScene, UISceneConnectionOptions, UISceneDelegate, UISceneSession,
+  UIWindowScene,
 };
 
-use crate::platform_impl::platform::{app_state, ffi::id};
+use crate::{
+  event::{Event, WindowEvent},
+  platform_impl::platform::{app_state, event_loop::EventWrapper, ffi::id},
+  window::WindowId as RootWindowId,
+};
 
 pub unsafe fn app_supports_multiple_scenes() -> bool {
   let application: id = msg_send![class!(UIApplication), sharedApplication];
@@ -56,40 +61,69 @@ define_class!(
       _session: &UISceneSession,
       _connection_options: &UISceneConnectionOptions,
     ) {
-      log::error!("connecting scene...");
       unsafe {
         app_state::connect_scene(scene);
       }
     }
 
     #[unsafe(method(sceneDidDisconnect:))]
-    fn sceneDidDisconnect(&self, _scene: &UIScene) {
-      log::error!("[lucas] disconnect");
-    }
+    fn sceneDidDisconnect(&self, _scene: &UIScene) {}
 
     #[unsafe(method(sceneDidBecomeActive:))]
-    fn sceneDidBecomeActive(&self, _scene: &UIScene) {
-      log::error!("[lucas] active");
+    fn sceneDidBecomeActive(&self, scene: &UIScene) {
+      unsafe {
+        if let Some(window_scene) = scene.downcast_ref::<UIWindowScene>() {
+          for window in window_scene.windows() {
+            app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::WindowEvent {
+              window_id: RootWindowId(window.into()),
+              event: WindowEvent::Focused(true),
+            }));
+          }
+        }
+      }
     }
 
     #[unsafe(method(sceneWillResignActive:))]
-    fn sceneWillResignActive(&self, _scene: &UIScene) {
-      log::error!("[lucas] resign");
+    fn sceneWillResignActive(&self, scene: &UIScene) {
+      unsafe {
+        if let Some(window_scene) = scene.downcast_ref::<UIWindowScene>() {
+          for window in window_scene.windows() {
+            app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::WindowEvent {
+              window_id: RootWindowId(window.into()),
+              event: WindowEvent::Focused(false),
+            }));
+          }
+        }
+      }
     }
 
     #[unsafe(method(sceneWillEnterForeground:))]
-    fn sceneWillEnterForeground(&self, _scene: &UIScene) {
-      log::error!("[lucas] foreground");
-    }
+    fn sceneWillEnterForeground(&self, _scene: &UIScene) {}
 
     #[unsafe(method(sceneDidEnterBackground:))]
-    fn sceneDidEnterBackground(&self, _scene: &UIScene) {
-      log::error!("[lucas] background");
-    }
+    fn sceneDidEnterBackground(&self, _scene: &UIScene) {}
 
     #[unsafe(method(scene:openURLContexts:))]
-    fn scene_openURLContexts(&self, _scene: &UIScene, _url_contexts: &NSSet<UIOpenURLContext>) {
-      log::error!("[lucas] contexts");
+    fn scene_openURLContexts(&self, _scene: &UIScene, url_contexts: &NSSet<UIOpenURLContext>) {
+      unsafe {
+        let urls: Vec<url::Url> = url_contexts
+          .iter()
+          .filter_map(|ctx| {
+            ctx.URL().absoluteString().and_then(|url| {
+              let url = url.to_string();
+              url
+                .parse()
+                .inspect_err(|e| {
+                  log::error!("failed to parse URL {url} from scene:openURLContexts: {e}")
+                })
+                .ok()
+            })
+          })
+          .collect();
+        if !urls.is_empty() {
+          app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::Opened { urls }));
+        }
+      }
     }
 
     #[unsafe(method(stateRestorationActivityForScene:))]
@@ -97,7 +131,7 @@ define_class!(
       &self,
       _scene: &UIScene,
     ) -> Option<std::ptr::NonNull<NSUserActivity>> {
-      log::error!("[lucas] activity for restore");
+      log::info!("scene erstore");
       None
     }
 
@@ -107,7 +141,7 @@ define_class!(
       _scene: &UIScene,
       _state_restoration_activity: &NSUserActivity,
     ) {
-      log::error!("[lucas] state with user");
+      log::info!("scene erstorasdasdsade");
     }
 
     #[unsafe(method(scene:willContinueUserActivityWithType:))]
@@ -116,12 +150,12 @@ define_class!(
       _scene: &UIScene,
       _user_activity_type: &NSString,
     ) {
-      log::error!("[lucas] continue ");
+      log::info!("scene erstore ytype");
     }
 
     #[unsafe(method(scene:continueUserActivity:))]
     fn scene_continueUserActivity(&self, _scene: &UIScene, _user_activity: &NSUserActivity) {
-      log::error!("[lucas] continue2");
+      log::info!("scene continue");
     }
 
     #[unsafe(method(scene:didFailToContinueUserActivityWithType:error:))]
@@ -131,12 +165,12 @@ define_class!(
       _user_activity_type: &NSString,
       _error: &NSError,
     ) {
-      log::error!("[lucas] fail");
+      log::info!("scene fail");
     }
 
     #[unsafe(method(scene:didUpdateUserActivity:))]
     fn scene_didUpdateUserActivity(&self, _scene: &UIScene, _user_activity: &NSUserActivity) {
-      log::error!("[lucas] update");
+      log::info!("scene updated");
     }
   }
 );

--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -116,8 +116,9 @@ define_class!(
               let url = url.to_string();
               url
                 .parse()
-                .inspect_err(|e| {
-                  log::error!("failed to parse URL {url} from scene:openURLContexts: {e}")
+                .map_err(|e| {
+                  log::error!("failed to parse URL {url} from scene:openURLContexts: {e}");
+                  e
                 })
                 .ok()
             })

--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -62,10 +62,10 @@ define_class!(
       &self,
       scene: &UIScene,
       _session: &UISceneSession,
-      _connection_options: &UISceneConnectionOptions,
+      connection_options: &UISceneConnectionOptions,
     ) {
       unsafe {
-        app_state::connect_scene(scene);
+        app_state::connect_scene(scene, connection_options);
       }
     }
 

--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -1,47 +1,50 @@
 // Copyright 2021-2025 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
-use objc2::{define_class, rc::Retained, MainThreadOnly};
+use objc2::{define_class, rc::Retained, MainThreadMarker, MainThreadOnly};
 use objc2_foundation::{
   NSBundle, NSDictionary, NSError, NSNumber, NSObject, NSObjectProtocol, NSSet, NSString,
   NSUserActivity,
 };
 use objc2_ui_kit::{
-  UIOpenURLContext, UIScene, UISceneConnectionOptions, UISceneDelegate, UISceneSession,
-  UIWindowScene,
+  UIApplication, UIOpenURLContext, UIScene, UISceneConnectionOptions, UISceneDelegate,
+  UISceneSession, UIWindowScene,
 };
 
 use crate::{
   event::{Event, WindowEvent},
-  platform_impl::platform::{app_state, event_loop::EventWrapper, ffi::id},
+  platform_impl::platform::{app_state, event_loop::EventWrapper},
   window::WindowId as RootWindowId,
 };
 
+// true when the system allows the app to display multiple scenes and multiple_scenes_enabled() returns true
+// https://developer.apple.com/documentation/uikit/uiapplication/supportsmultiplescenes?language=objc
 pub unsafe fn app_supports_multiple_scenes() -> bool {
-  let application: id = msg_send![class!(UIApplication), sharedApplication];
-  // this function can be called before the UIApplication is set up (class delegate registration)
-  if application == std::ptr::null_mut() {
-    let bundle = NSBundle::mainBundle();
-    let Some(info) = bundle.infoDictionary() else {
-      return false;
-    };
+  let mtm = MainThreadMarker::new().unwrap();
+  let application = UIApplication::sharedApplication(mtm);
+  application.supportsMultipleScenes()
+}
 
-    let key = NSString::from_str("UIApplicationSceneManifest");
-    let Some(manifest) = (*info).objectForKey(&key) else {
-      return false;
-    };
+// check whether the app's Info.plist enabled multiple scenes
+pub unsafe fn multiple_scenes_enabled() -> bool {
+  let bundle = NSBundle::mainBundle();
+  let Some(info) = bundle.infoDictionary() else {
+    return false;
+  };
 
-    let manifest_dict = Retained::cast_unchecked::<NSDictionary<NSString, NSObject>>(manifest);
-    let supports_key = NSString::from_str("UIApplicationSupportsMultipleScenes");
-    let Some(value) = (*manifest_dict).objectForKey(&supports_key) else {
-      return false;
-    };
+  let key = NSString::from_str("UIApplicationSceneManifest");
+  let Some(manifest) = (*info).objectForKey(&key) else {
+    return false;
+  };
 
-    let num = Retained::cast_unchecked::<NSNumber>(value);
-    (*num).as_bool()
-  } else {
-    msg_send![application, supportsMultipleScenes]
-  }
+  let manifest_dict = Retained::cast_unchecked::<NSDictionary<NSString, NSObject>>(manifest);
+  let supports_key = NSString::from_str("UIApplicationSupportsMultipleScenes");
+  let Some(value) = (*manifest_dict).objectForKey(&supports_key) else {
+    return false;
+  };
+
+  let num = Retained::cast_unchecked::<NSNumber>(value);
+  (*num).as_bool()
 }
 
 define_class!(
@@ -131,7 +134,6 @@ define_class!(
       &self,
       _scene: &UIScene,
     ) -> Option<std::ptr::NonNull<NSUserActivity>> {
-      log::info!("scene erstore");
       None
     }
 
@@ -141,7 +143,6 @@ define_class!(
       _scene: &UIScene,
       _state_restoration_activity: &NSUserActivity,
     ) {
-      log::info!("scene erstorasdasdsade");
     }
 
     #[unsafe(method(scene:willContinueUserActivityWithType:))]
@@ -150,13 +151,10 @@ define_class!(
       _scene: &UIScene,
       _user_activity_type: &NSString,
     ) {
-      log::info!("scene erstore ytype");
     }
 
     #[unsafe(method(scene:continueUserActivity:))]
-    fn scene_continueUserActivity(&self, _scene: &UIScene, _user_activity: &NSUserActivity) {
-      log::info!("scene continue");
-    }
+    fn scene_continueUserActivity(&self, _scene: &UIScene, _user_activity: &NSUserActivity) {}
 
     #[unsafe(method(scene:didFailToContinueUserActivityWithType:error:))]
     fn scene_didFailToContinueUserActivityWithType_error(
@@ -165,12 +163,9 @@ define_class!(
       _user_activity_type: &NSString,
       _error: &NSError,
     ) {
-      log::info!("scene fail");
     }
 
     #[unsafe(method(scene:didUpdateUserActivity:))]
-    fn scene_didUpdateUserActivity(&self, _scene: &UIScene, _user_activity: &NSUserActivity) {
-      log::info!("scene updated");
-    }
+    fn scene_didUpdateUserActivity(&self, _scene: &UIScene, _user_activity: &NSUserActivity) {}
   }
 );

--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -1,0 +1,142 @@
+// Copyright 2021-2025 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+
+use objc2::{define_class, rc::Retained, MainThreadOnly};
+use objc2_foundation::{
+  NSBundle, NSDictionary, NSError, NSNumber, NSObject, NSObjectProtocol, NSSet, NSString,
+  NSUserActivity,
+};
+use objc2_ui_kit::{
+  UIOpenURLContext, UIScene, UISceneConnectionOptions, UISceneDelegate, UISceneSession,
+};
+
+use crate::platform_impl::platform::{app_state, ffi::id};
+
+pub unsafe fn app_supports_multiple_scenes() -> bool {
+  let application: id = msg_send![class!(UIApplication), sharedApplication];
+  // this function can be called before the UIApplication is set up (class delegate registration)
+  if application == std::ptr::null_mut() {
+    let bundle = NSBundle::mainBundle();
+    let Some(info) = bundle.infoDictionary() else {
+      return false;
+    };
+
+    let key = NSString::from_str("UIApplicationSceneManifest");
+    let Some(manifest) = (*info).objectForKey(&key) else {
+      return false;
+    };
+
+    let manifest_dict = Retained::cast_unchecked::<NSDictionary<NSString, NSObject>>(manifest);
+    let supports_key = NSString::from_str("UIApplicationSupportsMultipleScenes");
+    let Some(value) = (*manifest_dict).objectForKey(&supports_key) else {
+      return false;
+    };
+
+    let num = Retained::cast_unchecked::<NSNumber>(value);
+    (*num).as_bool()
+  } else {
+    msg_send![application, supportsMultipleScenes]
+  }
+}
+
+define_class!(
+  #[unsafe(super(NSObject))]
+  #[name = "TaoSceneDelegate"]
+  #[thread_kind = MainThreadOnly]
+  pub struct TaoSceneDelegate;
+
+  unsafe impl NSObjectProtocol for TaoSceneDelegate {}
+
+  #[allow(non_snake_case)]
+  unsafe impl UISceneDelegate for TaoSceneDelegate {
+    #[unsafe(method(scene:willConnectToSession:options:))]
+    fn scene_willConnectToSession_options(
+      &self,
+      scene: &UIScene,
+      _session: &UISceneSession,
+      _connection_options: &UISceneConnectionOptions,
+    ) {
+      log::error!("connecting scene...");
+      unsafe {
+        app_state::connect_scene(scene);
+      }
+    }
+
+    #[unsafe(method(sceneDidDisconnect:))]
+    fn sceneDidDisconnect(&self, _scene: &UIScene) {
+      log::error!("[lucas] disconnect");
+    }
+
+    #[unsafe(method(sceneDidBecomeActive:))]
+    fn sceneDidBecomeActive(&self, _scene: &UIScene) {
+      log::error!("[lucas] active");
+    }
+
+    #[unsafe(method(sceneWillResignActive:))]
+    fn sceneWillResignActive(&self, _scene: &UIScene) {
+      log::error!("[lucas] resign");
+    }
+
+    #[unsafe(method(sceneWillEnterForeground:))]
+    fn sceneWillEnterForeground(&self, _scene: &UIScene) {
+      log::error!("[lucas] foreground");
+    }
+
+    #[unsafe(method(sceneDidEnterBackground:))]
+    fn sceneDidEnterBackground(&self, _scene: &UIScene) {
+      log::error!("[lucas] background");
+    }
+
+    #[unsafe(method(scene:openURLContexts:))]
+    fn scene_openURLContexts(&self, _scene: &UIScene, _url_contexts: &NSSet<UIOpenURLContext>) {
+      log::error!("[lucas] contexts");
+    }
+
+    #[unsafe(method(stateRestorationActivityForScene:))]
+    fn stateRestorationActivityForScene(
+      &self,
+      _scene: &UIScene,
+    ) -> Option<std::ptr::NonNull<NSUserActivity>> {
+      log::error!("[lucas] activity for restore");
+      None
+    }
+
+    #[unsafe(method(scene:restoreInteractionStateWithUserActivity:))]
+    fn scene_restoreInteractionStateWithUserActivity(
+      &self,
+      _scene: &UIScene,
+      _state_restoration_activity: &NSUserActivity,
+    ) {
+      log::error!("[lucas] state with user");
+    }
+
+    #[unsafe(method(scene:willContinueUserActivityWithType:))]
+    fn scene_willContinueUserActivityWithType(
+      &self,
+      _scene: &UIScene,
+      _user_activity_type: &NSString,
+    ) {
+      log::error!("[lucas] continue ");
+    }
+
+    #[unsafe(method(scene:continueUserActivity:))]
+    fn scene_continueUserActivity(&self, _scene: &UIScene, _user_activity: &NSUserActivity) {
+      log::error!("[lucas] continue2");
+    }
+
+    #[unsafe(method(scene:didFailToContinueUserActivityWithType:error:))]
+    fn scene_didFailToContinueUserActivityWithType_error(
+      &self,
+      _scene: &UIScene,
+      _user_activity_type: &NSString,
+      _error: &NSError,
+    ) {
+      log::error!("[lucas] fail");
+    }
+
+    #[unsafe(method(scene:didUpdateUserActivity:))]
+    fn scene_didUpdateUserActivity(&self, _scene: &UIScene, _user_activity: &NSUserActivity) {
+      log::error!("[lucas] update");
+    }
+  }
+);

--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -154,7 +154,20 @@ define_class!(
     }
 
     #[unsafe(method(scene:continueUserActivity:))]
-    fn scene_continueUserActivity(&self, _scene: &UIScene, _user_activity: &NSUserActivity) {}
+    fn scene_continueUserActivity(&self, _scene: &UIScene, user_activity: &NSUserActivity) {
+      unsafe {
+        // universal app links
+        if let Some(url) = user_activity
+          .webpageURL()
+          .and_then(|url| url.absoluteString())
+        {
+          let url = url.to_string().parse::<url::Url>().unwrap();
+          app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::Opened {
+            urls: vec![url],
+          }));
+        }
+      }
+    }
 
     #[unsafe(method(scene:didFailToContinueUserActivityWithType:error:))]
     fn scene_didFailToContinueUserActivityWithType_error(

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -7,7 +7,13 @@ use std::{
   ffi::{c_char, CStr, CString},
 };
 
-use objc2::runtime::{AnyClass as Class, AnyObject as Object, ClassBuilder as ClassDecl, Sel};
+use objc2::{
+  rc::Retained,
+  runtime::{AnyClass as Class, AnyObject as Object, ClassBuilder as ClassDecl, Sel},
+  ClassType,
+};
+use objc2_foundation::NSString;
+use objc2_ui_kit::UISceneConfiguration;
 
 use crate::{
   dpi::PhysicalPosition,
@@ -20,6 +26,7 @@ use crate::{
       id, nil, CGFloat, CGPoint, CGRect, UIForceTouchCapability, UIInterfaceOrientationMask,
       UIRectEdge, UITouchPhase, UITouchType, BOOL, NO, YES,
     },
+    scene::app_supports_multiple_scenes,
     window::PlatformSpecificWindowBuilderAttributes,
     DeviceId,
   },
@@ -526,6 +533,22 @@ pub unsafe fn create_window(
     !window.is_null(),
     "Failed to initialize `UIWindow` instance"
   );
+
+  if app_supports_multiple_scenes() {
+    if let Some(scene) = app_state::pending_scene() {
+      let _: () = msg_send![window, setWindowScene: Retained::as_ptr(&scene)];
+    } else {
+      unsafe {
+        let mtm = objc2::MainThreadMarker::new().unwrap();
+        let application = objc2_ui_kit::UIApplication::sharedApplication(mtm);
+        let _: () = msg_send![window, setHidden: true];
+        app_state::register_window_for_scene(window);
+        application
+          .requestSceneSessionActivation_userActivity_options_errorHandler(None, None, None, None);
+      }
+    }
+  }
+
   let () = msg_send![window, setRootViewController: view_controller];
   match window_attributes.fullscreen {
     Some(Fullscreen::Exclusive(ref video_mode)) => {
@@ -556,6 +579,27 @@ pub fn create_delegate_class() {
       app_state::did_finish_launching();
     }
     YES
+  }
+
+  extern "C" fn configuration_for_connecting_scene_session(
+    _: &Object,
+    _: Sel,
+    _application: id,
+    _connecting_scene_session: id,
+    _options: id,
+  ) -> id {
+    unsafe {
+      let mtm = objc2_foundation::MainThreadMarker::new_unchecked();
+      let config = UISceneConfiguration::configurationWithName_sessionRole(
+        Some(&NSString::from_str("TaoScene")),
+        &NSString::from_str("UIWindowSceneSessionRoleApplication"),
+        mtm,
+      );
+
+      // Dynamically set the delegate class name
+      config.setDelegateClass(Some(super::scene::TaoSceneDelegate::class()));
+      Retained::as_ptr(&config) as _
+    }
   }
 
   fn handle_deep_link(url: id) {
@@ -658,6 +702,13 @@ pub fn create_delegate_class() {
       sel!(application:didFinishLaunchingWithOptions:),
       did_finish_launching as extern "C" fn(_, _, _, _) -> _,
     );
+
+    if app_supports_multiple_scenes() {
+      decl.add_method(
+        sel!(application:configurationForConnectingSceneSession:options:),
+        configuration_for_connecting_scene_session as extern "C" fn(_, _, _, _, _) -> _,
+      );
+    }
 
     decl.add_method(
       sel!(application:openURL:options:),

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -13,12 +13,15 @@ use objc2::{
   ClassType, MainThreadMarker,
 };
 use objc2_foundation::NSString;
-use objc2_ui_kit::{UIApplication, UISceneSessionActivationRequest, UISceneActivationRequestOptions, UISceneConfiguration};
+use objc2_ui_kit::{
+  UIApplication, UISceneActivationRequestOptions, UISceneConfiguration,
+  UISceneSessionActivationRequest,
+};
 
 use crate::{
   dpi::PhysicalPosition,
   event::{DeviceId as RootDeviceId, Event, Force, Touch, TouchPhase, WindowEvent},
-  platform::ios::{MonitorHandleExtIOS, operating_system_version},
+  platform::ios::{operating_system_version, MonitorHandleExtIOS},
   platform_impl::platform::{
     app_state::{self, OSCapabilities},
     event_loop::{self, EventProxy, EventWrapper},

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -10,10 +10,10 @@ use std::{
 use objc2::{
   rc::Retained,
   runtime::{AnyClass as Class, AnyObject as Object, ClassBuilder as ClassDecl, Sel},
-  ClassType,
+  ClassType, MainThreadMarker,
 };
 use objc2_foundation::NSString;
-use objc2_ui_kit::UISceneConfiguration;
+use objc2_ui_kit::{UIApplication, UISceneActivationRequestOptions, UISceneConfiguration};
 
 use crate::{
   dpi::PhysicalPosition,
@@ -520,7 +520,7 @@ pub unsafe fn create_view_controller(
 // requires main thread
 pub unsafe fn create_window(
   window_attributes: &WindowAttributes,
-  _platform_attributes: &PlatformSpecificWindowBuilderAttributes,
+  platform_attributes: &PlatformSpecificWindowBuilderAttributes,
   frame: CGRect,
   view_controller: id,
 ) -> id {
@@ -535,16 +535,29 @@ pub unsafe fn create_window(
   );
 
   if app_supports_multiple_scenes() {
-    if let Some(scene) = app_state::pending_scene() {
+    if let Some(scene) = app_state::unitialized_scene() {
       let _: () = msg_send![window, setWindowScene: Retained::as_ptr(&scene)];
     } else {
       unsafe {
-        let mtm = objc2::MainThreadMarker::new().unwrap();
-        let application = objc2_ui_kit::UIApplication::sharedApplication(mtm);
-        let _: () = msg_send![window, setHidden: true];
+        let mtm = MainThreadMarker::new().unwrap();
+        let application = UIApplication::sharedApplication(mtm);
         app_state::register_window_for_scene(window);
-        application
-          .requestSceneSessionActivation_userActivity_options_errorHandler(None, None, None, None);
+
+        let options = UISceneActivationRequestOptions::new(mtm);
+        if let Some(scene) = platform_attributes
+          .requesting_scene_identifier
+          .as_ref()
+          .and_then(|id| app_state::scene_by_id(id))
+        {
+          options.setRequestingScene(Some(&scene));
+        }
+
+        application.requestSceneSessionActivation_userActivity_options_errorHandler(
+          None,
+          None,
+          Some(&options),
+          None,
+        );
       }
     }
   }

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -26,7 +26,7 @@ use crate::{
       id, nil, CGFloat, CGPoint, CGRect, UIForceTouchCapability, UIInterfaceOrientationMask,
       UIRectEdge, UITouchPhase, UITouchType, BOOL, NO, YES,
     },
-    scene::app_supports_multiple_scenes,
+    scene::{app_supports_multiple_scenes, multiple_scenes_enabled},
     window::PlatformSpecificWindowBuilderAttributes,
     DeviceId,
   },
@@ -534,10 +534,28 @@ pub unsafe fn create_window(
     "Failed to initialize `UIWindow` instance"
   );
 
-  if app_supports_multiple_scenes() {
+  if multiple_scenes_enabled() {
+    // if multiple scenes is enabled in Info.plist, we need to assign it
+    // regarless of whether the device supports multiple scenes or not
     if let Some(scene) = app_state::unitialized_scene() {
       let _: () = msg_send![window, setWindowScene: Retained::as_ptr(&scene)];
+    } else if !app_supports_multiple_scenes() {
+      // if there's no unitialized scene and the app does not support multiple scenes
+      // we need to move this window to the main scene, otherwise it won't be visible
+      let scene = unsafe {
+        let mtm = MainThreadMarker::new().unwrap();
+        let application = UIApplication::sharedApplication(mtm);
+        application.connectedScenes().iter().next()
+      };
+      let scene = scene
+        .as_ref()
+        .map(|s| Retained::as_ptr(s))
+        .unwrap_or(std::ptr::null_mut());
+
+      let _: () = msg_send![window, setWindowScene: scene];
     } else {
+      // only request a new scene if the system actually supports it
+      // otherwise it is silently ignored
       unsafe {
         let mtm = MainThreadMarker::new().unwrap();
         let application = UIApplication::sharedApplication(mtm);
@@ -552,6 +570,8 @@ pub unsafe fn create_window(
           options.setRequestingScene(Some(&scene));
         }
 
+        // alternative function is iOS 17+
+        #[allow(deprecated)]
         application.requestSceneSessionActivation_userActivity_options_errorHandler(
           None,
           None,
@@ -716,7 +736,7 @@ pub fn create_delegate_class() {
       did_finish_launching as extern "C" fn(_, _, _, _) -> _,
     );
 
-    if app_supports_multiple_scenes() {
+    if multiple_scenes_enabled() {
       decl.add_method(
         sel!(application:configurationForConnectingSceneSession:options:),
         configuration_for_connecting_scene_session as extern "C" fn(_, _, _, _, _) -> _,

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -13,12 +13,12 @@ use objc2::{
   ClassType, MainThreadMarker,
 };
 use objc2_foundation::NSString;
-use objc2_ui_kit::{UIApplication, UISceneActivationRequestOptions, UISceneConfiguration};
+use objc2_ui_kit::{UIApplication, UISceneSessionActivationRequest, UISceneActivationRequestOptions, UISceneConfiguration};
 
 use crate::{
   dpi::PhysicalPosition,
   event::{DeviceId as RootDeviceId, Event, Force, Touch, TouchPhase, WindowEvent},
-  platform::ios::MonitorHandleExtIOS,
+  platform::ios::{MonitorHandleExtIOS, operating_system_version},
   platform_impl::platform::{
     app_state::{self, OSCapabilities},
     event_loop::{self, EventProxy, EventWrapper},
@@ -568,6 +568,24 @@ pub unsafe fn create_window(
           .and_then(|id| app_state::scene_by_id(id))
         {
           options.setRequestingScene(Some(&scene));
+        }
+
+        let error_handler = block2::RcBlock::new(move |error| {
+          log::error!("error activating scene: {error:?}");
+        });
+
+        if operating_system_version().0 >= 17 {
+          let request = UISceneSessionActivationRequest::request();
+          request.setOptions(Some(&options));
+          application.activateSceneSessionForRequest_errorHandler(&request, Some(&error_handler));
+        } else {
+          #[allow(deprecated)]
+          application.requestSceneSessionActivation_userActivity_options_errorHandler(
+            None,
+            None,
+            Some(&options),
+            Some(&error_handler),
+          );
         }
 
         // alternative function is iOS 17+

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -46,9 +46,28 @@ pub struct Inner {
 impl Drop for Inner {
   fn drop(&mut self) {
     unsafe {
+      let window = self.window();
+      if let Some(scene) = window.windowScene() {
+        // our windows are tied to scenes - so when this is the last window of the scene,
+        // request the scene to be destroyed
+        if scene.windows().count() == 1 {
+          let mtm = MainThreadMarker::new().unwrap();
+          let application = UIApplication::sharedApplication(mtm);
+          application.requestSceneSessionDestruction_options_errorHandler(
+            &scene.session(),
+            None,
+            None,
+          );
+        }
+      }
       let () = msg_send![self.view, release];
       let () = msg_send![self.view_controller, release];
       let () = msg_send![self.window, release];
+
+      app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::WindowEvent {
+        window_id: RootWindowId(self.window.into()),
+        event: WindowEvent::Focused(false),
+      }));
     }
   }
 }

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -12,7 +12,7 @@ use objc2::{
   runtime::{AnyClass, AnyObject},
   MainThreadMarker,
 };
-use objc2_ui_kit::{UIApplication, UISceneActivationState, UIWindow};
+use objc2_ui_kit::{UIApplication, UISceneActivationState, UIWindow, UISceneSessionActivationRequest};
 
 use crate::{
   dpi::{self, LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Position, Size},
@@ -20,7 +20,7 @@ use crate::{
   event::{Event, WindowEvent},
   icon::Icon,
   monitor::MonitorHandle as RootMonitorHandle,
-  platform::ios::{MonitorHandleExtIOS, ScreenEdge, ValidOrientations},
+  platform::ios::{MonitorHandleExtIOS, ScreenEdge, ValidOrientations, operating_system_version},
   platform_impl::platform::{
     app_state,
     event_loop::{self, EventProxy, EventWrapper},
@@ -102,16 +102,23 @@ impl Inner {
       let mtm = MainThreadMarker::new().unwrap();
       let application = UIApplication::sharedApplication(mtm);
 
+      let error_handler = block2::RcBlock::new(move |error| {
+        log::error!("error activating scene: {error:?}");
+      });
+
       // when we support multiple scenes, request the activation of this window's scene
       if application.supportsMultipleScenes() {
-        // alternative function is iOS 17+
-        #[allow(deprecated)]
-        application.requestSceneSessionActivation_userActivity_options_errorHandler(
-          Some(&scene.session()),
-          None,
-          None,
-          None,
-        );
+        if operating_system_version().0 >= 17 {
+          application.activateSceneSessionForRequest_errorHandler(&UISceneSessionActivationRequest::request(), Some(&error_handler));
+        } else {
+          #[allow(deprecated)]
+          application.requestSceneSessionActivation_userActivity_options_errorHandler(
+            Some(&scene.session()),
+            None,
+            None,
+            Some(&error_handler),
+          );
+        }
       } else {
         window.makeKeyAndVisible();
       }

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -12,7 +12,9 @@ use objc2::{
   runtime::{AnyClass, AnyObject},
   MainThreadMarker,
 };
-use objc2_ui_kit::{UIApplication, UISceneActivationState, UIWindow, UISceneSessionActivationRequest};
+use objc2_ui_kit::{
+  UIApplication, UISceneActivationState, UISceneSessionActivationRequest, UIWindow,
+};
 
 use crate::{
   dpi::{self, LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Position, Size},
@@ -20,7 +22,7 @@ use crate::{
   event::{Event, WindowEvent},
   icon::Icon,
   monitor::MonitorHandle as RootMonitorHandle,
-  platform::ios::{MonitorHandleExtIOS, ScreenEdge, ValidOrientations, operating_system_version},
+  platform::ios::{operating_system_version, MonitorHandleExtIOS, ScreenEdge, ValidOrientations},
   platform_impl::platform::{
     app_state,
     event_loop::{self, EventProxy, EventWrapper},
@@ -109,7 +111,10 @@ impl Inner {
       // when we support multiple scenes, request the activation of this window's scene
       if application.supportsMultipleScenes() {
         if operating_system_version().0 >= 17 {
-          application.activateSceneSessionForRequest_errorHandler(&UISceneSessionActivationRequest::request(), Some(&error_handler));
+          application.activateSceneSessionForRequest_errorHandler(
+            &UISceneSessionActivationRequest::request(),
+            Some(&error_handler),
+          );
         } else {
           #[allow(deprecated)]
           application.requestSceneSessionActivation_userActivity_options_errorHandler(

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -7,7 +7,12 @@ use std::{
   ops::{Deref, DerefMut},
 };
 
-use objc2::runtime::{AnyClass, AnyObject};
+use objc2::{
+  rc::Retained,
+  runtime::{AnyClass, AnyObject},
+  MainThreadMarker,
+};
+use objc2_ui_kit::{UIApplication, UISceneActivationState, UIWindow};
 
 use crate::{
   dpi::{self, LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Position, Size},
@@ -68,8 +73,22 @@ impl Inner {
   }
 
   pub fn set_focus(&self) {
-    //FIXME: implementation goes here
-    warn!("set_focus not yet implemented on iOS");
+    unsafe {
+      let Some(scene) = self.window().windowScene() else {
+        return;
+      };
+      let mtm = MainThreadMarker::new().unwrap();
+      let application = UIApplication::sharedApplication(mtm);
+
+      // alternative function is iOS 17+
+      #[allow(deprecated)]
+      application.requestSceneSessionActivation_userActivity_options_errorHandler(
+        Some(&scene.session()),
+        None,
+        None,
+        None,
+      );
+    }
   }
 
   pub fn set_focusable(&self, _focusable: bool) {
@@ -77,8 +96,13 @@ impl Inner {
   }
 
   pub fn is_focused(&self) -> bool {
-    warn!("`Window::is_focused` is ignored on iOS");
-    false
+    unsafe {
+      self
+        .window()
+        .windowScene()
+        .map(|scene| scene.activationState() == UISceneActivationState::ForegroundActive)
+        .unwrap_or_default()
+    }
   }
 
   pub fn is_always_on_top(&self) -> bool {
@@ -258,8 +282,7 @@ impl Inner {
   }
 
   pub fn is_visible(&self) -> bool {
-    log::warn!("`Window::is_visible` is ignored on iOS");
-    false
+    !self.window().isHidden()
   }
 
   pub fn is_resizable(&self) -> bool {
@@ -449,6 +472,18 @@ impl Inner {
   pub fn set_badge_count(&self, count: i32) {
     set_badge_count(count);
   }
+
+  // instead of returning an Option here, we default to an empty string
+  // scene lifecycle will be enforced anyway soon (iOS 27)
+  pub fn scene_identifier(&self) -> String {
+    unsafe {
+      let window = self.window();
+      let Some(scene) = window.windowScene() else {
+        return "".into();
+      };
+      scene.session().persistentIdentifier().to_string()
+    }
+  }
 }
 
 pub struct Window {
@@ -492,11 +527,9 @@ impl Window {
     window_attributes: WindowAttributes,
     platform_attributes: PlatformSpecificWindowBuilderAttributes,
   ) -> Result<Window, RootOsError> {
-    log::error!("Window::new calledddd");
     if window_attributes.always_on_top {
       warn!("`WindowAttributes::always_on_top` is unsupported on iOS");
     }
-    log::error!("window::new called!");
     // TODO: transparency, visible
 
     unsafe {
@@ -598,6 +631,9 @@ impl Inner {
   }
   pub fn ui_view(&self) -> id {
     self.view
+  }
+  pub fn window(&self) -> Retained<UIWindow> {
+    unsafe { Retained::<UIWindow>::retain(self.window as _).unwrap() }
   }
 
   pub fn set_scale_factor(&self, scale_factor: f64) {
@@ -768,6 +804,14 @@ impl From<id> for WindowId {
   }
 }
 
+impl From<Retained<UIWindow>> for WindowId {
+  fn from(window: Retained<UIWindow>) -> WindowId {
+    WindowId {
+      window: Retained::as_ptr(&window) as _,
+    }
+  }
+}
+
 #[derive(Clone)]
 pub struct PlatformSpecificWindowBuilderAttributes {
   pub root_view_class: &'static AnyClass,
@@ -776,6 +820,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
   pub prefers_home_indicator_hidden: bool,
   pub prefers_status_bar_hidden: bool,
   pub preferred_screen_edges_deferring_system_gestures: ScreenEdge,
+  pub requesting_scene_identifier: Option<String>,
 }
 
 impl Default for PlatformSpecificWindowBuilderAttributes {
@@ -787,6 +832,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
       prefers_home_indicator_hidden: false,
       prefers_status_bar_hidden: false,
       preferred_screen_edges_deferring_system_gestures: Default::default(),
+      requesting_scene_identifier: None,
     }
   }
 }

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -74,20 +74,28 @@ impl Inner {
 
   pub fn set_focus(&self) {
     unsafe {
-      let Some(scene) = self.window().windowScene() else {
+      let window = self.window();
+      // only call makeKeyAndVisible() when Info.plist was not set up to support scenes
+      let Some(scene) = window.windowScene() else {
+        window.makeKeyAndVisible();
         return;
       };
       let mtm = MainThreadMarker::new().unwrap();
       let application = UIApplication::sharedApplication(mtm);
 
-      // alternative function is iOS 17+
-      #[allow(deprecated)]
-      application.requestSceneSessionActivation_userActivity_options_errorHandler(
-        Some(&scene.session()),
-        None,
-        None,
-        None,
-      );
+      // when we support multiple scenes, request the activation of this window's scene
+      if application.supportsMultipleScenes() {
+        // alternative function is iOS 17+
+        #[allow(deprecated)]
+        application.requestSceneSessionActivation_userActivity_options_errorHandler(
+          Some(&scene.session()),
+          None,
+          None,
+          None,
+        );
+      } else {
+        window.makeKeyAndVisible();
+      }
     }
   }
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -492,9 +492,11 @@ impl Window {
     window_attributes: WindowAttributes,
     platform_attributes: PlatformSpecificWindowBuilderAttributes,
   ) -> Result<Window, RootOsError> {
+    log::error!("Window::new calledddd");
     if window_attributes.always_on_top {
       warn!("`WindowAttributes::always_on_top` is unsupported on iOS");
     }
+    log::error!("window::new called!");
     // TODO: transparency, visible
 
     unsafe {

--- a/tao-macros/Cargo.toml
+++ b/tao-macros/Cargo.toml
@@ -3,7 +3,7 @@ name = "tao-macros"
 description = "Proc macros for tao"
 version = "0.1.3"
 edition = "2021"
-authors = [ "Tauri Programme within The Commons Conservancy" ]
+authors = ["Tauri Programme within The Commons Conservancy"]
 rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
@@ -14,9 +14,9 @@ documentation = "https://docs.rs/tao-macros"
 proc-macro = true
 
 [features]
-default = [ ]
+default = []
 
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "2", features = [ "full" ] }
+syn = { version = "2", features = ["full"] }


### PR DESCRIPTION
Leverages [scenes](https://developer.apple.com/documentation/uikit/scenes) on iOS and [Activity embedding](https://developer.android.com/develop/ui/views/layout/activity-embedding) on Android.

# iOS
- Added Event::SceneRequested (on iPad the user can request a new window to be open - e.g. by long pressing the app icon and selecting "New window")
- Request new scene to be created on Window::new (if needed, main scene is detected automatically) and assign the window instance later when it gets connected

# Android
- Create new activity on Window::new (if needed, main activity is detected automatically)
- Added builder methods to determine the activity to be created
- System determines what to do with the activity (new stack, next to another one.. based on the embedding rules)