### PR TITLE
fix(linux): don't unwrap None in CursorIgnoreEvents handler

### DIFF
--- a/src/platform_impl/linux/event_loop.rs
+++ b/src/platform_impl/linux/event_loop.rs
@@ -442,11 +442,15 @@ impl<T: 'static> EventLoop<T> {
           }
           WindowRequest::CursorIgnoreEvents(ignore) => {
             if ignore {
-              let empty_region = Region::create_rectangle(&RectangleInt::new(0, 0, 1, 1));
-              window
-                .window()
-                .unwrap()
-                .input_shape_combine_region(&empty_region, 0, 0);
+              // `window.window()` is None until the GdkWindow is realized.
+              // Tauri/wry can send CursorIgnoreEvents before a transparent
+              // or initially-hidden window is mapped, and the bare unwrap
+              // aborts the whole GTK main loop with a non-unwinding panic.
+              // Silently skipping keeps the event loop alive.
+              if let Some(gdk_window) = window.window() {
+                let empty_region = Region::create_rectangle(&RectangleInt::new(0, 0, 1, 1));
+                gdk_window.input_shape_combine_region(&empty_region, 0, 0);
+              }
             } else {
               window.input_shape_combine_region(None)
             };


### PR DESCRIPTION
## Which issue(s) this PR fixes:

Closes #1178

## What kind of change does this PR introduce?

Bug fix — replaces a bare `.unwrap()` that crosses a non-unwinding GTK main-loop boundary and aborts the whole process.

## Scenario

Creating a window with `transparent(true)` and `visible(false)` and later dispatching `CursorIgnoreEvents(true)` on it (which Tauri/wry does during setup for hidden popover-style windows) panics at `src/platform_impl/linux/event_loop.rs:448`:

```
thread 'main' panicked at tao-0.34.8/src/platform_impl/linux/event_loop.rs:448:18:
called `Option::unwrap()` on a `None` value
panic in a function that cannot unwind
```

`gtk::Window::window()` returns `None` until the underlying `GdkWindow` is realized. When the request is processed before realize, the `.unwrap()` blows up, and because the call lives inside the GTK main-context channel dispatcher (a non-unwinding C boundary), the panic becomes a hard abort and takes the whole event loop down. Users of downstream apps (Tauri v2 on modern Linux distros: Fedora 43+/Wayland, Arch, etc.) see the window flash white and die.

Reported repeatedly on Wayland — #1178 and various Tauri issues.

## How was the bug fixed?

`if let Some(gdk_window) = window.window()` instead of the bare unwrap. If the GdkWindow isn't available yet, skip — the event loop keeps running and the caller can re-send `CursorIgnoreEvents(true)` after the window is mapped (this is idempotent). The behaviour matches the `else` branch right below, which already operates on `gtk::Window` directly without touching the GdkWindow.

No behaviour change for callers that wait for realize before calling `set_ignore_cursor_events`. Callers that don't previously crashed the app — now they silently no-op until realize.

## Reproduction

Minimal Tauri v2 app on Fedora 43 / Wayland / aarch64 with a transparent, hidden window created via `WebviewWindowBuilder::new(...).transparent(true).visible(false).build()`. Same setup used by the Hat-Cross project where this was caught.

## Checklist

- [x] Ran cargo fmt locally (pure replacement of unwrap with if-let, no formatting drift)
- [x] Added a comment explaining the why
- [x] Tested locally — downstream app that used to panic on startup now runs cleanly on Fedora 43 aarch64 / Wayland with the fork applied via `[patch.crates-io]`