### PR TITLE
fix(macos): update is_maximized method to use ns_window's isZoomed

### DIFF
--- a/.changes/fix-macos-is_maximized.md
+++ b/.changes/fix-macos-is_maximized.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Update is_maximized method to use ns_window's isZoomed

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1077,7 +1077,7 @@ impl UnownedWindow {
 
   #[inline]
   pub fn is_maximized(&self) -> bool {
-    self.is_zoomed()
+    unsafe { self.ns_window.isZoomed() }
   }
 
   #[inline]


### PR DESCRIPTION
It calls `set_style_mask_sync` twice, forces synchronous IPC. Temporarily adding and removing that triggers unnecessary window layout recalculations and repaints. In multi-thread, modifing the `styleMask` while view is till initializing leads to the first responder errors and precondition failure crashes. Or lead to unexpected resize behavior.

https://github.com/tauri-apps/tao/blob/648161769c35ddd2bffd939f4d4d6a027325326c/src/platform_impl/macos/window.rs#L976-L995

This PR related to:
https://github.com/tauri-apps/plugins-workspace/pull/3242
https://github.com/tauri-apps/tauri/issues/5812
https://github.com/agmmnn/tauri-controls/issues/10
https://github.com/tauri-apps/tauri/issues/10261
https://github.com/tauri-apps/tao/issues/641

The `is_zoomed` is setting a temporary, then reading. Leads to

> This seems to trigger an infinite loop of sorts https://github.com/tauri-apps/tauri/issues/5812

I will give another PR to change `is_zoomed` latter.

CC @Legend-Master, @amrbashir