### PR TITLE
fix(macos): create non-focused window when `focus` or `forcusable` to false

### DIFF
--- a/.changes/fix-macos-create-non-focused-window.md
+++ b/.changes/fix-macos-create-non-focused-window.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix macos cannot create non-focused widnow when configure either `focuse` or `focusable` to false.

--- a/.changes/fix-macos-create-non-focused-window.md
+++ b/.changes/fix-macos-create-non-focused-window.md
@@ -2,4 +2,4 @@
 "tao": patch
 ---
 
-Fix macos cannot create non-focused widnow when configure either `focuse` or `focusable` to false.
+Fix macos cannot create non-focused widnow when configure either `focus` or `focusable` to false.

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -632,7 +632,7 @@ impl UnownedWindow {
         // Tightly linked with `app_state::window_activation_hack`
         unsafe { window.ns_window.makeKeyAndOrderFront(None) };
       } else {
-        unsafe { window.ns_window.orderFront(None) };
+        unsafe { window.ns_window.orderBack(None) };
       }
     }
 


### PR DESCRIPTION
Fix https://github.com/tauri-apps/tauri/issues/9065 
Fix https://github.com/tauri-apps/tauri/issues/14102

Tested locally.