### PR TITLE
fix(windows): paint window background_color in WM_PAINT; add borderless_fixed example

### DIFF
--- a/.changes/fix-windows-background-color-undecorated.md
+++ b/.changes/fix-windows-background-color-undecorated.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix `WindowBuilder::with_background_color` on Windows for undecorated windows by painting the configured color during `WM_PAINT` (in addition to `WM_ERASEBKGND`). Add `borderless_fixed` example (500×600, undecorated, non-resizable, gray background, drag to move).

--- a/examples/borderless_fixed.rs
+++ b/examples/borderless_fixed.rs
@@ -1,0 +1,47 @@
+// Copyright 2014-2021 The winit contributors
+// Copyright 2021-2023 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+
+//! Undecorated (borderless) 500×600 window with a gray client background — no system title bar
+//! and not resizable. Drag with the left mouse button to move the window.
+
+use tao::{
+  dpi::LogicalSize,
+  event::{ElementState, Event, MouseButton, WindowEvent},
+  event_loop::{ControlFlow, EventLoop},
+  window::WindowBuilder,
+};
+
+#[allow(clippy::single_match)]
+fn main() {
+  env_logger::init();
+  let event_loop = EventLoop::new();
+
+  let window = WindowBuilder::new()
+    .with_title("Borderless + fixed size — drag to move")
+    .with_inner_size(LogicalSize::new(500.0, 600.0))
+    .with_background_color((192, 192, 192, 255))
+    .with_decorations(false)
+    .with_resizable(false)
+    .build(&event_loop)
+    .unwrap();
+
+  event_loop.run(move |event, _, control_flow| {
+    *control_flow = ControlFlow::Wait;
+
+    match event {
+      Event::WindowEvent { event, .. } => match event {
+        WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+        WindowEvent::MouseInput {
+          state: ElementState::Pressed,
+          button: MouseButton::Left,
+          ..
+        } => {
+          let _ = window.drag_window();
+        }
+        _ => (),
+      },
+      _ => (),
+    };
+  });
+}

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1085,6 +1085,21 @@ unsafe fn public_window_callback_inner<T: 'static>(
     }
 
     win32wm::WM_PAINT => {
+      // `WM_ERASEBKGND` alone is unreliable for some styles (e.g. undecorated windows); painting the
+      // solid color here matches user expectations for `WindowAttributes::background_color`.
+      let background_color = subclass_input.window_state.lock().background_color;
+      let painted_client_background = background_color.is_some();
+      if let Some(color) = background_color {
+        let mut ps = PAINTSTRUCT::default();
+        let hdc = BeginPaint(window, &mut ps);
+        if !hdc.is_invalid() {
+          let brush = CreateSolidBrush(util::RGB(color.0, color.1, color.2));
+          let _ = FillRect(hdc, &ps.rcPaint, brush);
+          let _ = DeleteObject(brush.into());
+        }
+        let _ = EndPaint(window, &ps);
+      }
+
       if subclass_input.event_loop_runner.should_buffer() {
         // this branch can happen in response to `UpdateWindow`, if win32 decides to
         // redraw the window outside the normal flow of the event loop.
@@ -1098,6 +1113,10 @@ unsafe fn public_window_callback_inner<T: 'static>(
           subclass_input.event_loop_runner.redraw_events_cleared();
           process_control_flow(&subclass_input.event_loop_runner);
         }
+      }
+
+      if painted_client_background {
+        result = ProcResult::Value(LRESULT(0));
       }
     }
 


### PR DESCRIPTION
### What this PR does

- Add `borderless_fixed` example: 500×600, undecorated, non-resizable, drag to move (with gray `background_color`).
- Windows: paint `background_color` in `WM_PAINT` so the solid color shows reliably on **undecorated** windows (`WM_ERASEBKGND` alone was often insufficient).

### Motivation

Undecorated windows frequently did not show `with_background_color` / `set_background_color` as users expect; handling the fill in `WM_PAINT` matches common Win32 practice for custom client backgrounds.
<img width="555" height="635" alt="QQ20260329-202331" src="https://github.com/user-attachments/assets/b801ecd4-8c18-46da-b76d-41a42cb2dcea" />

### Test plan

- [ ] `cargo test` (full suite)
- [ ] `cargo run --example borderless_fixed` on Windows — gray client area, drag-to-move, close
- [ ] (optional) Decorated window with `with_background_color` still correct

### Checklist

- [x] Change file added under `.changes/` (patch)
- [ ] Commits signed (per [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits))

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Made-with: Cursor