### PR TITLE
fix(windows): prevent panics by handling invalid monitor handles

### DIFF
--- a/.changes/fix-monitor-panic.md
+++ b/.changes/fix-monitor-panic.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Prevent panics on Windows when a monitor handle becomes invalid during info retrieval.

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -179,7 +179,7 @@ impl MonitorHandle {
 
   #[inline]
   pub fn name(&self) -> Option<String> {
-    let monitor_info = get_monitor_info(self.hmonitor()).unwrap();
+    let monitor_info = get_monitor_info(self.hmonitor()).ok()?;
     Some(util::wchar_ptr_to_string(PCWSTR::from_raw(
       monitor_info.szDevice.as_ptr(),
     )))
@@ -197,7 +197,12 @@ impl MonitorHandle {
 
   #[inline]
   pub fn size(&self) -> PhysicalSize<u32> {
-    let monitor_info = get_monitor_info(self.hmonitor()).unwrap();
+    let Ok(monitor_info) = get_monitor_info(self.hmonitor()) else {
+      return PhysicalSize {
+        width: 0,
+        height: 0,
+      };
+    };
     PhysicalSize {
       width: (monitor_info.monitorInfo.rcMonitor.right - monitor_info.monitorInfo.rcMonitor.left)
         as u32,
@@ -208,7 +213,9 @@ impl MonitorHandle {
 
   #[inline]
   pub fn position(&self) -> PhysicalPosition<i32> {
-    let monitor_info = get_monitor_info(self.hmonitor()).unwrap();
+    let Ok(monitor_info) = get_monitor_info(self.hmonitor()) else {
+      return PhysicalPosition { x: 0, y: 0 };
+    };
     PhysicalPosition {
       x: monitor_info.monitorInfo.rcMonitor.left,
       y: monitor_info.monitorInfo.rcMonitor.top,
@@ -230,12 +237,15 @@ impl MonitorHandle {
     // fields are probably changing, but we aren't looking at those fields
     // anyway), so we're using a BTreeSet deduplicate
     let mut modes = BTreeSet::new();
-    let mut i = 0;
 
+    let Ok(monitor_info) = get_monitor_info(self.hmonitor()) else {
+      return modes.into_iter();
+    };
+
+    let device_name = PCWSTR::from_raw(monitor_info.szDevice.as_ptr());
+    let mut i = 0;
     loop {
       unsafe {
-        let monitor_info = get_monitor_info(self.hmonitor()).unwrap();
-        let device_name = PCWSTR::from_raw(monitor_info.szDevice.as_ptr());
         let mut mode: DEVMODEW = mem::zeroed();
         mode.dmSize = mem::size_of_val(&mode) as u16;
         if !EnumDisplaySettingsExW(


### PR DESCRIPTION
### Description
This PR addresses intermittent crashes on Windows that occur when a monitor is disconnected or its handle becomes invalid between acquisition and the time its details (size, position, etc.) are retrieved.

Previously, `MonitorHandle` methods used `unwrap()` on `get_monitor_info`, leading to panics. As discussed on Discord, this PR implements a pragmatic fix to prevent crashes without introducing breaking changes to the API:

**If the monitor handle is invalid:**
- `name()`: Returns `None`.
- `size()`: Returns a `PhysicalSize` of `0,0`.
- `position()`: Returns a `PhysicalPosition` of `0,0`.
- `video_modes()`: Returns an empty iterator.

### Checklist
- [x] I have read the [Pull Request Guidelines](https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines).
- [x] I have given the PR a descriptive title.
- [x] I have followed the commit signing requirements.
- [x] `cargo test` passes locally.