### PR TITLE
fix(macos): use correct display for coordinate conversion

### DIFF
--- a/.changes/macos-coordinate-display.md
+++ b/.changes/macos-coordinate-display.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix macOS coordinate translations to use each window's active display so cursor queries and window positioning behave correctly on secondary monitors.

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -14,8 +14,10 @@ use objc2::{
   class,
   runtime::{AnyClass as Class, AnyObject as Object, Sel},
 };
-use objc2_app_kit::{NSApp, NSView, NSWindow, NSWindowStyleMask};
-use objc2_foundation::{MainThreadMarker, NSAutoreleasePool, NSPoint, NSRange, NSRect, NSUInteger};
+use objc2_app_kit::{NSApp, NSScreen, NSView, NSWindow, NSWindowStyleMask};
+use objc2_foundation::{
+  MainThreadMarker, NSAutoreleasePool, NSDictionary, NSPoint, NSRange, NSRect, NSString, NSUInteger,
+};
 
 use crate::{
   dpi::{LogicalPosition, PhysicalPosition},
@@ -81,21 +83,30 @@ impl Clone for IdRef {
   }
 }
 
+// Allow directly accessing the current screen internally without unwrapping.
+#[inline]
+pub fn display_of_screen(screen: &NSScreen) -> CGDisplay {
+  unsafe {
+    let desc = NSScreen::deviceDescription(&screen);
+    let key = NSString::from_str("NSScreenNumber");
+    let value = NSDictionary::objectForKey(&desc, &key).unwrap();
+    let display_id: NSUInteger = msg_send![&value, unsignedIntegerValue];
+    CGDisplay::new(display_id.try_into().unwrap())
+  }
+}
+
 // For consistency with other platforms, this will...
 // 1. translate the bottom-left window corner into the top-left window corner
 // 2. translate the coordinate from a bottom-left origin coordinate system to a top-left one
-pub fn bottom_left_to_top_left(rect: NSRect) -> f64 {
-  CGDisplay::main().pixels_high() as f64 - (rect.origin.y + rect.size.height)
+pub fn bottom_left_to_top_left(rect: NSRect, display: CGDisplay) -> f64 {
+  display.pixels_high() as f64 - (rect.origin.y + rect.size.height)
 }
 
 /// Converts from tao screen-coordinates to macOS screen-coordinates.
 /// Tao: top-left is (0, 0) and y increasing downwards
 /// macOS: bottom-left is (0, 0) and y increasing upwards
-pub fn window_position(position: LogicalPosition<f64>) -> NSPoint {
-  NSPoint::new(
-    position.x,
-    CGDisplay::main().pixels_high() as f64 - position.y,
-  )
+pub fn window_position(position: LogicalPosition<f64>, display: CGDisplay) -> NSPoint {
+  NSPoint::new(position.x, display.pixels_high() as f64 - position.y)
 }
 
 pub fn cursor_position() -> Result<PhysicalPosition<f64>, ExternalError> {

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -13,6 +13,7 @@ use std::{
   sync::{Arc, Mutex, Weak},
 };
 
+use core_graphics::display::CGDisplay;
 use objc2::{
   msg_send,
   rc::Retained,
@@ -39,7 +40,7 @@ use crate::{
     app_state::AppState,
     event::{code_to_key, create_key_event, event_mods, get_scancode, EventWrapper},
     ffi::*,
-    util::{self},
+    util::{self, display_of_screen},
     window::get_window_id,
     DEVICE_ID,
   },
@@ -500,13 +501,15 @@ extern "C" fn first_rect_for_character_range(
     trace!("Triggered `firstRectForCharacterRange`");
     let state_ptr: *mut c_void = *this.get_ivar("taoState");
     let state = &mut *(state_ptr as *mut ViewState);
+    let window = state.ns_window.load().unwrap();
     let (x, y) = state.ime_spot.unwrap_or_else(|| {
-      let content_rect = NSWindow::contentRectForFrameRect(
-        &state.ns_window.load().unwrap(),
-        NSWindow::frame(&state.ns_window.load().unwrap()),
-      );
+      let content_rect = NSWindow::contentRectForFrameRect(&window, NSWindow::frame(&window));
+      let display = window
+        .screen()
+        .map(|screen| display_of_screen(&screen))
+        .unwrap_or_else(|| CGDisplay::main());
       let x = content_rect.origin.x;
-      let y = util::bottom_left_to_top_left(content_rect);
+      let y = util::bottom_left_to_top_left(content_rect, display);
       (x, y)
     });
     trace!("Completed `firstRectForCharacterRange`");

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -5,7 +5,6 @@
 
 use std::{
   collections::VecDeque,
-  convert::TryInto,
   f64,
   ffi::CStr,
   os::raw::c_void,
@@ -57,12 +56,13 @@ use objc2_app_kit::{
   NSWindowOrderingMode, NSWindowSharingType, NSWindowStyleMask,
 };
 use objc2_foundation::{
-  MainThreadMarker, NSArray, NSAutoreleasePool, NSDictionary, NSInteger, NSPoint, NSRect, NSSize,
-  NSString, NSTimeInterval, NSUInteger,
+  MainThreadMarker, NSArray, NSAutoreleasePool, NSInteger, NSPoint, NSRect, NSSize, NSString,
+  NSTimeInterval, NSUInteger,
 };
 
 use super::{
   ffi::{id, nil, NO},
+  util::display_of_screen,
   view::ViewState,
 };
 
@@ -189,6 +189,7 @@ fn create_window(
           .position
           .and_then(screen_from_position)
           .unwrap_or_else(|| appkit::NSScreen::mainScreen(mtm).unwrap());
+        let display = display_of_screen(&screen);
         let scale_factor = NSScreen::backingScaleFactor(&screen) as f64;
         let desired_size = attrs
           .inner_size
@@ -200,7 +201,7 @@ fn create_window(
           .into();
         let (left, bottom) = match attrs.position {
           Some(position) => {
-            let logical = util::window_position(position.to_logical(scale_factor));
+            let logical = util::window_position(position.to_logical(scale_factor), display);
             // macOS wants the position of the bottom left corner,
             // but caller is setting the position of top left corner
             (logical.x, logical.y - height)
@@ -705,32 +706,50 @@ impl UnownedWindow {
   }
 
   pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
+    let display = self
+      .ns_window
+      .screen()
+      .map(|screen| display_of_screen(&screen))
+      .unwrap_or_else(|| CGDisplay::main());
     let frame_rect = unsafe { NSWindow::frame(&self.ns_window) };
     let position = LogicalPosition::new(
       frame_rect.origin.x as f64,
-      util::bottom_left_to_top_left(frame_rect),
+      util::bottom_left_to_top_left(frame_rect, display),
     );
     let scale_factor = self.scale_factor();
     Ok(position.to_physical(scale_factor))
   }
 
   pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
+    let display = self
+      .ns_window
+      .screen()
+      .map(|screen| display_of_screen(&screen))
+      .unwrap_or_else(|| CGDisplay::main());
     let content_rect = unsafe {
       NSWindow::contentRectForFrameRect(&self.ns_window, NSWindow::frame(&self.ns_window))
     };
     let position = LogicalPosition::new(
       content_rect.origin.x as f64,
-      util::bottom_left_to_top_left(content_rect),
+      util::bottom_left_to_top_left(content_rect, display),
     );
     let scale_factor = self.scale_factor();
     Ok(position.to_physical(scale_factor))
   }
 
   pub fn set_outer_position(&self, position: Position) {
+    let display = self
+      .ns_window
+      .screen()
+      .map(|screen| display_of_screen(&screen))
+      .unwrap_or_else(|| CGDisplay::main());
     let scale_factor = self.scale_factor();
     let position = position.to_logical(scale_factor);
     unsafe {
-      util::set_frame_top_left_point_async(&self.ns_window, util::window_position(position));
+      util::set_frame_top_left_point_async(
+        &self.ns_window,
+        util::window_position(position, display),
+      );
     }
   }
 
@@ -879,7 +898,15 @@ impl UnownedWindow {
 
   #[inline]
   pub fn cursor_position(&self) -> Result<PhysicalPosition<f64>, ExternalError> {
-    util::cursor_position()
+    let display = self
+      .ns_window
+      .screen()
+      .map(|screen| display_of_screen(&screen))
+      .unwrap_or_else(|| CGDisplay::main());
+    let point: NSPoint = unsafe { msg_send![class!(NSEvent), mouseLocation] };
+    let y = display.pixels_high() as f64 - point.y;
+    let point = LogicalPosition::new(point.x, y);
+    Ok(point.to_physical(self.scale_factor()))
   }
 
   #[inline]
@@ -1435,16 +1462,11 @@ impl UnownedWindow {
   #[inline]
   // Allow directly accessing the current monitor internally without unwrapping.
   pub(crate) fn current_monitor_inner(&self) -> Option<RootMonitorHandle> {
-    unsafe {
-      let screen: Retained<NSScreen> = self.ns_window.screen()?;
-      let desc = NSScreen::deviceDescription(&screen);
-      let key = NSString::from_str("NSScreenNumber");
-      let value = NSDictionary::objectForKey(&desc, &key).unwrap();
-      let display_id: NSUInteger = msg_send![&value, unsignedIntegerValue];
-      Some(RootMonitorHandle {
-        inner: MonitorHandle::new(display_id.try_into().unwrap()),
-      })
-    }
+    let screen: Retained<NSScreen> = self.ns_window.screen()?;
+    let display = display_of_screen(&screen);
+    Some(RootMonitorHandle {
+      inner: MonitorHandle::new(display.id),
+    })
   }
 
   #[inline]

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -9,6 +9,7 @@ use std::{
   sync::{Arc, Weak},
 };
 
+use core_graphics::display::CGDisplay;
 use objc2::{
   msg_send,
   rc::Retained,
@@ -27,7 +28,7 @@ use crate::{
     app_state::AppState,
     event::{EventProxy, EventWrapper},
     ffi::{id, nil, BOOL, NO, YES},
-    util::{self, IdRef},
+    util::{self, display_of_screen, IdRef},
     view::ViewState,
     window::{get_ns_theme, get_window_id, UnownedWindow},
   },
@@ -122,9 +123,14 @@ impl WindowDelegateState {
   }
 
   fn emit_move_event(&mut self) {
+    let display = self
+      .ns_window
+      .screen()
+      .map(|screen| display_of_screen(&screen))
+      .unwrap_or_else(|| CGDisplay::main());
     let rect = NSWindow::frame(&self.ns_window);
     let x = rect.origin.x as f64;
-    let y = util::bottom_left_to_top_left(rect);
+    let y = util::bottom_left_to_top_left(rect, display);
     let moved = self.previous_position != Some((x, y));
     if moved {
       self.previous_position = Some((x, y));


### PR DESCRIPTION
Replace hardcoded main display usage with current window's display for coordinate conversion functions. This ensures proper positioning when working with multiple displays.

Add helper function `display_of_screen` to safely get `CGDisplay` from `NSScreen`. Update all coordinate-related functions to accept display parameter.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
