### PR TITLE
fix(windows): do not panic when transitioning from `Destroyed`

### DIFF
--- a/.changes/no-panic.md
+++ b/.changes/no-panic.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Prevent panics on Windows during shutdown of the eventloop.

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -365,7 +365,9 @@ impl<T> EventLoopRunner<T> {
         self.call_event_handler(Event::LoopDestroyed);
       }
 
-      (Destroyed, _) => panic!("cannot move state from Destroyed"),
+      (Destroyed, state) => {
+        debug!("Eventloop is already destroyed, cannot move to {state}")
+      }
     }
   }
 

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -6,7 +6,7 @@ use std::{
   any::Any,
   cell::{Cell, RefCell},
   collections::{HashSet, VecDeque},
-  mem, panic,
+  fmt, mem, panic,
   rc::Rc,
   time::Instant,
 };
@@ -59,6 +59,18 @@ enum RunnerState {
   HandlingRedrawEvents,
   /// The event loop has been destroyed. No other events will be emitted.
   Destroyed,
+}
+
+impl fmt::Display for RunnerState {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      RunnerState::Uninitialized => write!(f, "Uninitialized"),
+      RunnerState::Idle => write!(f, "Idle"),
+      RunnerState::HandlingMainEvents => write!(f, "HandlingMainEvents"),
+      RunnerState::HandlingRedrawEvents => write!(f, "HandlingRedrawEvents"),
+      RunnerState::Destroyed => write!(f, "Destroyed"),
+    }
+  }
 }
 
 enum BufferedEvent<T: 'static> {

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -6,7 +6,7 @@ use std::{
   any::Any,
   cell::{Cell, RefCell},
   collections::{HashSet, VecDeque},
-  fmt, mem, panic,
+  mem, panic,
   rc::Rc,
   time::Instant,
 };
@@ -59,18 +59,6 @@ enum RunnerState {
   HandlingRedrawEvents,
   /// The event loop has been destroyed. No other events will be emitted.
   Destroyed,
-}
-
-impl fmt::Display for RunnerState {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    match self {
-      RunnerState::Uninitialized => write!(f, "Uninitialized"),
-      RunnerState::Idle => write!(f, "Idle"),
-      RunnerState::HandlingMainEvents => write!(f, "HandlingMainEvents"),
-      RunnerState::HandlingRedrawEvents => write!(f, "HandlingRedrawEvents"),
-      RunnerState::Destroyed => write!(f, "Destroyed"),
-    }
-  }
 }
 
 enum BufferedEvent<T: 'static> {
@@ -378,7 +366,7 @@ impl<T> EventLoopRunner<T> {
       }
 
       (Destroyed, state) => {
-        debug!("Eventloop is already destroyed, cannot move to {state}")
+        debug!("Eventloop is already destroyed, cannot move to {state:?}")
       }
     }
   }


### PR DESCRIPTION
We are seeing crash reports from Tauri applications caused by this particular panic. I am not sure what they are caused by but it seems save to just remove the panic, log a message and leave the state in `Destroyed` instead.

Resolves: #1180