### PR TITLE
fix(android): don't panic when intent.getType() returns null

### DIFF
--- a/.changes/fix-intent-type-null.md
+++ b/.changes/fix-intent-type-null.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+fix(android): don't panic on `onNewIntent` when `intent.getType()` returns null

--- a/src/platform_impl/android/ndk_glue.rs
+++ b/src/platform_impl/android/ndk_glue.rs
@@ -504,13 +504,13 @@ pub unsafe fn handle_intent(mut env: JNIEnv, intent: JObject) {
   // Get intent type (may be null)
   let intent_type = jni_call_method!(env, &intent, "getType", "()Ljava/lang/String;", l)
     .ok()
+    .filter(|jstr| !jstr.is_null())
     .map(|jstr| jstr.into())
-    .map(|intent_type| {
+    .and_then(|intent_type: JString| {
       env
         .get_string(&intent_type)
-        .unwrap()
-        .to_string_lossy()
-        .to_string()
+        .ok()
+        .map(|s| s.to_string_lossy().to_string())
     });
 
   // Handle text/plain intents (EXTRA_TEXT)


### PR DESCRIPTION
I think this bug is similar to #15311. I'm on 0.35.2 now, and I'm getting a very similar panic but in `onNewIntent` when opening via a deeplink.

```
backtrace:
  #00  pc 0x0000000000053324  /apex/com.android.runtime/lib64/bionic/libc.so (abort+180)
  #01  pc 0x0000000001bbe390  /data/app/~~QY1Z8D6dBBKG8LuWxf17cw==/com.yourmenu-yy02J_UwvIupEIqIGUHxHg==/split_config.arm64_v8a.apk (std::sys::pal::unix::abort_internal::h9a3710cbc64175d0+8)
  #02  pc 0x0000000001bc8284  /data/app/~~QY1Z8D6dBBKG8LuWxf17cw==/com.yourmenu-yy02J_UwvIupEIqIGUHxHg==/split_config.arm64_v8a.apk (std::process::abort::ha67efaacf66f4bfc+8)
  #03  pc 0x0000000001bc972c  /data/app/~~QY1Z8D6dBBKG8LuWxf17cw==/com.yourmenu-yy02J_UwvIupEIqIGUHxHg==/split_config.arm64_v8a.apk (std::panicking::panic_with_hook::h34978a6d5693a4f7+488)
  #04  pc 0x0000000001bc9310  /data/app/~~QY1Z8D6dBBKG8LuWxf17cw==/com.yourmenu-yy02J_UwvIupEIqIGUHxHg==/split_config.arm64_v8a.apk (std::panicking::panic_handler::_$u7b$$u7b$closure$u7d$$u7d$::hee65bfe72fb680aa+92)
  #05  pc 0x0000000001bc3380  /data/app/~~QY1Z8D6dBBKG8LuWxf17cw==/com.yourmenu-yy02J_UwvIupEIqIGUHxHg==/split_config.arm64_v8a.apk (std::sys::backtrace::__rust_end_short_backtrace::h41bd914d4be2b9b6+8)
  #06  pc 0x0000000001bb02f0  /data/app/~~QY1Z8D6dBBKG8LuWxf17cw==/com.yourmenu-yy02J_UwvIupEIqIGUHxHg==/split_config.arm64_v8a.apk (_RNvCsj3IbkTTFM3W_7___rustc17rust_begin_unwind+28)
  #07  pc 0x0000000001c003ec  /data/app/~~QY1Z8D6dBBKG8LuWxf17cw==/com.yourmenu-yy02J_UwvIupEIqIGUHxHg==/split_config.arm64_v8a.apk (core::panicking::panic_nounwind_fmt::ha5480706ab229051+48)
  #08  pc 0x0000000001c00350  /data/app/~~QY1Z8D6dBBKG8LuWxf17cw==/com.yourmenu-yy02J_UwvIupEIqIGUHxHg==/split_config.arm64_v8a.apk (core::panicking::panic_nounwind::h59b825fb7613ed60+56)
  #09  pc 0x0000000001c004f4  /data/app/~~QY1Z8D6dBBKG8LuWxf17cw==/com.yourmenu-yy02J_UwvIupEIqIGUHxHg==/split_config.arm64_v8a.apk (core::panicking::panic_cannot_unwind::h66c700eb9a7cd0cc+20)
  #10  pc 0x000000000153e7b8  /data/app/~~QY1Z8D6dBBKG8LuWxf17cw==/com.yourmenu-yy02J_UwvIupEIqIGUHxHg==/split_config.arm64_v8a.apk (Java_com_yourmenu_Rust_onNewIntent+20)
  #11  pc 0x000000000101bd5c  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (art_jni_trampoline+124)
  #12  pc 0x0000000000668468  /apex/com.android.art/lib64/libart.so (nterp_helper+152)
  #13  pc 0x000000000014d130  /data/app/~~QY1Z8D6dBBKG8LuWxf17cw==/com.yourmenu-yy02J_UwvIupEIqIGUHxHg==/base.apk (com.yourmenu.WryActivity.onNewIntent+16)
  #14  pc 0x0000000000669324  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  #15  pc 0x000000000014cd2e  /data/app/~~QY1Z8D6dBBKG8LuWxf17cw==/com.yourmenu-yy02J_UwvIupEIqIGUHxHg==/base.apk (com.yourmenu.TauriActivity.onNewIntent+10)
  ```
```
05-22 11:10:31.162 16006 16006 V tao::platform_impl::platform::ndk_glue: [tao::platform_impl::platform::ndk_glue] Start
05-22 11:10:31.168  1425  4167 D CoreBackPreview: Window{f4f24ff u0 com.yourmenu/com.yourmenu.MainActivity}: Setting back callback OnBackInvokedCallbackInfo{mCallback=android.window.IOnBackInvokedCallback$Stub$Proxy@c3f7334, mPriority=0, mIsAnimationCallback=false, mOverrideBehavior=0}
05-22 11:10:31.173 16006 16050 I RustStdoutStderr: 
05-22 11:10:31.173 16006 16050 I RustStdoutStderr: thread '<unnamed>' (16006) panicked at /Users/brad/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tao-0.35.2/src/platform_impl/android/ndk_glue.rs:511:10:
05-22 11:10:31.173 16006 16050 I RustStdoutStderr: called `Result::unwrap()` on an `Err` value: NullPtr("get_object_class")
05-22 11:10:31.173 16006 16050 I RustStdoutStderr: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
05-22 11:10:31.173 16006 16050 I RustStdoutStderr: 
05-22 11:10:31.173 16006 16050 I RustStdoutStderr: thread '<unnamed>' (16006) panicked at library/core/src/panicking.rs:225:5:
05-22 11:10:31.173 16006 16050 I RustStdoutStderr: panic in a function that cannot unwind
05-22 11:10:31.173 16006 16050 I RustStdoutStderr: stack backtrace:
05-22 11:10:31.183  1425  1512 D SGM:FgCheckThread: noteResumeComponent(), received pkgName: com.yourmenu, userId: 0
05-22 11:10:31.184  1425  1716 D SGM:FgCheckThread: onLooperPrepared(), msg: MSG_APP_RESUME, pkgName: com.yourmenu, userid: 0
05-22 11:10:31.185  1425  1716 D SGM:FgCheckThread:   handleResume(). pkgName: com.yourmenu, userId: 0, category: non-game
05-22 11:10:31.185  1425  1716 D SGM:FgCheckThread: notifyFocusInOut(). of pkg: com.yourmenu, type: 4, isSecGameFamily: false, userId: 0
```

I'm not familiar enough with Rust/Android to check its work, but based on the debugging I've provided Claude Code, it asserts:

> The panic is at ndk_glue.rs:511:
> ```rs
> let intent_type = jni_call_method!(env, &intent, "getType", "()Ljava/lang/String;", l)
>   .ok()
>   .map(|jstr| jstr.into())
>   .map(|intent_type| {
>     env.get_string(&intent_type).unwrap()  // ← line 511: panics on null
>     ...
> ```
> Intent.getType() returns null for most intents that don't carry a MIME type (notably action=VIEW deep links). The previous code passed the null JString through `.ok().map(...)` and then called `env.get_string(&null_jstring).unwrap()`, which fails with NullPtr("get_object_class") and aborts via panic_cannot_unwind because onNewIntent is an extern "C" JNI export.
> 
> Filter out null returns before calling get_string, and degrade the inner unwrap to .ok() so a JNI error doesn't abort either.

Hopefully this patch makes sense. The `cargo test` and the command `cargo check --target armv7-linux-androideabi` Claude Code used both passed.

Closes #1219