### PR TITLE
fix(macos): remove synchronous styleMask mutations in is_zoomed

### DIFF
--- a/.changes/fix-macos-zoom-detection-logic.md
+++ b/.changes/fix-macos-zoom-detection-logic.md
@@ -1,0 +1,4 @@
+---
+"tao": patch
+---
+Remove synchronous styleMask mutations in is_zoomed on macOS

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -976,22 +976,25 @@ impl UnownedWindow {
   pub(crate) fn is_zoomed(&self) -> bool {
     // because `isZoomed` doesn't work if the window's borderless,
     // we make it resizable temporalily.
-    let curr_mask = unsafe { self.ns_window.styleMask() };
+    unsafe {
+      let curr_mask = self.ns_window.styleMask();
 
-    let required = NSWindowStyleMask::Titled | NSWindowStyleMask::Resizable;
-    let needs_temp_mask = !curr_mask.contains(required);
-    if needs_temp_mask {
-      self.set_style_mask_sync(required);
+      let required = NSWindowStyleMask::Titled | NSWindowStyleMask::Resizable;
+      if curr_mask.contains(required) {
+        return self.ns_window.isZoomed();
+      }
+
+      if let Some(screen) = self.ns_window.screen() {
+        let frame = self.ns_window.frame();
+        let visible_frame = screen.visibleFrame();
+
+        return (frame.size.width - visible_frame.size.width).abs() < 1.0
+          && (frame.size.height - visible_frame.size.height).abs() < 1.0;
+      }
+
+      // Fallback to original `isZoomed` check
+      self.ns_window.isZoomed()
     }
-
-    let is_zoomed: bool = unsafe { self.ns_window.isZoomed() };
-
-    // Roll back temp styles
-    if needs_temp_mask {
-      self.set_style_mask_sync(curr_mask);
-    }
-
-    is_zoomed
   }
 
   fn saved_style(&self, shared_state: &mut SharedState) -> NSWindowStyleMask {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -974,8 +974,11 @@ impl UnownedWindow {
   }
 
   pub(crate) fn is_zoomed(&self) -> bool {
-    // because `isZoomed` doesn't work if the window's borderless,
-    // we make it resizable temporalily.
+    // Previously, is_zoomed temporarily mutated the window's styleMask(or resizable)
+    // to force macOS to return a valid result for borderless windows.
+    // This synchronous mutation could trigger unnecessary layout passes or state inconsistencies.
+    // Related issue: https://github.com/rust-windowing/winit/issues/4071 and https://github.com/tauri-apps/plugins-workspace/issues/3240
+
     unsafe {
       let curr_mask = self.ns_window.styleMask();
 


### PR DESCRIPTION
Mentioned on https://github.com/tauri-apps/tao/pull/1181

fixes https://github.com/tauri-apps/plugins-workspace/issues/3240
fixes https://github.com/tauri-apps/plugins-workspace/pull/3242
fixes https://github.com/tauri-apps/tao/issues/641
fixes https://github.com/tauri-apps/tauri/issues/5812
fixes https://github.com/tauri-apps/tauri/issues/10261
fixes https://github.com/tauri-apps/tauri/issues/14822

CC @Legend-Master, @amrbashir