### PR TITLE
feat(macos): expose CrApp protocol on TaoApp

### DIFF
--- a/.changes/macos-crapp-protocol.md
+++ b/.changes/macos-crapp-protocol.md
@@ -1,0 +1,10 @@
+---
+"tao": minor
+---
+
+On macOS, expose the CrApp protocol (`isHandlingSendEvent` /
+`setHandlingSendEvent:`) on the `TaoApp` `NSApplication` subclass.
+This lets a Chromium / CEF embedder coordinate its event-pump work
+with the host's `sendEvent:` dispatch without having to subclass or
+swizzle `NSApp` itself. Purely additive — existing tao users see no
+behavior change because nothing else calls these selectors.

--- a/src/platform_impl/macos/app.rs
+++ b/src/platform_impl/macos/app.rs
@@ -2,9 +2,13 @@
 // Copyright 2021-2023 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::VecDeque, ffi::CStr};
+use std::{
+  collections::VecDeque,
+  ffi::CStr,
+  sync::atomic::{AtomicBool, Ordering},
+};
 
-use objc2::runtime::{AnyClass as Class, ClassBuilder as ClassDecl, Sel};
+use objc2::runtime::{AnyClass as Class, Bool as ObjcBool, ClassBuilder as ClassDecl, Sel};
 use objc2_app_kit::{self as appkit, NSApplication, NSEvent, NSEventType};
 use once_cell::sync::Lazy;
 
@@ -15,6 +19,13 @@ pub struct AppClass(pub *const Class);
 unsafe impl Send for AppClass {}
 unsafe impl Sync for AppClass {}
 
+/// Tracks whether `NSApp` is currently dispatching `sendEvent:`.
+/// Exposed via the `isHandlingSendEvent` / `setHandlingSendEvent:`
+/// methods (the CrApp protocol Chromium / CEF expects from the host
+/// `NSApplication` subclass). A single static `AtomicBool` is correct
+/// because `NSApplication` is a process-wide singleton.
+static IS_HANDLING_SEND_EVENT: AtomicBool = AtomicBool::new(false);
+
 pub static APP_CLASS: Lazy<AppClass> = Lazy::new(|| unsafe {
   let superclass = class!(NSApplication);
   let mut decl =
@@ -22,13 +33,43 @@ pub static APP_CLASS: Lazy<AppClass> = Lazy::new(|| unsafe {
 
   decl.add_method(sel!(sendEvent:), send_event as extern "C" fn(_, _, _));
 
+  // CrApp protocol — lets a Chromium / CEF embedder coordinate its own
+  // event-pump work with the host's `sendEvent:` dispatch. Purely
+  // additive: existing tao users see no behavior change because nobody
+  // else calls these selectors.
+  decl.add_method(
+    sel!(isHandlingSendEvent),
+    is_handling_send_event as extern "C" fn(_, _) -> ObjcBool,
+  );
+  decl.add_method(
+    sel!(setHandlingSendEvent:),
+    set_handling_send_event as extern "C" fn(_, _, ObjcBool),
+  );
+
   AppClass(decl.register())
 });
+
+// `objc2::runtime::Bool` is the correct FFI type for Objective-C `BOOL`
+// (signed char). Plain Rust `bool` is not `Encode`-compatible.
+extern "C" fn is_handling_send_event(_: &NSApplication, _: Sel) -> ObjcBool {
+  ObjcBool::new(IS_HANDLING_SEND_EVENT.load(Ordering::Acquire))
+}
+
+extern "C" fn set_handling_send_event(_: &NSApplication, _: Sel, handling: ObjcBool) {
+  IS_HANDLING_SEND_EVENT.store(handling.as_bool(), Ordering::Release);
+}
 
 // Normally, holding Cmd + any key never sends us a `keyUp` event for that key.
 // Overriding `sendEvent:` like this fixes that. (https://stackoverflow.com/a/15294196)
 // Fun fact: Firefox still has this bug! (https://bugzilla.mozilla.org/show_bug.cgi?id=1299553)
+//
+// The save/restore around `IS_HANDLING_SEND_EVENT` keeps the CrApp flag
+// truthful for any embedded code that queries it during dispatch
+// (Chromium's `CrAppProtocol.mm` uses the same pattern). Restoring the
+// previous value rather than always clearing keeps re-entrant calls
+// well-behaved.
 extern "C" fn send_event(this: &NSApplication, _sel: Sel, event: &NSEvent) {
+  let prev_handling = IS_HANDLING_SEND_EVENT.swap(true, Ordering::AcqRel);
   unsafe {
     // For posterity, there are some undocumented event types
     // (https://github.com/servo/cocoa-rs/issues/155)
@@ -49,6 +90,7 @@ extern "C" fn send_event(this: &NSApplication, _sel: Sel, event: &NSEvent) {
       let _: () = msg_send![super(this, superclass), sendEvent: event];
     }
   }
+  IS_HANDLING_SEND_EVENT.store(prev_handling, Ordering::Release);
 }
 
 unsafe fn maybe_dispatch_device_event(event: &NSEvent) {


### PR DESCRIPTION
## Summary

Adds `isHandlingSendEvent` and `setHandlingSendEvent:` to the `TaoApp` `NSApplication` subclass and wraps `sendEvent:` so the CrApp flag is truthful during dispatch (save/restore for re-entrant calls).

## Why

This is the protocol Chromium / CEF expect from a host's `NSApplication` subclass. Without it, an embedded CEF process can't safely coordinate its own message-pump work with the host's `sendEvent:` dispatch — so embedders are forced to either subclass `NSApp` themselves (which conflicts with tao's `TaoApp` subclass) or swizzle methods at runtime.

The patch is purely additive: existing tao users see no behavior change because nothing else queries these selectors. The CrApp flag is a single static `AtomicBool` (correct because `NSApplication` is a process-wide singleton).

## Validation

Built end-to-end on top of this patch: CEF 147 (via [cef-rs](https://github.com/tauri-apps/cef-rs)) running in-process inside a Tauri/tao host on macOS, with `external_message_pump = 1` and an `NSTimer`-driven pump. Gmail (including WebAuthn / passkeys), YouTube, and the rest of the modern web stack load and behave correctly.

The full integration that proved this out lives at https://github.com/Sozenta-Inc/veya/pull/11 — see [`chromium/TAO_PATCH.md`](https://github.com/Sozenta-Inc/veya/blob/main/chromium/TAO_PATCH.md) for the rationale we wrote up internally before sending this upstream.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --lib` passes
- [x] `cargo fmt --all -- --check` exit 0
- [x] Verified at runtime: CEF embed succeeds + pumps without re-entry crashes
- [ ] Reviewer: any tao tests in CI that exercise sendEvent: dispatch (none observed in the existing suite, all checks should be green)

## Notes for reviewers

- `objc2::runtime::Bool` is used at the FFI boundary because Objective-C `BOOL` is a signed char — Rust `bool` is not `Encode`-compatible.
- The save/restore pattern in `send_event` mirrors Chromium's [`CrAppProtocol.mm`](https://source.chromium.org/chromium/chromium/src/+/main:base/mac/scoped_sending_event.h) so re-entrant `sendEvent:` calls (which can happen if embedded code posts an event during dispatch) leave the flag in the caller's expected state.
- A `.changes/macos-crapp-protocol.md` file is included for covector (minor bump — additive API surface).