### PR TITLE
Change run loop observer mode to common modes to prevent freezing on iOS

### DIFF
--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -311,7 +311,7 @@ fn setup_control_flow_observers() {
       control_flow_begin_handler,
       ptr::null_mut(),
     );
-    CFRunLoopAddObserver(main_loop, begin_observer, kCFRunLoopDefaultMode);
+    CFRunLoopAddObserver(main_loop, begin_observer, kCFRunLoopCommonModes);
 
     let main_end_observer = CFRunLoopObserverCreate(
       ptr::null_mut(),
@@ -321,7 +321,7 @@ fn setup_control_flow_observers() {
       control_flow_main_end_handler,
       ptr::null_mut(),
     );
-    CFRunLoopAddObserver(main_loop, main_end_observer, kCFRunLoopDefaultMode);
+    CFRunLoopAddObserver(main_loop, main_end_observer, kCFRunLoopCommonModes);
 
     let end_observer = CFRunLoopObserverCreate(
       ptr::null_mut(),
@@ -331,7 +331,7 @@ fn setup_control_flow_observers() {
       control_flow_end_handler,
       ptr::null_mut(),
     );
-    CFRunLoopAddObserver(main_loop, end_observer, kCFRunLoopDefaultMode);
+    CFRunLoopAddObserver(main_loop, end_observer, kCFRunLoopCommonModes);
   }
 }
 


### PR DESCRIPTION
Proposed fix for issue #1162 - **Needs maintainer validation**.

On iOS, **all events are blocked while the user is scrolling**.  This breaks every Tao-based iOS app that needs real-time updates during scroll.

**Affected**

- Signal/state updates
- Async task completions
- Cross-thread UI communication

iOS run loop modes:

| Mode                    | When Active | `DefaultMode` Observers | `CommonModes` Observers |
| ----------------------- | ----------- | ----------------------- | ----------------------- |
| `kCFRunLoopDefaultMode` | Normal      | ✅ Fire                 | ✅ Fire                 |
| `UITrackingRunLoopMode` | Scrolling   | ❌ Don't fire           | ✅ Fire                 |

The run loop **observers** are registered for `kCFRunLoopDefaultMode` only. During scroll, iOS switches to `UITrackingRunLoopMode` — observers aren't registered for that mode, so they don't fire and events don't get processed.
