### PR TITLE
fix(macos): wire up is_checking_zoomed_in guard in is_zoomed()

### DIFF
--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -499,6 +499,44 @@ impl From<WindowAttributes> for SharedState {
   }
 }
 
+/// RAII guard that sets `is_checking_zoomed_in` on the window delegate while
+/// the style mask is being temporarily toggled in `is_zoomed()`. This suppresses
+/// spurious `windowDidResize:`/`windowDidMove:` events that would otherwise
+/// create an infinite feedback loop when user code calls `is_maximized()` inside
+/// an event handler. The flag is always cleared on drop, even during unwind.
+struct ZoomCheckGuard {
+  delegate: id,
+}
+
+impl ZoomCheckGuard {
+  fn new(ns_window: &NSWindow) -> Self {
+    // SAFETY: The delegate is retained by ns_window for the duration of this
+    // synchronous, main-thread-only call. The guard does not outlive is_zoomed(),
+    // and the window (and thus its delegate) is kept alive by the caller's
+    // Retained<NSWindow>. The delegate pointer is !Send/!Sync by default (raw
+    // pointer), which correctly prevents use from other threads.
+    unsafe {
+      let delegate: id = msg_send![ns_window, delegate];
+      if !delegate.is_null() {
+        let _: () = msg_send![delegate, markIsCheckingZoomedIn];
+      }
+      Self { delegate }
+    }
+  }
+}
+
+impl Drop for ZoomCheckGuard {
+  fn drop(&mut self) {
+    // SAFETY: clearIsCheckingZoomedIn is always registered on the TaoWindowDelegate
+    // class (window_delegate.rs) and cannot fail. Sending to nil is a no-op in ObjC.
+    if !self.delegate.is_null() {
+      unsafe {
+        let _: () = msg_send![self.delegate, clearIsCheckingZoomedIn];
+      }
+    }
+  }
+}
+
 pub struct UnownedWindow {
   pub ns_window: Retained<NSWindow>, // never changes
   pub ns_view: Retained<NSView>,     // never changes
@@ -974,22 +1012,27 @@ impl UnownedWindow {
   }
 
   pub(crate) fn is_zoomed(&self) -> bool {
-    // because `isZoomed` doesn't work if the window's borderless,
-    // we make it resizable temporalily.
+    debug_assert!(
+      util::is_main_thread(),
+      "is_zoomed() must be called from the main thread"
+    );
+
+    // Because `isZoomed` doesn't work if the window's borderless,
+    // we make it resizable temporarily.
     let curr_mask = unsafe { self.ns_window.styleMask() };
-
     let required = NSWindowStyleMask::Titled | NSWindowStyleMask::Resizable;
-    let needs_temp_mask = !curr_mask.contains(required);
-    if needs_temp_mask {
-      self.set_style_mask_sync(required);
+
+    if curr_mask.contains(required) {
+      return unsafe { self.ns_window.isZoomed() };
     }
 
+    // Suppress spurious windowDidResize:/windowDidMove: events fired by
+    // setStyleMask:. The RAII guard ensures the flag is always cleared.
+    let _guard = ZoomCheckGuard::new(&self.ns_window);
+    self.set_style_mask_sync(required);
     let is_zoomed: bool = unsafe { self.ns_window.isZoomed() };
-
-    // Roll back temp styles
-    if needs_temp_mask {
-      self.set_style_mask_sync(curr_mask);
-    }
+    self.set_style_mask_sync(curr_mask);
+    // _guard dropped here, clearing is_checking_zoomed_in
 
     is_zoomed
   }

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -358,7 +358,9 @@ extern "C" fn window_did_resize(this: &Object, _: Sel, _: id) {
 extern "C" fn window_did_move(this: &Object, _: Sel, _: id) {
   trace!("Triggered `windowDidMove:`");
   with_state(this, |state| {
-    state.emit_move_event();
+    if !state.is_checking_zoomed_in {
+      state.emit_move_event();
+    }
   });
   trace!("Completed `windowDidMove:`");
 }


### PR DESCRIPTION
## Summary

- **Wire up the existing `is_checking_zoomed_in` guard** that was designed to suppress spurious `windowDidResize:`/`windowDidMove:` events during `is_zoomed()`'s temporary style mask toggle, but was never connected
- **Add RAII `ZoomCheckGuard`** struct to ensure the flag is always cleared, even on panic/unwind
- **Guard `windowDidMove:`** with the same `is_checking_zoomed_in` check that `windowDidResize:` already has
- **Add `debug_assert!`** for main-thread-only access in `is_zoomed()`

## Problem

Calling `is_maximized()` inside a window event listener on macOS causes 100% CPU and memory leaks. `is_zoomed()` temporarily toggles the window's style mask to `Titled | Resizable` (because `NSWindow.isZoomed()` doesn't work on borderless windows), which fires `windowDidResize:` on the delegate. If user code calls `is_maximized()` in the resize handler, it re-enters `is_zoomed()` — creating an infinite feedback loop.

On macOS 15 Sequoia, this also triggers `NSThemeFrame.newZoomButton` to create `_NSThemeZoomWidget` objects on every layout pass, compounding the CPU issue with memory leaks.

## Root Cause

The guard infrastructure already existed but was never wired up:
- `window_delegate.rs` defines `is_checking_zoomed_in: bool` and `markIsCheckingZoomedIn`/`clearIsCheckingZoomedIn` methods
- `windowDidResize:` already checks this flag and suppresses events when `true`
- **But `is_zoomed()` in `window.rs` never called these methods** before toggling the style mask

## Testing

Reproduction branches with a `maximize_check` example (borderless window calling `is_maximized()` in resize handler):

| Branch | What it shows |
|--------|---------------|
| [`repro/is-maximized-cpu-spike-before`](https://github.com/afonsojramos/tao/tree/repro/is-maximized-cpu-spike-before) | **Bug**: CPU spikes to 100% on resize |
| [`repro/is-maximized-cpu-spike-after`](https://github.com/afonsojramos/tao/tree/repro/is-maximized-cpu-spike-after) | **Fixed**: CPU stays idle on resize |

```bash
# Before fix — CPU spikes to 100%
git checkout repro/is-maximized-cpu-spike-before
cargo run --example maximize_check

# After fix — CPU stays idle
git checkout repro/is-maximized-cpu-spike-after
cargo run --example maximize_check
```

All existing tests pass (`cargo test --all`).

## Related Issues

- https://github.com/tauri-apps/tauri/issues/13199 — isMaximized() causes infinite loop on macOS
- https://github.com/tauri-apps/tauri/issues/6577 — CSS performance on macOS
- https://github.com/hoppscotch/hoppscotch/issues/3990 — 200% CPU usage on macOS when idle
- https://github.com/tauri-apps/tauri/issues/6754 — Window resize causes memory spike and crash