### PR TITLE
fix(windows): Fix cursor visibility toggle not working on Windows

### DIFF
--- a/.changes/fix-windows-cursor.md
+++ b/.changes/fix-windows-cursor.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix cursor visibility not working on window creation and over child windows (like WebView2) on Windows. Closes tauri-apps/tauri#10231

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1813,7 +1813,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         // `WM_MOUSEMOVE` seems to come after `WM_SETCURSOR` for a given cursor movement.
         let in_client_area = u32::from(util::LOWORD(lparam.0 as u32)) == HTCLIENT;
         let is_hidden = window_state.mouse.cursor_flags().contains(CursorFlags::HIDDEN);
-        if is_hidden {
+        if is_hidden && in_client_area {
           (None, true)
         } else if in_client_area {
           (Some(window_state.mouse.cursor), false)

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1830,37 +1830,32 @@ unsafe fn public_window_callback_inner<T: 'static>(
     }
 
     win32wm::WM_SETCURSOR => {
-      let (set_cursor_to, is_cursor_hidden) = {
-        let window_state = userdata.window_state.lock();
-        // The return value for the preceding `WM_NCHITTEST` message is conveniently
-        // provided through the low-order word of lParam. We use that here since
-        // `WM_MOUSEMOVE` seems to come after `WM_SETCURSOR` for a given cursor movement.
-        let in_client_area = u32::from(util::LOWORD(lparam.0 as u32)) == HTCLIENT;
-        let is_hidden = window_state
-          .mouse
-          .cursor_flags()
-          .contains(CursorFlags::HIDDEN);
-        if is_hidden && in_client_area {
-          (None, true)
-        } else if in_client_area {
-          (Some(window_state.mouse.cursor), false)
-        } else {
-          (None, false)
-        }
-      };
+      let window_state = userdata.window_state.lock();
+      // The low-order word of lParam contains the hit-test result (e.g., HTCLIENT).
+      // Additionally, wParam contains the HWND under the cursor. If it is not
+      // our own window (e.g., it's a child window like WebView2), we delegate
+      // to DefWindowProc to avoid overwriting its cursor settings.
+      let in_client_area = u32::from(util::LOWORD(lparam.0 as u32)) == HTCLIENT;
+      let is_hidden = window_state
+        .mouse
+        .cursor_flags()
+        .contains(CursorFlags::HIDDEN);
+      let cursor = window_state.mouse.cursor;
+      drop(window_state);
 
-      if is_cursor_hidden {
+      let is_cursor_over_foreign_hwnd = HWND(wparam.0 as *mut _) != window;
+
+      if is_cursor_over_foreign_hwnd || !in_client_area {
+        result = ProcResult::DefWindowProc;
+      } else if is_hidden {
         SetCursor(None);
         result = ProcResult::Value(LRESULT(1));
       } else {
-        match set_cursor_to {
-          Some(cursor) => {
-            if let Ok(cursor) = LoadCursorW(None, cursor.to_windows_cursor()) {
-              SetCursor(Some(cursor));
-            }
-            result = ProcResult::Value(LRESULT(1));
-          }
-          None => result = ProcResult::DefWindowProc,
+        if let Ok(cursor) = LoadCursorW(None, cursor.to_windows_cursor()) {
+          SetCursor(Some(cursor));
+          result = ProcResult::Value(LRESULT(1));
+        } else {
+          result = ProcResult::DefWindowProc;
         }
       }
     }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1806,27 +1806,35 @@ unsafe fn public_window_callback_inner<T: 'static>(
     }
 
     win32wm::WM_SETCURSOR => {
-      let set_cursor_to = {
+      let (set_cursor_to, is_cursor_hidden) = {
         let window_state = subclass_input.window_state.lock();
         // The return value for the preceding `WM_NCHITTEST` message is conveniently
         // provided through the low-order word of lParam. We use that here since
         // `WM_MOUSEMOVE` seems to come after `WM_SETCURSOR` for a given cursor movement.
         let in_client_area = u32::from(util::LOWORD(lparam.0 as u32)) == HTCLIENT;
-        if in_client_area {
-          Some(window_state.mouse.cursor)
+        let is_hidden = window_state.mouse.cursor_flags().contains(CursorFlags::HIDDEN);
+        if is_hidden {
+          (None, true)
+        } else if in_client_area {
+          (Some(window_state.mouse.cursor), false)
         } else {
-          None
+          (None, false)
         }
       };
 
-      match set_cursor_to {
-        Some(cursor) => {
-          if let Ok(cursor) = LoadCursorW(None, cursor.to_windows_cursor()) {
-            SetCursor(Some(cursor));
+      if is_cursor_hidden {
+        SetCursor(None);
+        result = ProcResult::Value(LRESULT(1));
+      } else {
+        match set_cursor_to {
+          Some(cursor) => {
+            if let Ok(cursor) = LoadCursorW(None, cursor.to_windows_cursor()) {
+              SetCursor(Some(cursor));
+            }
+            result = ProcResult::Value(LRESULT(1));
           }
-          result = ProcResult::Value(LRESULT(0));
+          None => result = ProcResult::DefWindowProc,
         }
-        None => result = ProcResult::DefWindowProc,
       }
     }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1812,7 +1812,10 @@ unsafe fn public_window_callback_inner<T: 'static>(
         // provided through the low-order word of lParam. We use that here since
         // `WM_MOUSEMOVE` seems to come after `WM_SETCURSOR` for a given cursor movement.
         let in_client_area = u32::from(util::LOWORD(lparam.0 as u32)) == HTCLIENT;
-        let is_hidden = window_state.mouse.cursor_flags().contains(CursorFlags::HIDDEN);
+        let is_hidden = window_state
+          .mouse
+          .cursor_flags()
+          .contains(CursorFlags::HIDDEN);
         if is_hidden && in_client_area {
           (None, true)
         } else if in_client_area {

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -12,8 +12,8 @@ use crate::{
 use parking_lot::MutexGuard;
 use std::io;
 use windows::Win32::{
-  Foundation::{HWND, LPARAM, RECT, WPARAM},
-  Graphics::Gdi::InvalidateRgn,
+  Foundation::{HWND, LPARAM, POINT, RECT, WPARAM},
+  Graphics::Gdi::{InvalidateRgn, ScreenToClient},
   UI::WindowsAndMessaging::*,
 };
 
@@ -501,7 +501,21 @@ impl CursorFlags {
       }
     }
 
-    let cursor_in_client = self.contains(CursorFlags::IN_WINDOW);
+    let cursor_in_client = unsafe {
+      let mut pt = POINT::default();
+      if GetCursorPos(&mut pt).is_ok() {
+        let mut pt_client = pt;
+        let mut rect = RECT::default();
+        ScreenToClient(window, &mut pt_client).as_bool()
+          && GetClientRect(window, &mut rect).is_ok()
+          && pt_client.x >= 0
+          && pt_client.x < rect.right
+          && pt_client.y >= 0
+          && pt_client.y < rect.bottom
+      } else {
+        self.contains(CursorFlags::IN_WINDOW)
+      }
+    };
     if cursor_in_client {
       util::set_cursor_hidden(self.contains(CursorFlags::HIDDEN));
     } else {


### PR DESCRIPTION
## Summary

This PR fixes an issue where `window.set_cursor_visible(false)` does not work correctly on Windows.

## Tests

1. cargo test -> PASS
2. cargo fmt --check -> PASS
3. cargo clippy -- -D warnings -> PASS only for the scope of this PR. There are multiple warnings in the code unrelated to this PR, which are not addressed.
4. Added `main_window.set_cursor_visible(false);` to line 41 of `tao\examples\parentwindow.rs` and tested. See the video.
5. Tested with `tao\examples\cursor.rs`. Works normally.
6. Created a test TauriApp and tested the behavior. See the video.
Setup - Created a new Tauri command and implemented it to be called from the frontend:
```rust
// src-tauri\src\lib.rs
#[tauri::command]
fn hide_cursor(window: tauri::WebviewWindow) {
    let _ = window.set_cursor_visible(false);
}

#[tauri::command]
fn show_cursor(window: tauri::WebviewWindow) {
    let _ = window.set_cursor_visible(true);
}
```

https://github.com/user-attachments/assets/1d970ba3-765e-433c-bc99-c2bf98e4c735

## Environment

```bash
rustup show
Default host: x86_64-pc-windows-msvc
rustup home:  C:\Users\keufcp\.rustup

installed toolchains
--------------------
stable-x86_64-pc-windows-msvc (active, default)

active toolchain
----------------
name: stable-x86_64-pc-windows-msvc
active because: it's the default toolchain
installed targets:
  aarch64-linux-android
  wasm32-unknown-unknown
  wasm32-wasip2
  x86_64-linux-android
  x86_64-pc-windows-msvc

```

```
OS name:                 Microsoft Windows 11 Pro
OS version:              10.0.26200 N/A Build 26200
BIOS version:            American Megatrends Inc. 1825, 2025/10/09
```

Closes tauri-apps/tauri#10231