### PR TITLE
fix(macos): fix clippy, remove unnessary clone, remove unncessary casting, remove unsued code

### DIFF
--- a/.changes/fix-macos-clippy.md
+++ b/.changes/fix-macos-clippy.md
@@ -1,0 +1,5 @@
+---
+tao: patch
+---
+
+Fix clippy errors. Remove unnessary clone. Remove unnecessary casting. Remove some 8 years unused code.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -112,6 +112,7 @@ impl<T> EventLoopBuilder<T> {
   #[inline]
   pub fn build(&mut self) -> EventLoop<T> {
     EventLoop {
+      #[allow(clippy::unnecessary_mut_passed)]
       event_loop: platform_impl::EventLoop::new(&mut self.platform_specific),
       _marker: PhantomData,
     }

--- a/src/platform_impl/macos/app.rs
+++ b/src/platform_impl/macos/app.rs
@@ -61,8 +61,8 @@ unsafe fn maybe_dispatch_device_event(event: &NSEvent) {
     | NSEventType::RightMouseDragged => {
       let mut events = VecDeque::with_capacity(3);
 
-      let delta_x = event.deltaX() as f64;
-      let delta_y = event.deltaY() as f64;
+      let delta_x = event.deltaX();
+      let delta_y = event.deltaY();
 
       if delta_x != 0.0 {
         events.push_back(EventWrapper::StaticEvent(Event::DeviceEvent {

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -176,7 +176,7 @@ extern "C" fn application_continue_user_activity(
       match user_activity
         .webpageURL()
         .and_then(|url| url.absoluteString())
-        .and_then(|s| Some(s.to_string()))
+        .map(|s| s.to_string())
       {
         None => {
           error!(
@@ -201,7 +201,7 @@ extern "C" fn application_continue_user_activity(
 
   AppState::open_urls(vec![url]);
   trace!("Completed `application:continueUserActivity:restorationHandler:`");
-  return Bool::new(true);
+  Bool::new(true)
 }
 
 extern "C" fn application_should_handle_reopen(

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -123,11 +123,13 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     set_progress_indicator(progress);
   }
 
+  #[allow(dead_code)]
   #[inline]
   pub fn set_badge_count(&self, count: Option<i64>, _desktop_filename: Option<String>) {
     set_badge_label(count.map(|c| c.to_string()));
   }
 
+  #[allow(dead_code)]
   #[inline]
   pub fn set_badge_label(&self, label: Option<String>) {
     set_badge_label(label);

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -235,7 +235,7 @@ impl MonitorHandle {
       Some(screen) => screen,
       None => return 1.0, // default to 1.0 when we can't find the screen
     };
-    NSScreen::backingScaleFactor(&screen) as f64
+    NSScreen::backingScaleFactor(&screen)
   }
 
   pub fn video_modes(&self) -> impl Iterator<Item = RootVideoMode> {

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -12,15 +12,15 @@ use std::ops::{BitAnd, Deref};
 use core_graphics::display::CGDisplay;
 use objc2::{
   class,
-  runtime::{AnyClass as Class, AnyObject as Object, Sel},
+  runtime::{AnyClass as Class, AnyObject as Object},
 };
-use objc2_app_kit::{NSApp, NSView, NSWindow, NSWindowStyleMask};
-use objc2_foundation::{MainThreadMarker, NSAutoreleasePool, NSPoint, NSRange, NSRect, NSUInteger};
+use objc2_app_kit::{NSView, NSWindow, NSWindowStyleMask};
+use objc2_foundation::{NSAutoreleasePool, NSPoint, NSRange, NSRect, NSUInteger};
 
 use crate::{
   dpi::{LogicalPosition, PhysicalPosition},
   error::ExternalError,
-  platform_impl::platform::ffi::{self, id, nil, BOOL, YES},
+  platform_impl::platform::ffi::{self, id, nil},
 };
 
 // Replace with `!` once stable
@@ -114,17 +114,6 @@ pub unsafe fn create_input_context(view: &NSView) -> IdRef {
   let input_context: id = msg_send![class!(NSTextInputContext), alloc];
   let input_context: id = msg_send![input_context, initWithClient: view];
   IdRef::new(input_context)
-}
-
-#[allow(dead_code)]
-pub unsafe fn open_emoji_picker() {
-  // SAFETY: TODO
-  let mtm = unsafe { MainThreadMarker::new_unchecked() };
-  let () = msg_send![&NSApp(mtm), orderFrontCharacterPalette: nil];
-}
-
-pub extern "C" fn yes(_: &Object, _: Sel) -> BOOL {
-  YES
 }
 
 pub unsafe fn toggle_style_mask(

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -84,7 +84,7 @@ pub(super) struct ViewState {
 
 impl ViewState {
   fn get_scale_factor(&self) -> f64 {
-    (unsafe { NSWindow::backingScaleFactor(&self.ns_window.load().unwrap()) }) as f64
+    unsafe { NSWindow::backingScaleFactor(&self.ns_window.load().unwrap()) }
   }
 }
 
@@ -118,8 +118,8 @@ pub unsafe fn set_ime_position(ns_view: &NSView, input_context: id, x: f64, y: f
     &state.ns_window.load().unwrap(),
     NSWindow::frame(&state.ns_window.load().unwrap()),
   );
-  let base_x = content_rect.origin.x as f64;
-  let base_y = (content_rect.origin.y + content_rect.size.height) as f64;
+  let base_x = content_rect.origin.x;
+  let base_y = content_rect.origin.y + content_rect.size.height;
   state.ime_spot = Some((base_x + x, base_y - y));
   let _: () = msg_send![input_context, invalidateCharacterCoordinates];
 }
@@ -393,6 +393,8 @@ extern "C" fn reset_cursor_rects(this: &Object, _sel: Sel) {
 extern "C" fn has_marked_text(this: &Object, _sel: Sel) -> BOOL {
   unsafe {
     trace!("Triggered `hasMarkedText`");
+    // TODO deprecated = "this is difficult to use correctly, use `Ivar::load` instead."
+    #[allow(clippy::explicit_auto_deref)]
     let marked_text: &NSMutableAttributedString = *this.get_ivar("markedText");
     trace!("Completed `hasMarkedText`");
     (marked_text.length() > 0).into()
@@ -402,6 +404,8 @@ extern "C" fn has_marked_text(this: &Object, _sel: Sel) -> BOOL {
 extern "C" fn marked_range(this: &Object, _sel: Sel) -> NSRange {
   unsafe {
     trace!("Triggered `markedRange`");
+    // TODO deprecated = "this is difficult to use correctly, use `Ivar::load` instead."
+    #[allow(clippy::explicit_auto_deref)]
     let marked_text: &NSMutableAttributedString = *this.get_ivar("markedText");
     let length = marked_text.length();
     trace!("Completed `markedRange`");
@@ -875,7 +879,7 @@ extern "C" fn insert_tab(this: &Object, _sel: Sel, _sender: id) {
     let first_responder: id = msg_send![window, firstResponder];
     let this_ptr = this as *const _ as *mut _;
     if first_responder == this_ptr {
-      let (): _ = msg_send![window, selectNextKeyView: this];
+      let () = msg_send![window, selectNextKeyView: this];
     }
   }
 }
@@ -886,7 +890,7 @@ extern "C" fn insert_back_tab(this: &Object, _sel: Sel, _sender: id) {
     let first_responder: id = msg_send![window, firstResponder];
     let this_ptr = this as *const _ as *mut _;
     if first_responder == this_ptr {
-      let (): _ = msg_send![window, selectPreviousKeyView: this];
+      let () = msg_send![window, selectPreviousKeyView: this];
     }
   }
 }
@@ -992,8 +996,8 @@ fn mouse_motion(this: &NSView, event: &NSEvent) {
       }
     }
 
-    let x = view_point.x as f64;
-    let y = view_rect.size.height as f64 - view_point.y as f64;
+    let x = view_point.x;
+    let y = view_rect.size.height - view_point.y;
     let logical_position = LogicalPosition::new(x, y);
 
     update_potentially_stale_modifiers(state, event);

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -450,6 +450,7 @@ extern "C" fn send_event(this: &Object, _sel: Sel, event: &NSEvent) {
   }
 }
 
+// TODO impl Send + Sync for SharedState when use Arc<Mutex>
 #[derive(Default)]
 pub struct SharedState {
   pub resizable: bool,
@@ -600,6 +601,7 @@ impl UnownedWindow {
       ns_view,
       ns_window,
       input_context,
+      #[allow(clippy::arc_with_non_send_sync)]
       shared_state: Arc::new(Mutex::new(win_attribs.into())),
       decorations: AtomicBool::new(decorations),
       cursor_state,
@@ -611,7 +613,7 @@ impl UnownedWindow {
       Some(theme) => {
         set_ns_theme(Some(theme));
         let mut state = window.shared_state.lock().unwrap();
-        state.current_theme = theme.clone();
+        state.current_theme = theme;
       }
       None => {
         let mut state = window.shared_state.lock().unwrap();
@@ -707,7 +709,7 @@ impl UnownedWindow {
   pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
     let frame_rect = unsafe { NSWindow::frame(&self.ns_window) };
     let position = LogicalPosition::new(
-      frame_rect.origin.x as f64,
+      frame_rect.origin.x,
       util::bottom_left_to_top_left(frame_rect),
     );
     let scale_factor = self.scale_factor();
@@ -719,7 +721,7 @@ impl UnownedWindow {
       NSWindow::contentRectForFrameRect(&self.ns_window, NSWindow::frame(&self.ns_window))
     };
     let position = LogicalPosition::new(
-      content_rect.origin.x as f64,
+      content_rect.origin.x,
       util::bottom_left_to_top_left(content_rect),
     );
     let scale_factor = self.scale_factor();
@@ -737,8 +739,7 @@ impl UnownedWindow {
   #[inline]
   pub fn inner_size(&self) -> PhysicalSize<u32> {
     let view_frame = unsafe { NSView::frame(&self.ns_view) };
-    let logical: LogicalSize<f64> =
-      (view_frame.size.width as f64, view_frame.size.height as f64).into();
+    let logical: LogicalSize<f64> = (view_frame.size.width, view_frame.size.height).into();
     let scale_factor = self.scale_factor();
     logical.to_physical(scale_factor)
   }
@@ -746,8 +747,7 @@ impl UnownedWindow {
   #[inline]
   pub fn outer_size(&self) -> PhysicalSize<u32> {
     let view_frame = unsafe { NSWindow::frame(&self.ns_window) };
-    let logical: LogicalSize<f64> =
-      (view_frame.size.width as f64, view_frame.size.height as f64).into();
+    let logical: LogicalSize<f64> = (view_frame.size.width, view_frame.size.height).into();
     let scale_factor = self.scale_factor();
     logical.to_physical(scale_factor)
   }
@@ -1017,7 +1017,7 @@ impl UnownedWindow {
     shared_state_lock.fullscreen = None;
 
     let maximized = shared_state_lock.maximized;
-    let mask = self.saved_style(&mut *shared_state_lock);
+    let mask = self.saved_style(&mut shared_state_lock);
 
     drop(shared_state_lock);
     trace!("Unlocked shared state in `restore_state_from_fullscreen`");
@@ -1635,7 +1635,7 @@ impl WindowExtMacOS for UnownedWindow {
 
         true
       } else {
-        let new_mask = self.saved_style(&mut *shared_state_lock);
+        let new_mask = self.saved_style(&mut shared_state_lock);
         self.set_style_mask_async(new_mask);
         shared_state_lock.is_simple_fullscreen = false;
 
@@ -1743,8 +1743,8 @@ unsafe fn set_min_inner_size(window: &NSWindow, mut min_size: LogicalSize<f64>) 
   let mut current_rect = NSWindow::frame(window);
   let content_rect = NSWindow::contentRectForFrameRect(window, NSWindow::frame(window));
   // Convert from client area size to window size
-  min_size.width += (current_rect.size.width - content_rect.size.width) as f64; // this tends to be 0
-  min_size.height += (current_rect.size.height - content_rect.size.height) as f64;
+  min_size.width += current_rect.size.width - content_rect.size.width; // this tends to be 0
+  min_size.height += current_rect.size.height - content_rect.size.height;
   window.setMinSize(NSSize {
     width: min_size.width as CGFloat,
     height: min_size.height as CGFloat,
@@ -1767,8 +1767,8 @@ unsafe fn set_max_inner_size(window: &NSWindow, mut max_size: LogicalSize<f64>) 
   let mut current_rect = NSWindow::frame(window);
   let content_rect = NSWindow::contentRectForFrameRect(window, NSWindow::frame(window));
   // Convert from client area size to window size
-  max_size.width += (current_rect.size.width - content_rect.size.width) as f64; // this tends to be 0
-  max_size.height += (current_rect.size.height - content_rect.size.height) as f64;
+  max_size.width += current_rect.size.width - content_rect.size.width; // this tends to be 0
+  max_size.height += current_rect.size.height - content_rect.size.height;
   window.setMaxSize(NSSize {
     width: max_size.width as CGFloat,
     height: max_size.height as CGFloat,

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -116,14 +116,14 @@ impl WindowDelegateState {
   pub fn emit_resize_event(&mut self) {
     let rect = NSView::frame(&self.ns_view());
     let scale_factor = self.get_scale_factor();
-    let logical_size = LogicalSize::new(rect.size.width as f64, rect.size.height as f64);
+    let logical_size = LogicalSize::new(rect.size.width, rect.size.height);
     let size = logical_size.to_physical(scale_factor);
     self.emit_event(WindowEvent::Resized(size));
   }
 
   fn emit_move_event(&mut self) {
     let rect = NSWindow::frame(&self.ns_window);
-    let x = rect.origin.x as f64;
+    let x = rect.origin.x;
     let y = util::bottom_left_to_top_left(rect);
     let moved = self.previous_position != Some((x, y));
     if moved {
@@ -135,12 +135,12 @@ impl WindowDelegateState {
   }
 
   fn get_scale_factor(&self) -> f64 {
-    NSWindow::backingScaleFactor(&self.ns_window) as f64
+    NSWindow::backingScaleFactor(&self.ns_window)
   }
 
   fn view_size(&self) -> LogicalSize<f64> {
     let ns_size = NSView::frame(&self.ns_view()).size;
-    LogicalSize::new(ns_size.width as f64, ns_size.height as f64)
+    LogicalSize::new(ns_size.width, ns_size.height)
   }
 }
 
@@ -313,13 +313,13 @@ extern "C" fn init_with_tao(this: &Object, _sel: Sel, state: *mut c_void) -> id 
 }
 
 extern "C" fn mark_is_checking_zoomed_in(this: &Object, _sel: Sel) {
-  with_state(&*this, |state| {
+  with_state(this, |state| {
     state.is_checking_zoomed_in = true;
   });
 }
 
 extern "C" fn clear_is_checking_zoomed_in(this: &Object, _sel: Sel) {
-  with_state(&*this, |state| {
+  with_state(this, |state| {
     state.is_checking_zoomed_in = false;
   });
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1662,6 +1662,7 @@ pub enum ResizeDirection {
   West,
 }
 
+#[allow(dead_code)]
 pub(crate) fn hit_test(
   (left, top, right, bottom): (i32, i32, i32, i32),
   cx: i32,


### PR DESCRIPTION
Clippy passed, cagro test all features and all targets passed with rust 1.74. 

Some usage
```rust
let marked_text: &NSMutableAttributedString = *this.get_ivar("markedText");
```
```rust
/// Use [`Ivar::load`] instead.
    ///
    ///
    /// # Safety
    ///
    /// The object must have an instance variable with the given name, and it
    /// must be of type `T`.
    ///
    /// See [`Ivar::load_ptr`] for details surrounding this.
    #[deprecated = "this is difficult to use correctly, use `Ivar::load` instead."]
    pub unsafe fn get_ivar<T: Encode>(&self, name: &str) -> &T {
        let ivar = self.lookup_instance_variable_dynamically(name);
        // SAFETY: Upheld by caller
        unsafe { ivar.load::<T>(self) }
    }
```

Might introducing in the future?