### PR TITLE
fix(linux): add explicit set_content_protection returning NotSupported

### DIFF
--- a/src/platform_impl/linux/window.rs
+++ b/src/platform_impl/linux/window.rs
@@ -778,6 +778,10 @@ impl Window {
     Ok(())
   }
 
+  pub fn set_content_protection(&self, _enabled: bool) -> Result<(), ExternalError> {
+    Err(ExternalError::NotSupported(NotSupportedError::new()))
+  }
+
   pub fn set_cursor_grab(&self, _grab: bool) -> Result<(), ExternalError> {
     Ok(())
   }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1526,7 +1526,7 @@ impl UnownedWindow {
     state.current_theme = theme.unwrap_or_else(get_ns_theme);
   }
 
-  pub fn set_content_protection(&self, enabled: bool) {
+  pub fn set_content_protection(&self, enabled: bool) -> Result<(), ExternalError> {
     unsafe {
       self.ns_window.setSharingType(if enabled {
         NSWindowSharingType::None
@@ -1534,6 +1534,7 @@ impl UnownedWindow {
         NSWindowSharingType::ReadOnly
       });
     }
+    Ok(())
   }
 
   pub fn set_visible_on_all_workspaces(&self, visible: bool) {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1087,7 +1087,7 @@ impl Window {
       .contains(WindowFlags::MARKER_UNDECORATED_SHADOW)
   }
 
-  pub fn set_content_protection(&self, enabled: bool) {
+  pub fn set_content_protection(&self, enabled: bool) -> Result<(), ExternalError> {
     unsafe {
       let _ = SetWindowDisplayAffinity(
         self.hwnd(),
@@ -1098,6 +1098,7 @@ impl Window {
         },
       );
     }
+    Ok(())
   }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -1213,10 +1213,13 @@ impl Window {
   ///
   /// ## Platform-specific
   ///
-  /// - **iOS / Android / Linux:** Unsupported.
-  pub fn set_content_protection(&self, #[allow(unused)] enabled: bool) {
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    self.window.set_content_protection(enabled);
+  /// - **Linux:** Not supported. No equivalent mechanism exists in X11 or
+  ///   Wayland. The Wayland protocol has no surface-level capture exclusion
+  ///   hint; X11 has no equivalent of `SetWindowDisplayAffinity`. Returns
+  ///   `Err(ExternalError::NotSupported)`.
+  /// - **iOS / Android:** Unsupported.
+  pub fn set_content_protection(&self, enabled: bool) -> Result<(), ExternalError> {
+    self.window.set_content_protection(enabled)
   }
 
   /// Sets whether the window should be visible on all workspaces.


### PR DESCRIPTION
## Summary

Fixes #1222

`Window::set_content_protection` was previously a silent no-op on Linux via compile-time gating:

```rust
pub fn set_content_protection(&self, #[allow(unused)] enabled: bool) {
  #[cfg(any(target_os = "macos", target_os = "windows"))]
  self.window.set_content_protection(enabled);
}
```

Callers had no way to detect the failure and fall back gracefully.

## Changes

- **Return type**: changed from `()` to `Result<(), ExternalError>` on all platforms, consistent with `set_cursor_grab` and other fallible window operations.
- **Linux**: adds an explicit implementation returning `Err(ExternalError::NotSupported)` instead of silently doing nothing.
- **macOS / Windows**: existing implementations wrapped in `Ok(())` — no behaviour change.
- **Docs**: updated to accurately describe Linux behaviour.

## Why Linux can't implement this

No OS-level mechanism equivalent to Windows' `SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE)` or macOS' `NSWindow.setSharingType(.none)` exists on Linux:

- **X11**: no X11 protocol atom or extension for excluding a window from screen capture.
- **Wayland**: the protocol has no surface-level capture exclusion hint. `wp_content_type_v1` is for rendering optimisation; `zwp_linux_content_protection_v1` is for HDCP/DRM output — neither prevents capture.
- **GTK 4.14 / GNOME 46**: `GdkToplevelState` has no privacy or capture-protection state.

Returning `NotSupported` lets callers (e.g. Tauri) detect the failure and use alternatives, such as auto-hiding the window when a screen share is detected via PipeWire.

## Test plan

- [ ] `cargo check` passes on Linux (verified locally on Ubuntu 24.04 / GNOME 46 Wayland)
- [ ] macOS and Windows behaviour unchanged (return type now `Result` but callers can use `.ok()` to restore previous behaviour)
- [ ] Doc comment accurately reflects per-platform behaviour