### PR TITLE
Fix(linux): JIS key mapping

### DIFF
--- a/.changes/fix-jis-key-mapping.md
+++ b/.changes/fix-jis-key-mapping.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+fix(linux): map JIS keyboard specific keys (`Zenkaku_Hankaku`, `Hiragana_Katakana`, `Henkan`, `Muhenkan`) in `raw_key_to_key` to prevent them from becoming `Key::Unidentified`.

--- a/src/platform_impl/linux/keyboard.rs
+++ b/src/platform_impl/linux/keyboard.rs
@@ -115,6 +115,12 @@ pub(crate) fn raw_key_to_key(gdk_key: RawKey) -> Option<Key<'static>> {
     // KP_Separator? What does it map to?
     KP_Tab => Some(Key::Tab),
     KP_Up => Some(Key::ArrowUp),
+
+    // JIS
+    Zenkaku_Hankaku => Some(Key::ZenkakuHankaku),
+    Hiragana_Katakana => Some(Key::HiraganaKatakana),
+    Henkan => Some(Key::Convert),
+    Muhenkan => Some(Key::NonConvert),
     // TODO: more mappings (media etc)
     _ => None,
   }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

### Description

This PR adds missing mappings for Japanese (JIS) keyboard specific keys (`Zenkaku_Hankaku`, `Hiragana_Katakana`, `Henkan`, and `Muhenkan`) in `raw_key_to_key` for the GTK backend.

Without this mapping, pressing these keys on Linux environments causes them to fall back to `Key::Unidentified`, leading to unexpected behaviors or warning logs in frontend event handlers.