### PR TITLE
feat: add macOS prefersCompactControlSizeMetrics window builder option

### DIFF
--- a/.changes/change-pr-1227.md
+++ b/.changes/change-pr-1227.md
@@ -1,0 +1,5 @@
+---
+"tao": minor
+---
+
+Add a macOS window builder option for `prefersCompactControlSizeMetrics`.

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -213,6 +213,8 @@ pub trait WindowBuilderExtMacOS {
   fn with_has_shadow(self, has_shadow: bool) -> WindowBuilder;
   /// Sets the traffic light position to (x, y) relative to the upper left corner
   fn with_traffic_light_inset<P: Into<Position>>(self, inset: P) -> WindowBuilder;
+  /// Whether the window prefers compact control size metrics on macOS.
+  fn with_prefers_compact_control_size_metrics(self, enabled: bool) -> WindowBuilder;
   /// Sets whether the system can automatically organize windows into tabs.
   fn with_automatic_window_tabbing(self, automatic_tabbing: bool) -> WindowBuilder;
   /// Defines the window [tabbing identifier].
@@ -288,6 +290,12 @@ impl WindowBuilderExtMacOS for WindowBuilder {
   #[inline]
   fn with_traffic_light_inset<P: Into<Position>>(mut self, inset: P) -> WindowBuilder {
     self.platform_specific.traffic_light_inset = Some(inset.into());
+    self
+  }
+
+  #[inline]
+  fn with_prefers_compact_control_size_metrics(mut self, enabled: bool) -> WindowBuilder {
+    self.platform_specific.prefers_compact_control_size_metrics = enabled;
     self
   }
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -81,6 +81,7 @@ pub(super) struct ViewState {
   phys_modifiers: HashSet<KeyCode>,
   tracking_rect: Option<NSInteger>,
   pub(super) traffic_light_inset: Option<LogicalPosition<f64>>,
+  pub(super) prefers_compact_control_size_metrics: bool,
 }
 
 impl ViewState {
@@ -103,6 +104,7 @@ pub fn new_view(ns_window: &NSWindow) -> (Option<Retained<NSView>>, Weak<Mutex<C
     phys_modifiers: Default::default(),
     tracking_rect: None,
     traffic_light_inset: None,
+    prefers_compact_control_size_metrics: false,
   };
   unsafe {
     // This is free'd in `dealloc`
@@ -343,8 +345,13 @@ extern "C" fn draw_rect(this: &Object, _sel: Sel, rect: NSRect) {
     let state_ptr: *mut c_void = *this.get_ivar("taoState");
     let state = &mut *(state_ptr as *mut ViewState);
 
+    let window = state.ns_window.load().unwrap();
+
+    if state.prefers_compact_control_size_metrics {
+      set_prefers_compact_control_size_metrics(&window, true);
+    }
+
     if let Some(position) = state.traffic_light_inset {
-      let window = state.ns_window.load().unwrap();
       inset_traffic_lights(&window, position);
     }
 
@@ -1147,6 +1154,32 @@ extern "C" fn wants_key_down_for_event(_this: &Object, _sel: Sel, _event: id) ->
 
 extern "C" fn accepts_first_mouse(_this: &Object, _sel: Sel, _event: id) -> BOOL {
   YES
+}
+
+unsafe fn set_prefers_compact_control_size_metrics(window: &NSWindow, enabled: bool) {
+  let content_view: id = msg_send![window, contentView];
+
+  if content_view.is_null() {
+    return;
+  }
+
+  let title_bar_container_view: id = msg_send![content_view, superview];
+
+  if title_bar_container_view.is_null() {
+    return;
+  }
+
+  let responds: bool = msg_send![
+    title_bar_container_view,
+    respondsToSelector: sel!(setPrefersCompactControlSizeMetrics:)
+  ];
+
+  if responds {
+    let _: () = msg_send![
+      title_bar_container_view,
+      setPrefersCompactControlSizeMetrics: enabled
+    ];
+  }
 }
 
 pub unsafe fn inset_traffic_lights(window: &NSWindow, position: LogicalPosition<f64>) {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -102,6 +102,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
   pub disallow_hidpi: bool,
   pub has_shadow: bool,
   pub traffic_light_inset: Option<Position>,
+  pub prefers_compact_control_size_metrics: bool,
   pub automatic_tabbing: bool,
   pub tabbing_identifier: Option<String>,
 }
@@ -121,6 +122,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
       disallow_hidpi: false,
       has_shadow: true,
       traffic_light_inset: None,
+      prefers_compact_control_size_metrics: false,
       automatic_tabbing: true,
       tabbing_identifier: None,
     }
@@ -145,6 +147,12 @@ unsafe fn create_view(
       let scale_factor = NSWindow::backingScaleFactor(ns_window);
       let position = position.to_logical(scale_factor);
       state.traffic_light_inset = Some(position);
+    }
+
+    if pl_attribs.prefers_compact_control_size_metrics {
+      let state_ptr: *mut c_void = *(**ns_view).get_ivar("taoState");
+      let state = &mut *(state_ptr as *mut ViewState);
+      state.prefers_compact_control_size_metrics = true;
     }
 
     // On Mojave, views automatically become layer-backed shortly after being added to


### PR DESCRIPTION
## Summary

Adds a macOS option that sets AppKit’s `prefersCompactControlSizeMetrics` on the title bar container view when supported

Related issue: tauri-apps/tauri#15434

## Update 
Related PR tauri-apps/tauri#15442