### PR TITLE
fix(mac): fix creating new windows while in fullscreen

### DIFF
--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -209,10 +209,29 @@ pub unsafe fn order_out_sync(ns_window: &NSWindow) {
 
 // `makeKeyAndOrderFront:` isn't thread-safe. Calling it from another thread
 // actually works, but with an odd delay.
-pub unsafe fn make_key_and_order_front_sync(ns_window: &NSWindow) {
+//
+// This has to be `exec_async` not `run_on_main` because showing a window from
+// a fullscreen window hangs the app since it triggers a Space transition animation
+// that needs the Cocoa run loop to pump, and synchronous calls like showing from
+// inside the event loop callback means the run loop cannot pump and thus deadlocks.
+// Async dispatch returns immediately and the show executes on the next run after the callback returns.
+pub unsafe fn make_key_and_order_front_async(ns_window: &NSWindow) {
   let ns_window = MainThreadSafe(ns_window.retain());
-  run_on_main(move || {
+  DispatchQueue::main().exec_async(move || {
     ns_window.makeKeyAndOrderFront(None);
+  });
+}
+
+// `order_front_async:` isn't thread-safe. Calling it from another thread
+// actually works, but with an odd delay.
+//
+// Non-focusing variant of `make_key_and_order_front_async`.
+// Uses async dispatch for the same reason.
+// Shows the window without making it key.
+pub unsafe fn order_front_async(ns_window: &NSWindow) {
+  let ns_window = MainThreadSafe(ns_window.retain());
+  DispatchQueue::main().exec_async(move || {
+    ns_window.orderFront(None);
   });
 }
 
@@ -227,10 +246,11 @@ pub unsafe fn set_title_async(ns_window: &NSWindow, title: String) {
   });
 }
 
-// `setFocus:` isn't thread-safe.
+// `setFocus:` isn't thread-safe. Uses async dispatch for the same reason
+// as `make_key_and_order_front_async`.
 pub unsafe fn set_focus(ns_window: &NSWindow) {
   let ns_window = MainThreadSafe(ns_window.retain());
-  run_on_main(move || {
+  DispatchQueue::main().exec_async(move || {
     ns_window.makeKeyAndOrderFront(None);
     let app: id = msg_send![class!(NSApplication), sharedApplication];
     let () = msg_send![app, activateIgnoringOtherApps: YES];
@@ -238,10 +258,10 @@ pub unsafe fn set_focus(ns_window: &NSWindow) {
 }
 
 // `close:` is thread-safe, but we want the event to be triggered from the main
-// thread. Though, it's a good idea to look into that more...
+// thread. Uses async dispatch to avoid blocking the caller.
 pub unsafe fn close_async(ns_window: &NSWindow) {
   let ns_window = MainThreadSafe(ns_window.retain());
-  run_on_main(move || {
+  DispatchQueue::main().exec_async(move || {
     autoreleasepool(move |_| {
       ns_window.close();
     });

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -630,9 +630,9 @@ impl UnownedWindow {
     if visible {
       if focused {
         // Tightly linked with `app_state::window_activation_hack`
-        unsafe { window.ns_window.makeKeyAndOrderFront(None) };
+        unsafe { util::make_key_and_order_front_async(&window.ns_window) };
       } else {
-        unsafe { window.ns_window.orderFront(None) };
+        unsafe { util::order_front_async(&window.ns_window) };
       }
     }
 
@@ -667,7 +667,7 @@ impl UnownedWindow {
 
   pub fn set_visible(&self, visible: bool) {
     match visible {
-      true => unsafe { util::make_key_and_order_front_sync(&self.ns_window) },
+      true => unsafe { util::make_key_and_order_front_async(&self.ns_window) },
       false => unsafe { util::order_out_sync(&self.ns_window) },
     }
   }


### PR DESCRIPTION
on macOS, the `set_visible(true)`, `set_focus()`, and `WindowBuilder::build()` with `visible=true` all deadlock when called from inside the event loop callback while another window is in fullscreen. There's no way to detect or prevent this without pulling in objc2, which is nasty in code that should be platform agnostic.

The problem is that `make_key_and_order_front_sync()` uses `run_on_main()` to call `makeKeyAndOrderFront:` which triggers a macOS Space transition animation when another window is in fullscreen. The animation needs the Cocoa run loop to pump events, but the run loop is blocked waiting for the event loop callback to return, so it deadlocks.

This PR fixes this by just making `make_key_and_order_front_sync` and related helpers to use `DispatchQueue::main().exec_async()` instead of `run_on_main()`, like most other operations in the file.

Repro:

Run this app:
```
use tao::event::{Event, StartCause, WindowEvent};
use tao::event_loop::{ControlFlow, EventLoop};
use tao::window::{Fullscreen, WindowBuilder};

fn main() {
  let event_loop = EventLoop::new();
  let window = WindowBuilder::new()
    .with_title("mac bug repro")
    .build(&event_loop)
    .unwrap();
  let mut second_window: Option<tao::window::Window> = None;
  event_loop.run(move |event, event_loop, control_flow| {
    *control_flow = ControlFlow::Wait;
    match event {
      Event::WindowEvent {
        event: WindowEvent::KeyboardInput { .. },
        ..
      } => {
        second_window = Some(
          WindowBuilder::new()
            .with_title("Second Window")
            .build(event_loop)
            .unwrap(),
        );
      }
      Event::WindowEvent {
        event: WindowEvent::CloseRequested,
        ..
      } => {
        *control_flow = ControlFlow::Exit;
      }
      _ => {}
    }
  });
}
```

Press a key to spawn another window

Use this menu option to enter split-screen with the other window of the same app
<img width="397" height="326" alt="image" src="https://github.com/user-attachments/assets/8a82d722-0458-451d-8d36-841180133889" />

Press a key

Before fix behavior: deadlock/hang
After fix: no deadlock, it spawns windows tabbed.