### PR TITLE
Fix ABI mismatch in INIT_MAIN_THREAD_ID for Windows runtime

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -354,8 +354,8 @@ fn main_thread_id() -> u32 {
   #[used]
   #[allow(non_upper_case_globals)]
   #[link_section = ".CRT$XCU"]
-  static INIT_MAIN_THREAD_ID: unsafe fn() = {
-    unsafe fn initer() {
+  static INIT_MAIN_THREAD_ID: unsafe extern "C" fn() = {
+    unsafe extern "C" fn initer() {
       MAIN_THREAD_ID = GetCurrentThreadId();
     }
     initer


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Porting in https://github.com/rust-windowing/winit/pull/4442

This should fix the miri error we're getting for the past few months