### PR TITLE
chore(windows): downgrade eventloop warnings

### DIFF
--- a/.changes/downgrade-warnings.md
+++ b/.changes/downgrade-warnings.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Downgrades several logs in the Windows backend from WARN to DEBUG.

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -208,7 +208,7 @@ impl<T> EventLoopRunner<T> {
   pub(crate) unsafe fn send_event(&self, event: Event<'_, T>) {
     if let Event::RedrawRequested(_) = event {
       if self.runner_state.get() != RunnerState::HandlingRedrawEvents {
-        warn!("RedrawRequested dispatched without explicit MainEventsCleared");
+        debug!("RedrawRequested dispatched without explicit MainEventsCleared");
         self.move_state_to(RunnerState::HandlingRedrawEvents);
       }
       self.call_event_handler(event);
@@ -342,7 +342,7 @@ impl<T> EventLoopRunner<T> {
         self.call_event_handler(Event::MainEventsCleared);
       }
       (HandlingMainEvents, Idle) => {
-        warn!("RedrawEventsCleared emitted without explicit MainEventsCleared");
+        debug!("RedrawEventsCleared emitted without explicit MainEventsCleared");
         self.call_event_handler(Event::MainEventsCleared);
         self.call_redraw_events_cleared();
       }
@@ -356,7 +356,7 @@ impl<T> EventLoopRunner<T> {
         self.call_redraw_events_cleared();
       }
       (HandlingRedrawEvents, HandlingMainEvents) => {
-        warn!("NewEvents emitted without explicit RedrawEventsCleared");
+        debug!("NewEvents emitted without explicit RedrawEventsCleared");
         self.call_redraw_events_cleared();
         self.call_new_events(false);
       }

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -208,6 +208,7 @@ impl<T> EventLoopRunner<T> {
   pub(crate) unsafe fn send_event(&self, event: Event<'_, T>) {
     if let Event::RedrawRequested(_) = event {
       if self.runner_state.get() != RunnerState::HandlingRedrawEvents {
+        // TODO: Consider removing log once https://github.com/rust-windowing/winit/pull/2767 gets adopted.
         debug!("RedrawRequested dispatched without explicit MainEventsCleared");
         self.move_state_to(RunnerState::HandlingRedrawEvents);
       }
@@ -342,6 +343,7 @@ impl<T> EventLoopRunner<T> {
         self.call_event_handler(Event::MainEventsCleared);
       }
       (HandlingMainEvents, Idle) => {
+        // TODO: Consider removing log once https://github.com/rust-windowing/winit/pull/2767 gets adopted.
         debug!("RedrawEventsCleared emitted without explicit MainEventsCleared");
         self.call_event_handler(Event::MainEventsCleared);
         self.call_redraw_events_cleared();
@@ -356,6 +358,7 @@ impl<T> EventLoopRunner<T> {
         self.call_redraw_events_cleared();
       }
       (HandlingRedrawEvents, HandlingMainEvents) => {
+        // TODO: Consider removing log once https://github.com/rust-windowing/winit/pull/2767 gets adopted.
         debug!("NewEvents emitted without explicit RedrawEventsCleared");
         self.call_redraw_events_cleared();
         self.call_new_events(false);


### PR DESCRIPTION
We are seeing these warnings come up in normal operation of a Tauri Windows application. I am not sure about their significance as the application works just fine, suggesting that these actually are not very critical. I am suggesting to downgrade these to DEBUG instead.