### PR TITLE
fix(android): don't panic on getCurrentWindowMetrics on API<30

### DIFF
--- a/.changes/change-pr-1211.md
+++ b/.changes/change-pr-1211.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+fix(android): don't panic on getCurrentWindowMetrics on API<30

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -865,35 +865,44 @@ impl MonitorHandle {
     let Some(ctx) = ndk_glue::main_android_context() else {
       return PhysicalSize::new(0, 0);
     };
-    let vm = unsafe { jni::JavaVM::from_raw(ctx.java_vm.cast()) }.unwrap();
-    let mut env = vm.attach_current_thread().unwrap();
+    let Ok(vm) = (unsafe { jni::JavaVM::from_raw(ctx.java_vm.cast()) }) else {
+      return PhysicalSize::new(0, 0);
+    };
+    let Ok(mut env) = vm.attach_current_thread() else {
+      return PhysicalSize::new(0, 0);
+    };
     let window_manager = w.as_obj();
-    let metrics = env
-      .call_method(
-        window_manager,
-        "getCurrentWindowMetrics",
-        "()Landroid/view/WindowMetrics;",
-        &[],
-      )
-      .unwrap()
-      .l()
-      .unwrap();
-    let rect = env
-      .call_method(&metrics, "getBounds", "()Landroid/graphics/Rect;", &[])
-      .unwrap()
-      .l()
-      .unwrap();
-    let width = env
-      .call_method(&rect, "width", "()I", &[])
-      .unwrap()
-      .i()
-      .unwrap();
-    let height = env
-      .call_method(&rect, "height", "()I", &[])
-      .unwrap()
-      .i()
-      .unwrap();
-    PhysicalSize::new(width as u32, height as u32)
+
+    // getCurrentWindowMetrics requires Android R (API 30) — on older devices
+    // it raises NoSuchMethodError. Clear any pending JNI exception and fall
+    // back to a zero size; bubbling up the JavaException as a Rust panic
+    // crashes the whole app at startup on Android < 11.
+    let metrics_size = (|| -> Option<PhysicalSize<u32>> {
+      let metrics = env
+        .call_method(
+          window_manager,
+          "getCurrentWindowMetrics",
+          "()Landroid/view/WindowMetrics;",
+          &[],
+        )
+        .ok()?
+        .l()
+        .ok()?;
+      let rect = env
+        .call_method(&metrics, "getBounds", "()Landroid/graphics/Rect;", &[])
+        .ok()?
+        .l()
+        .ok()?;
+      let width = env.call_method(&rect, "width", "()I", &[]).ok()?.i().ok()?;
+      let height = env.call_method(&rect, "height", "()I", &[]).ok()?.i().ok()?;
+      Some(PhysicalSize::new(width as u32, height as u32))
+    })();
+
+    if metrics_size.is_none() && env.exception_check().unwrap_or(false) {
+      let _ = env.exception_clear();
+    }
+
+    metrics_size.unwrap_or(PhysicalSize::new(0, 0))
   }
 
   pub fn position(&self) -> PhysicalPosition<i32> {

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -894,7 +894,11 @@ impl MonitorHandle {
         .l()
         .ok()?;
       let width = env.call_method(&rect, "width", "()I", &[]).ok()?.i().ok()?;
-      let height = env.call_method(&rect, "height", "()I", &[]).ok()?.i().ok()?;
+      let height = env
+        .call_method(&rect, "height", "()I", &[])
+        .ok()?
+        .i()
+        .ok()?;
       Some(PhysicalSize::new(width as u32, height as u32))
     })();
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -947,6 +947,63 @@ pub(crate) use crate::icon::NoIcon as PlatformIcon;
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct MonitorHandle;
 
+fn current_window_metrics_size(
+  env: &mut jni::JNIEnv<'_>,
+  window_manager: &jni::objects::JObject<'_>,
+) -> Option<PhysicalSize<u32>> {
+  let metrics = jni_call_method!(
+    env,
+    window_manager,
+    "getCurrentWindowMetrics",
+    "()Landroid/view/WindowMetrics;",
+    l
+  )
+  .ok()?;
+
+  let rect = jni_call_method!(env, &metrics, "getBounds", "()Landroid/graphics/Rect;", l).ok()?;
+  let width = jni_call_method!(env, &rect, "width", "()I", i).ok()?;
+  let height = jni_call_method!(env, &rect, "height", "()I", i).ok()?;
+  Some(PhysicalSize::new(width as u32, height as u32))
+}
+
+fn legacy_display_metrics_size(
+  env: &mut jni::JNIEnv<'_>,
+  window_manager: &jni::objects::JObject<'_>,
+) -> Option<PhysicalSize<u32>> {
+  let display = jni_call_method!(
+    env,
+    window_manager,
+    "getDefaultDisplay",
+    "()Landroid/view/Display;",
+    l
+  )
+  .ok()?;
+  let display_metrics = env
+    .new_object("android/util/DisplayMetrics", "()V", &[])
+    .ok()?;
+
+  jni_call_method!(
+    env,
+    &display,
+    "getRealMetrics",
+    "(Landroid/util/DisplayMetrics;)V",
+    &[(&display_metrics).into()],
+    v
+  )
+  .ok()?;
+
+  let width = env
+    .get_field(&display_metrics, "widthPixels", "I")
+    .and_then(|v| v.i())
+    .ok()?;
+  let height = env
+    .get_field(&display_metrics, "heightPixels", "I")
+    .and_then(|v| v.i())
+    .ok()?;
+
+  Some(PhysicalSize::new(width as u32, height as u32))
+}
+
 impl MonitorHandle {
   pub fn name(&self) -> Option<String> {
     Some("Android Device".to_owned())
@@ -971,26 +1028,16 @@ impl MonitorHandle {
     };
     let window_manager = w.as_obj();
 
-    // getCurrentWindowMetrics requires Android R (API 30) — on older devices
-    // it raises NoSuchMethodError. Clear any pending JNI exception and fall
-    // back to a zero size; bubbling up the JavaException as a Rust panic
-    // crashes the whole app at startup on Android < 11.
-    let metrics_size = (|| -> Option<PhysicalSize<u32>> {
-      let metrics = jni_call_method!(
-        env,
-        window_manager,
-        "getCurrentWindowMetrics",
-        "()Landroid/view/WindowMetrics;",
-        l
-      )
-      .ok()?;
+    let sdk_int = env
+      .get_static_field("android/os/Build$VERSION", "SDK_INT", "I")
+      .and_then(|v| v.i())
+      .unwrap_or(0);
 
-      let rect =
-        jni_call_method!(env, &metrics, "getBounds", "()Landroid/graphics/Rect;", l).ok()?;
-      let width = jni_call_method!(env, &rect, "width", "()I", i).ok()?;
-      let height = jni_call_method!(env, &rect, "height", "()I", i).ok()?;
-      Some(PhysicalSize::new(width as u32, height as u32))
-    })();
+    let metrics_size = if sdk_int >= 30 {
+      current_window_metrics_size(&mut env, window_manager)
+    } else {
+      legacy_display_metrics_size(&mut env, window_manager)
+    };
 
     if metrics_size.is_none() && env.exception_check().unwrap_or(false) {
       let _ = env.exception_clear();


### PR DESCRIPTION
Addresses the Android 10 startup panic reported in DioxusLabs/dioxus#5149.

`MonitorHandle::size()` JNI-calls `getCurrentWindowMetrics`, which only exists on Android R (API 30+). On older devices it raises `NoSuchMethodError` and the chained `.unwrap()`s turn the JavaException into a hard process panic at startup. Catch the call failures, clear any pending JNI exception so the next JNI call doesn't blow up, and fall back to `PhysicalSize(0,0)` — the same fallback the function already uses when `window_manager` or the Android context is missing.