### PR TITLE
fix(linux): exit cleanly when GtkApplication is a remote GIO instance

### DIFF
--- a/.changes/change-pr-1190.md
+++ b/.changes/change-pr-1190.md
@@ -1,5 +1,4 @@
 ---
-"tao-macros": patch
 "tao": patch
 ---
 

--- a/.changes/change-pr-1190.md
+++ b/.changes/change-pr-1190.md
@@ -1,0 +1,6 @@
+---
+"tao-macros": patch
+"tao": patch
+---
+
+fix(linux): exit cleanly when GtkApplication is a remote GIO instance

--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -1035,6 +1035,15 @@ impl<T: 'static> EventLoop<T> {
 
         window_target.p.app.activate();
 
+        // If this is a secondary (remote) GIO instance, the activate signal
+        // was forwarded to the primary instance via D-Bus. Exit immediately so
+        // the primary can handle focus (e.g. bring its window to front).
+        // Without this, the secondary hangs forever waiting for a StartCause::Init
+        // event that never arrives (connect_activate only fires on the primary).
+        if window_target.p.app.is_remote() {
+          return 0;
+        }
+
         let mut state = EventState::NewStart;
         let exit_code = loop {
           let mut blocking = false;


### PR DESCRIPTION
## Problem

When two processes share the same `GtkApplication` app_id (e.g. a GUI application and a background webserver using the same binary), the second process to register on D-Bus becomes a **remote GIO instance**. `g_application_register()` succeeds but `priv->impl` is never initialized — the `startup` and `activate` signals only fire on the primary instance.

If the remote process then proceeds to create a `GtkApplicationWindow`, GTK calls:

```
gtk_window_set_application()
  → gtk_application_add_window()
    → g_signal_emit(WINDOW_ADDED)
      → dispatches into priv->impl  ← NULL
        → SIGSEGV
```

## Fix

After `app.activate()`, check `app.is_remote()` (which wraps `g_application_get_is_remote()`). If true, return immediately with exit code `0`.

GIO has already forwarded the activate signal to the primary instance via D-Bus at this point, so the primary can respond — for example, by handling the second `StartCause::Init` that tao's `connect_activate` closure emits and bringing its existing window to the front.

## Behavior

- **Before:** Second launch hangs forever (remote instance never receives `StartCause::Init` because `connect_activate` only fires on the primary), then crashes when it tries to create a window.
- **After:** Second launch exits cleanly with code 0. The primary receives a D-Bus activate, fires `connect_activate` again, and the application can respond by focusing its existing window.

## Testing

Reproduce by building any tao app with a fixed `app_id`, running two instances simultaneously on Linux. Without this fix the second instance crashes; with it, the second exits cleanly.