### PR TITLE
fix(android): don't panic when VIEW intent has null MIME type

### DIFF
--- a/src/platform_impl/android/ndk_glue.rs
+++ b/src/platform_impl/android/ndk_glue.rs
@@ -505,12 +505,11 @@ pub unsafe fn handle_intent(mut env: JNIEnv, intent: JObject) {
   let intent_type = jni_call_method!(env, &intent, "getType", "()Ljava/lang/String;", l)
     .ok()
     .map(|jstr| jstr.into())
-    .map(|intent_type| {
+    .and_then(|intent_type: JString| {
       env
         .get_string(&intent_type)
-        .unwrap()
-        .to_string_lossy()
-        .to_string()
+        .ok()
+        .map(|s| s.to_string_lossy().to_string())
     });
 
   // Handle text/plain intents (EXTRA_TEXT)


### PR DESCRIPTION
Intent.getType() returns null for typical VIEW deep links (e.g. capsule://...), which causes env.get_string() to return Err. The previous .map(...unwrap()) chain panicked from the onActivityCreate JNI callback, aborting the process via SIGABRT.

Switch to and_then + .ok() to mirror the pattern already used a few lines above for the action string.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
