### PR TITLE
refactor(windows): re-land remove window subclassing

### DIFF
--- a/.changes/windows-initial-background-color.md
+++ b/.changes/windows-initial-background-color.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fixed `with_background_color` doesn't work on initial load on Windows

--- a/.changes/windows-remove-subclassing.md
+++ b/.changes/windows-remove-subclassing.md
@@ -1,0 +1,5 @@
+---
+"tao": minor
+---
+
+Removed window subclassing on Windows

--- a/examples/background_color.rs
+++ b/examples/background_color.rs
@@ -1,0 +1,49 @@
+// Copyright 2014-2021 The winit contributors
+// Copyright 2021-2023 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+
+use dpi::LogicalSize;
+use tao::{
+  event::{ElementState, Event, KeyEvent, WindowEvent},
+  event_loop::{ControlFlow, EventLoop},
+  keyboard::KeyCode,
+  window::WindowBuilder,
+};
+
+fn main() {
+  let event_loop = EventLoop::new();
+
+  let mut background_color = (100, 100, 100, 255);
+
+  let window = WindowBuilder::new()
+    .with_title("Hit space to change background color!")
+    .with_inner_size(LogicalSize::new(400.0, 300.0))
+    .with_background_color(background_color)
+    .build(&event_loop)
+    .unwrap();
+
+  event_loop.run(move |event, _, control_flow| {
+    *control_flow = ControlFlow::Wait;
+
+    match event {
+      Event::WindowEvent { event, .. } => match event {
+        WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+        WindowEvent::KeyboardInput {
+          event:
+            KeyEvent {
+              physical_key: KeyCode::Space,
+              state: ElementState::Released,
+              ..
+            },
+          ..
+        } => {
+          background_color.1 = background_color.1.wrapping_add(20);
+          println!("Setting background color to: {background_color:?}");
+          window.set_background_color(Some(background_color));
+        }
+        _ => (),
+      },
+      _ => (),
+    }
+  });
+}

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -657,7 +657,7 @@ fn create_event_target_window<T: 'static>() -> HWND {
       // `explorer.exe` and then starting the process back up.
       // It is unclear why the bug is triggered by waiting for several hours.
       WS_EX_TOOLWINDOW,
-      PCWSTR::from_raw(thread_event_target_window_class.clone().as_ptr()),
+      thread_event_target_window_class,
       PCWSTR::null(),
       WS_OVERLAPPED,
       0,
@@ -2279,8 +2279,8 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
 ) -> LRESULT {
   let userdata_ptr = util::GetWindowLongPtrW(window, GWL_USERDATA) as *mut ThreadMsgTargetData<T>;
   if userdata_ptr.is_null() {
-    // `userdata_ptr` will always be null for the first `WM_GETMINMAXINFO`, as well as `WM_NCCREATE` and
-    // `WM_CREATE`.
+    // `userdata_ptr` will always be null for the first `WM_GETMINMAXINFO`, as well as
+    // `WM_NCCREATE` and `WM_CREATE`.
     return DefWindowProcW(window, msg, wparam, lparam);
   }
   let userdata = Box::from_raw(userdata_ptr);

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -36,13 +36,14 @@ use windows::{
       Controls::{self as win32c, HOVER_DEFAULT},
       Input::{KeyboardAndMouse::*, Pointer::*, Touch::*, *},
       Shell::{
-        DefSubclassProc, RemoveWindowSubclass, SHAppBarMessage, SetWindowSubclass, ABE_BOTTOM,
-        ABE_LEFT, ABE_RIGHT, ABE_TOP, ABM_GETAUTOHIDEBAR, APPBARDATA,
+        DefSubclassProc, SHAppBarMessage, ABE_BOTTOM, ABE_LEFT, ABE_RIGHT, ABE_TOP,
+        ABM_GETAUTOHIDEBAR, APPBARDATA,
       },
       WindowsAndMessaging::{self as win32wm, *},
     },
   },
 };
+use windows_core::w;
 
 use crate::{
   dpi::{PhysicalPosition, PhysicalSize, PixelUnit},
@@ -59,7 +60,7 @@ use crate::{
     minimal_ime::is_msg_ime_related,
     monitor::{self, MonitorHandle},
     raw_input, util,
-    window::set_skip_taskbar,
+    window::{set_skip_taskbar, InitData},
     window_state::{CursorFlags, WindowFlags, WindowState},
     wrap_device_id, WindowId, DEVICE_ID,
   },
@@ -108,27 +109,27 @@ static GET_POINTER_TOUCH_INFO: Lazy<Option<GetPointerTouchInfo>> =
 static GET_POINTER_PEN_INFO: Lazy<Option<GetPointerPenInfo>> =
   Lazy::new(|| get_function!("user32.dll", GetPointerPenInfo));
 
-pub(crate) struct SubclassInput<T: 'static> {
+pub(crate) struct WindowData<T: 'static> {
   pub window_state: Arc<Mutex<WindowState>>,
   pub event_loop_runner: EventLoopRunnerShared<T>,
   pub _file_drop_handler: Option<IDropTarget>,
-  pub subclass_removed: Cell<bool>,
+  pub userdata_removed: Cell<bool>,
   pub recurse_depth: Cell<u32>,
   pub event_loop_preferred_theme: Arc<Mutex<Option<Theme>>>,
 }
 
-impl<T> SubclassInput<T> {
+impl<T> WindowData<T> {
   unsafe fn send_event(&self, event: Event<'_, T>) {
     self.event_loop_runner.send_event(event);
   }
 }
 
-struct ThreadMsgTargetSubclassInput<T: 'static> {
+struct ThreadMsgTargetData<T: 'static> {
   event_loop_runner: EventLoopRunnerShared<T>,
   user_event_receiver: Receiver<T>,
 }
 
-impl<T> ThreadMsgTargetSubclassInput<T> {
+impl<T> ThreadMsgTargetData<T> {
   unsafe fn send_event(&self, event: Event<'_, T>) {
     self.event_loop_runner.send_event(event);
   }
@@ -136,8 +137,7 @@ impl<T> ThreadMsgTargetSubclassInput<T> {
 
 /// The result of a subclass procedure (the message handling callback)
 pub(crate) enum ProcResult {
-  DefSubclassProc, // <- this should be the default value
-  DefWindowProc,
+  DefWindowProc, // <- this should be the default value
   Value(LRESULT),
 }
 
@@ -190,7 +190,7 @@ impl<T: 'static> EventLoop<T> {
       become_dpi_aware();
     }
 
-    let thread_msg_target = create_event_target_window();
+    let thread_msg_target = create_event_target_window::<T>();
 
     super::dark_mode::allow_dark_mode_for_app(true);
 
@@ -200,7 +200,8 @@ impl<T: 'static> EventLoop<T> {
 
     let runner_shared = Rc::new(EventLoopRunner::new(thread_msg_target, wait_thread_id));
 
-    let thread_msg_sender = subclass_event_target_window(thread_msg_target, runner_shared.clone());
+    let thread_msg_sender =
+      insert_event_target_window_data::<T>(thread_msg_target, runner_shared.clone());
     raw_input::register_all_mice_and_keyboards_for_raw_input(thread_msg_target, Default::default());
 
     EventLoop {
@@ -623,30 +624,29 @@ pub static CHANGE_THEME_MSG_ID: Lazy<u32> =
 /// When the application receives this message, it should assume that any taskbar icons it added have been removed and add them again.
 pub static S_U_TASKBAR_RESTART: Lazy<u32> =
   Lazy::new(|| unsafe { RegisterWindowMessageA(s!("TaskbarCreated")) });
-static THREAD_EVENT_TARGET_WINDOW_CLASS: Lazy<Vec<u16>> = Lazy::new(|| unsafe {
-  let class_name = util::encode_wide("Tao Thread Event Target");
 
-  let class = WNDCLASSEXW {
-    cbSize: mem::size_of::<WNDCLASSEXW>() as u32,
-    style: Default::default(),
-    lpfnWndProc: Some(util::call_default_window_proc),
-    cbClsExtra: 0,
-    cbWndExtra: 0,
-    hInstance: HINSTANCE(GetModuleHandleW(PCWSTR::null()).unwrap_or_default().0),
-    hIcon: HICON::default(),
-    hCursor: HCURSOR::default(), // must be null in order for cursor state to work properly
-    hbrBackground: HBRUSH::default(),
-    lpszMenuName: PCWSTR::null(),
-    lpszClassName: PCWSTR::from_raw(class_name.as_ptr()),
-    hIconSm: HICON::default(),
-  };
+fn create_event_target_window<T: 'static>() -> HWND {
+  let thread_event_target_window_class = w!("Tao Thread Event Target");
 
-  RegisterClassExW(&class);
+  unsafe {
+    let class = WNDCLASSEXW {
+      cbSize: mem::size_of::<WNDCLASSEXW>() as u32,
+      style: Default::default(),
+      lpfnWndProc: Some(thread_event_target_callback::<T>),
+      cbClsExtra: 0,
+      cbWndExtra: 0,
+      hInstance: HINSTANCE(GetModuleHandleW(PCWSTR::null()).unwrap_or_default().0),
+      hIcon: HICON::default(),
+      hCursor: HCURSOR::default(), // must be null in order for cursor state to work properly
+      hbrBackground: HBRUSH::default(),
+      lpszMenuName: PCWSTR::null(),
+      lpszClassName: thread_event_target_window_class,
+      hIconSm: HICON::default(),
+    };
 
-  class_name
-});
+    RegisterClassExW(&class);
+  }
 
-fn create_event_target_window() -> HWND {
   let window = unsafe {
     CreateWindowExW(
       WS_EX_NOACTIVATE | WS_EX_TRANSPARENT | WS_EX_LAYERED |
@@ -658,7 +658,7 @@ fn create_event_target_window() -> HWND {
       // `explorer.exe` and then starting the process back up.
       // It is unclear why the bug is triggered by waiting for several hours.
       WS_EX_TOOLWINDOW,
-      PCWSTR::from_raw(THREAD_EVENT_TARGET_WINDOW_CLASS.clone().as_ptr()),
+      PCWSTR::from_raw(thread_event_target_window_class.clone().as_ptr()),
       PCWSTR::null(),
       WS_OVERLAPPED,
       0,
@@ -688,39 +688,21 @@ fn create_event_target_window() -> HWND {
   window
 }
 
-fn subclass_event_target_window<T>(
-  window: HWND,
+fn insert_event_target_window_data<T>(
+  thread_msg_target: HWND,
   event_loop_runner: EventLoopRunnerShared<T>,
 ) -> Sender<T> {
-  unsafe {
-    let (tx, rx) = channel::unbounded();
+  let (tx, rx) = channel::unbounded();
 
-    let subclass_input = ThreadMsgTargetSubclassInput {
-      event_loop_runner,
-      user_event_receiver: rx,
-    };
-    let input_ptr = Box::into_raw(Box::new(subclass_input));
-    let subclass_result = SetWindowSubclass(
-      window,
-      Some(thread_event_target_callback::<T>),
-      THREAD_EVENT_TARGET_SUBCLASS_ID,
-      input_ptr as usize,
-    );
-    assert!(subclass_result.as_bool());
-
-    tx
-  }
-}
-
-fn remove_event_target_window_subclass<T: 'static>(window: HWND) {
-  let removal_result = unsafe {
-    RemoveWindowSubclass(
-      window,
-      Some(thread_event_target_callback::<T>),
-      THREAD_EVENT_TARGET_SUBCLASS_ID,
-    )
+  let userdata = ThreadMsgTargetData {
+    event_loop_runner,
+    user_event_receiver: rx,
   };
-  assert!(removal_result.as_bool());
+  let input_ptr = Box::into_raw(Box::new(userdata));
+
+  util::SetWindowLongPtrW(thread_msg_target, GWL_USERDATA, input_ptr as isize);
+
+  tx
 }
 
 /// Capture mouse input, allowing `window` to receive mouse events when the cursor is outside of
@@ -739,33 +721,6 @@ unsafe fn release_mouse(mut window_state: parking_lot::MutexGuard<'_, WindowStat
     drop(window_state);
     let _ = ReleaseCapture();
   }
-}
-
-const WINDOW_SUBCLASS_ID: usize = 0;
-const THREAD_EVENT_TARGET_SUBCLASS_ID: usize = 1;
-pub(crate) fn subclass_window<T>(window: HWND, subclass_input: SubclassInput<T>) {
-  subclass_input.event_loop_runner.register_window(window);
-  let input_ptr = Box::into_raw(Box::new(subclass_input));
-  let subclass_result = unsafe {
-    SetWindowSubclass(
-      window,
-      Some(public_window_callback::<T>),
-      WINDOW_SUBCLASS_ID,
-      input_ptr as usize,
-    )
-  };
-  assert!(subclass_result.as_bool());
-}
-
-fn remove_window_subclass<T: 'static>(window: HWND) {
-  let removal_result = unsafe {
-    RemoveWindowSubclass(
-      window,
-      Some(public_window_callback::<T>),
-      WINDOW_SUBCLASS_ID,
-    )
-  };
-  assert!(removal_result.as_bool());
 }
 
 fn normalize_pointer_pressure(pressure: u32) -> Option<Force> {
@@ -846,11 +801,11 @@ unsafe fn process_control_flow<T: 'static>(runner: &EventLoopRunner<T>) {
 
 /// Emit a `ModifiersChanged` event whenever modifiers have changed.
 /// Returns the current modifier state
-fn update_modifiers<T>(window: HWND, subclass_input: &SubclassInput<T>) -> ModifiersState {
+fn update_modifiers<T>(window: HWND, useredata: &WindowData<T>) -> ModifiersState {
   use crate::event::WindowEvent::ModifiersChanged;
 
   let modifiers = LAYOUT_CACHE.lock().get_agnostic_mods();
-  let mut window_state = subclass_input.window_state.lock();
+  let mut window_state = useredata.window_state.lock();
   if window_state.modifiers_state != modifiers {
     window_state.modifiers_state = modifiers;
 
@@ -858,7 +813,7 @@ fn update_modifiers<T>(window: HWND, subclass_input: &SubclassInput<T>) -> Modif
     drop(window_state);
 
     unsafe {
-      subclass_input.send_event(Event::WindowEvent {
+      useredata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: ModifiersChanged(modifiers),
       });
@@ -867,26 +822,26 @@ fn update_modifiers<T>(window: HWND, subclass_input: &SubclassInput<T>) -> Modif
   modifiers
 }
 
-unsafe fn gain_active_focus<T>(window: HWND, subclass_input: &SubclassInput<T>) {
+unsafe fn gain_active_focus<T>(window: HWND, userdata: &WindowData<T>) {
   use crate::event::WindowEvent::Focused;
-  update_modifiers(window, subclass_input);
+  update_modifiers(window, userdata);
 
-  subclass_input.send_event(Event::WindowEvent {
+  userdata.send_event(Event::WindowEvent {
     window_id: RootWindowId(WindowId(window.0 as _)),
     event: Focused(true),
   });
 }
 
-unsafe fn lose_active_focus<T>(window: HWND, subclass_input: &SubclassInput<T>) {
+unsafe fn lose_active_focus<T>(window: HWND, userdata: &WindowData<T>) {
   use crate::event::WindowEvent::{Focused, ModifiersChanged};
 
-  subclass_input.window_state.lock().modifiers_state = ModifiersState::empty();
-  subclass_input.send_event(Event::WindowEvent {
+  userdata.window_state.lock().modifiers_state = ModifiersState::empty();
+  userdata.send_event(Event::WindowEvent {
     window_id: RootWindowId(WindowId(window.0 as _)),
     event: ModifiersChanged(ModifiersState::empty()),
   });
 
-  subclass_input.send_event(Event::WindowEvent {
+  userdata.send_event(Event::WindowEvent {
     window_id: RootWindowId(WindowId(window.0 as _)),
     event: Focused(false),
   });
@@ -899,36 +854,52 @@ unsafe fn lose_active_focus<T>(window: HWND, subclass_input: &SubclassInput<T>) 
 //
 // Returning 0 tells the Win32 API that the message has been processed.
 // FIXME: detect WM_DWMCOMPOSITIONCHANGED and call DwmEnableBlurBehindWindow if necessary
-unsafe extern "system" fn public_window_callback<T: 'static>(
+pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
   window: HWND,
   msg: u32,
   wparam: WPARAM,
   lparam: LPARAM,
-  uidsubclass: usize,
-  subclass_input_ptr: usize,
 ) -> LRESULT {
-  let subclass_input_ptr = subclass_input_ptr as *mut SubclassInput<T>;
-  let (result, subclass_removed, recurse_depth) = {
-    let subclass_input = &*subclass_input_ptr;
-    subclass_input
-      .recurse_depth
-      .set(subclass_input.recurse_depth.get() + 1);
+  let userdata = GetWindowLongPtrW(window, GWL_USERDATA);
+  let userdata_ptr = match (userdata, msg) {
+    (0, WM_NCCREATE) => {
+      let createstruct = &mut *(lparam.0 as *mut CREATESTRUCTW);
+      let initdata = createstruct.lpCreateParams;
+      let initdata = &mut *(initdata as *mut InitData<'_, T>);
 
-    // Clear userdata
-    util::SetWindowLongPtrW(window, GWL_USERDATA, 0);
-
-    let result =
-      public_window_callback_inner(window, msg, wparam, lparam, uidsubclass, subclass_input);
-
-    let subclass_removed = subclass_input.subclass_removed.get();
-    let recurse_depth = subclass_input.recurse_depth.get() - 1;
-    subclass_input.recurse_depth.set(recurse_depth);
-
-    (result, subclass_removed, recurse_depth)
+      let runner = initdata.event_loop.runner_shared.clone();
+      if let Some((win, userdata)) = runner.catch_unwind(|| (initdata.post_init)(window)) {
+        initdata.window = Some(win);
+        let userdata = Box::into_raw(Box::new(userdata));
+        util::SetWindowLongPtrW(window, GWL_USERDATA, userdata as isize);
+        userdata
+      } else {
+        return LRESULT(-1);
+      }
+    }
+    // Getting here should quite frankly be impossible,
+    // but we'll make window creation fail here just in case.
+    (0, WM_CREATE) => return LRESULT(-1),
+    (0, _) => return DefWindowProcW(window, msg, wparam, lparam),
+    _ => userdata as *mut WindowData<T>,
   };
 
-  if subclass_removed && recurse_depth == 0 {
-    drop(Box::from_raw(subclass_input_ptr))
+  let (result, userdata_removed, recurse_depth) = {
+    let userdata = &*(userdata_ptr);
+
+    userdata.recurse_depth.set(userdata.recurse_depth.get() + 1);
+
+    let result = public_window_callback_inner(window, msg, wparam, lparam, &userdata);
+
+    let userdata_removed = userdata.userdata_removed.get();
+    let recurse_depth = userdata.recurse_depth.get() - 1;
+    userdata.recurse_depth.set(recurse_depth);
+
+    (result, userdata_removed, recurse_depth)
+  };
+
+  if userdata_removed && recurse_depth == 0 {
+    drop(Box::from_raw(userdata_ptr));
   }
 
   result
@@ -939,27 +910,26 @@ unsafe fn public_window_callback_inner<T: 'static>(
   msg: u32,
   wparam: WPARAM,
   lparam: LPARAM,
-  _: usize,
-  subclass_input: &SubclassInput<T>,
+  userdata: &WindowData<T>,
 ) -> LRESULT {
   let _ = RedrawWindow(
-    Some(subclass_input.event_loop_runner.thread_msg_target()),
+    Some(userdata.event_loop_runner.thread_msg_target()),
     None,
     None,
     RDW_INTERNALPAINT,
   );
 
-  let mut result = ProcResult::DefSubclassProc;
+  let mut result = ProcResult::DefWindowProc;
 
   // Send new modifiers before sending key events.
   let mods_changed_callback = || match msg {
     win32wm::WM_KEYDOWN | win32wm::WM_SYSKEYDOWN | win32wm::WM_KEYUP | win32wm::WM_SYSKEYUP => {
-      update_modifiers(window, subclass_input);
+      update_modifiers(window, userdata);
       result = ProcResult::Value(LRESULT(0));
     }
     _ => (),
   };
-  subclass_input
+  userdata
     .event_loop_runner
     .catch_unwind(mods_changed_callback)
     .unwrap_or_else(|| result = ProcResult::Value(LRESULT(-1)));
@@ -982,7 +952,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
       }
     };
     for event in events {
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: KeyboardInput {
           device_id: DEVICE_ID,
@@ -992,7 +962,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
       });
     }
   };
-  subclass_input
+  userdata
     .event_loop_runner
     .catch_unwind(keyboard_callback)
     .unwrap_or_else(|| result = ProcResult::Value(LRESULT(-1)));
@@ -1004,19 +974,19 @@ unsafe fn public_window_callback_inner<T: 'static>(
       return;
     }
     let text = {
-      let mut window_state = subclass_input.window_state.lock();
+      let mut window_state = userdata.window_state.lock();
       window_state
         .ime_handler
         .process_message(window, msg, wparam, lparam, &mut result)
     };
     if let Some(str) = text {
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: ReceivedImeText(str),
       });
     }
   };
-  subclass_input
+  userdata
     .event_loop_runner
     .catch_unwind(ime_callback)
     .unwrap_or_else(|| result = ProcResult::Value(LRESULT(-1)));
@@ -1026,7 +996,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
   // the git blame and history would be preserved.
   let callback = || match msg {
     win32wm::WM_ENTERSIZEMOVE => {
-      subclass_input
+      userdata
         .window_state
         .lock()
         .set_window_flags_in_place(|f| f.insert(WindowFlags::MARKER_IN_SIZE_MOVE));
@@ -1034,7 +1004,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
     }
 
     win32wm::WM_EXITSIZEMOVE => {
-      let mut state = subclass_input.window_state.lock();
+      let mut state = userdata.window_state.lock();
       if state.dragging {
         state.dragging = false;
         let _ = unsafe { PostMessageW(Some(window), WM_LBUTTONUP, WPARAM::default(), lparam) };
@@ -1045,6 +1015,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
     win32wm::WM_NCCREATE => {
       enable_non_client_dpi_scaling(window);
+      result = ProcResult::DefWindowProc;
     }
     win32wm::WM_NCLBUTTONDOWN => {
       if wparam.0 == HTCAPTION as _ {
@@ -1052,7 +1023,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
       }
 
       use crate::event::WindowEvent::DecorationsClick;
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: DecorationsClick,
       });
@@ -1060,7 +1031,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
     win32wm::WM_CLOSE => {
       use crate::event::WindowEvent::CloseRequested;
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: CloseRequested,
       });
@@ -1070,39 +1041,39 @@ unsafe fn public_window_callback_inner<T: 'static>(
     win32wm::WM_DESTROY => {
       use crate::event::WindowEvent::Destroyed;
       let _ = RevokeDragDrop(window);
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: Destroyed,
       });
-      subclass_input.event_loop_runner.remove_window(window);
+      userdata.event_loop_runner.remove_window(window);
       result = ProcResult::Value(LRESULT(0));
     }
 
     win32wm::WM_NCDESTROY => {
-      remove_window_subclass::<T>(window);
-      subclass_input.subclass_removed.set(true);
+      SetWindowLongPtrW(window, GWL_USERDATA, 0);
+      userdata.userdata_removed.set(true);
       result = ProcResult::Value(LRESULT(0));
     }
 
     win32wm::WM_PAINT => {
-      if subclass_input.event_loop_runner.should_buffer() {
+      if userdata.event_loop_runner.should_buffer() {
         // this branch can happen in response to `UpdateWindow`, if win32 decides to
         // redraw the window outside the normal flow of the event loop.
         let _ = RedrawWindow(Some(window), None, None, RDW_INTERNALPAINT);
       } else {
-        let managing_redraw = flush_paint_messages(Some(window), &subclass_input.event_loop_runner);
-        subclass_input.send_event(Event::RedrawRequested(RootWindowId(WindowId(
+        let managing_redraw = flush_paint_messages(Some(window), &userdata.event_loop_runner);
+        userdata.send_event(Event::RedrawRequested(RootWindowId(WindowId(
           window.0 as _,
         ))));
         if managing_redraw {
-          subclass_input.event_loop_runner.redraw_events_cleared();
-          process_control_flow(&subclass_input.event_loop_runner);
+          userdata.event_loop_runner.redraw_events_cleared();
+          process_control_flow(&userdata.event_loop_runner);
         }
       }
     }
 
     win32wm::WM_ERASEBKGND => {
-      let w = subclass_input.window_state.lock();
+      let w = userdata.window_state.lock();
       if let Some(color) = w.background_color {
         let hdc = HDC(wparam.0 as *mut _);
         let mut rc = RECT::default();
@@ -1113,15 +1084,15 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
           result = ProcResult::Value(LRESULT(1));
         } else {
-          result = ProcResult::DefSubclassProc;
+          result = ProcResult::DefWindowProc;
         }
       } else {
-        result = ProcResult::DefSubclassProc;
+        result = ProcResult::DefWindowProc;
       }
     }
 
     win32wm::WM_WINDOWPOSCHANGING => {
-      let mut window_state = subclass_input.window_state.lock();
+      let mut window_state = userdata.window_state.lock();
 
       if let Some(ref mut fullscreen) = window_state.fullscreen {
         let window_pos = &mut *(lparam.0 as *mut WINDOWPOS);
@@ -1214,14 +1185,14 @@ unsafe fn public_window_callback_inner<T: 'static>(
       let windowpos = lparam.0 as *const WINDOWPOS;
       if (*windowpos).flags & SWP_NOMOVE != SWP_NOMOVE {
         let physical_position = PhysicalPosition::new((*windowpos).x, (*windowpos).y);
-        subclass_input.send_event(Event::WindowEvent {
+        userdata.send_event(Event::WindowEvent {
           window_id: RootWindowId(WindowId(window.0 as _)),
           event: Moved(physical_position),
         });
       }
 
       // This is necessary for us to still get sent WM_SIZE.
-      result = ProcResult::DefSubclassProc;
+      result = ProcResult::DefWindowProc;
     }
 
     win32wm::WM_SIZE => {
@@ -1236,7 +1207,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
       };
 
       {
-        let mut w = subclass_input.window_state.lock();
+        let mut w = userdata.window_state.lock();
         // See WindowFlags::MARKER_RETAIN_STATE_ON_SIZE docs for info on why this `if` check exists.
         if !w
           .window_flags()
@@ -1247,24 +1218,24 @@ unsafe fn public_window_callback_inner<T: 'static>(
         }
       }
 
-      subclass_input.send_event(event);
+      userdata.send_event(event);
       result = ProcResult::Value(LRESULT(0));
     }
 
     // this is necessary for us to maintain minimize/restore state
     win32wm::WM_SYSCOMMAND => {
       if wparam.0 == SC_RESTORE as _ {
-        let mut w = subclass_input.window_state.lock();
+        let mut w = userdata.window_state.lock();
         w.set_window_flags_in_place(|f| f.set(WindowFlags::MINIMIZED, false));
       }
       if wparam.0 == SC_MINIMIZE as _ {
-        let mut w = subclass_input.window_state.lock();
+        let mut w = userdata.window_state.lock();
         w.set_window_flags_in_place(|f| f.set(WindowFlags::MINIMIZED, true));
       }
       // Send `WindowEvent::Minimized` here if we decide to implement one
 
       if wparam.0 == SC_SCREENSAVE as _ {
-        let window_state = subclass_input.window_state.lock();
+        let window_state = userdata.window_state.lock();
         if window_state.fullscreen.is_some() {
           result = ProcResult::Value(LRESULT(0));
           return;
@@ -1277,7 +1248,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
     win32wm::WM_MOUSEMOVE => {
       use crate::event::WindowEvent::{CursorEntered, CursorMoved};
       let mouse_was_outside_window = {
-        let mut w = subclass_input.window_state.lock();
+        let mut w = userdata.window_state.lock();
 
         let was_outside_window = !w.mouse.cursor_flags().contains(CursorFlags::IN_WINDOW);
         w.mouse
@@ -1287,7 +1258,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
       };
 
       if mouse_was_outside_window {
-        subclass_input.send_event(Event::WindowEvent {
+        userdata.send_event(Event::WindowEvent {
           window_id: RootWindowId(WindowId(window.0 as _)),
           event: CursorEntered {
             device_id: DEVICE_ID,
@@ -1311,13 +1282,13 @@ unsafe fn public_window_callback_inner<T: 'static>(
         // handle spurious WM_MOUSEMOVE messages
         // see https://devblogs.microsoft.com/oldnewthing/20031001-00/?p=42343
         // and http://debugandconquer.blogspot.com/2015/08/the-cause-of-spurious-mouse-move.html
-        let mut w = subclass_input.window_state.lock();
+        let mut w = userdata.window_state.lock();
         cursor_moved = w.mouse.last_position != Some(position);
         w.mouse.last_position = Some(position);
       }
       if cursor_moved {
-        let modifiers = update_modifiers(window, subclass_input);
-        subclass_input.send_event(Event::WindowEvent {
+        let modifiers = update_modifiers(window, userdata);
+        userdata.send_event(Event::WindowEvent {
           window_id: RootWindowId(WindowId(window.0 as _)),
           event: CursorMoved {
             device_id: DEVICE_ID,
@@ -1333,13 +1304,13 @@ unsafe fn public_window_callback_inner<T: 'static>(
     win32c::WM_MOUSELEAVE => {
       use crate::event::WindowEvent::CursorLeft;
       {
-        let mut w = subclass_input.window_state.lock();
+        let mut w = userdata.window_state.lock();
         w.mouse
           .set_cursor_flags(window, |f| f.set(CursorFlags::IN_WINDOW, false))
           .ok();
       }
 
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: CursorLeft {
           device_id: DEVICE_ID,
@@ -1355,7 +1326,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
       let value = f32::from(util::GET_WHEEL_DELTA_WPARAM(wparam));
       let value = value / WHEEL_DELTA as f32;
 
-      let modifiers = update_modifiers(window, subclass_input);
+      let modifiers = update_modifiers(window, userdata);
 
       let mut scroll_lines = DEFAULT_SCROLL_LINES_PER_WHEEL_DELTA;
 
@@ -1371,7 +1342,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         scroll_lines = DEFAULT_SCROLL_LINES_PER_WHEEL_DELTA;
       }
 
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: WindowEvent::MouseWheel {
           device_id: DEVICE_ID,
@@ -1390,7 +1361,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
       let value = f32::from(util::GET_WHEEL_DELTA_WPARAM(wparam));
       let value = value / WHEEL_DELTA as f32;
 
-      let modifiers = update_modifiers(window, subclass_input);
+      let modifiers = update_modifiers(window, userdata);
 
       let mut scroll_characters = DEFAULT_SCROLL_CHARACTERS_PER_WHEEL_DELTA;
 
@@ -1401,7 +1372,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS(0),
       );
 
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: WindowEvent::MouseWheel {
           device_id: DEVICE_ID,
@@ -1416,18 +1387,18 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
     win32wm::WM_KEYDOWN | win32wm::WM_SYSKEYDOWN => {
       if msg == WM_SYSKEYDOWN && wparam.0 == usize::from(VK_F4.0) {
-        result = ProcResult::DefSubclassProc;
+        result = ProcResult::DefWindowProc;
       }
     }
 
     win32wm::WM_LBUTTONDOWN => {
       use crate::event::{ElementState::Pressed, MouseButton::Left, WindowEvent::MouseInput};
 
-      capture_mouse(window, &mut subclass_input.window_state.lock());
+      capture_mouse(window, &mut userdata.window_state.lock());
 
-      let modifiers = update_modifiers(window, subclass_input);
+      let modifiers = update_modifiers(window, userdata);
 
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: MouseInput {
           device_id: DEVICE_ID,
@@ -1442,11 +1413,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
     win32wm::WM_LBUTTONUP => {
       use crate::event::{ElementState::Released, MouseButton::Left, WindowEvent::MouseInput};
 
-      release_mouse(subclass_input.window_state.lock());
+      release_mouse(userdata.window_state.lock());
 
-      let modifiers = update_modifiers(window, subclass_input);
+      let modifiers = update_modifiers(window, userdata);
 
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: MouseInput {
           device_id: DEVICE_ID,
@@ -1461,11 +1432,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
     win32wm::WM_RBUTTONDOWN => {
       use crate::event::{ElementState::Pressed, MouseButton::Right, WindowEvent::MouseInput};
 
-      capture_mouse(window, &mut subclass_input.window_state.lock());
+      capture_mouse(window, &mut userdata.window_state.lock());
 
-      let modifiers = update_modifiers(window, subclass_input);
+      let modifiers = update_modifiers(window, userdata);
 
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: MouseInput {
           device_id: DEVICE_ID,
@@ -1480,11 +1451,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
     win32wm::WM_RBUTTONUP => {
       use crate::event::{ElementState::Released, MouseButton::Right, WindowEvent::MouseInput};
 
-      release_mouse(subclass_input.window_state.lock());
+      release_mouse(userdata.window_state.lock());
 
-      let modifiers = update_modifiers(window, subclass_input);
+      let modifiers = update_modifiers(window, userdata);
 
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: MouseInput {
           device_id: DEVICE_ID,
@@ -1499,11 +1470,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
     win32wm::WM_MBUTTONDOWN => {
       use crate::event::{ElementState::Pressed, MouseButton::Middle, WindowEvent::MouseInput};
 
-      capture_mouse(window, &mut subclass_input.window_state.lock());
+      capture_mouse(window, &mut userdata.window_state.lock());
 
-      let modifiers = update_modifiers(window, subclass_input);
+      let modifiers = update_modifiers(window, userdata);
 
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: MouseInput {
           device_id: DEVICE_ID,
@@ -1518,11 +1489,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
     win32wm::WM_MBUTTONUP => {
       use crate::event::{ElementState::Released, MouseButton::Middle, WindowEvent::MouseInput};
 
-      release_mouse(subclass_input.window_state.lock());
+      release_mouse(userdata.window_state.lock());
 
-      let modifiers = update_modifiers(window, subclass_input);
+      let modifiers = update_modifiers(window, userdata);
 
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: MouseInput {
           device_id: DEVICE_ID,
@@ -1538,11 +1509,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
       use crate::event::{ElementState::Pressed, MouseButton::Other, WindowEvent::MouseInput};
       let xbutton = util::GET_XBUTTON_WPARAM(wparam);
 
-      capture_mouse(window, &mut subclass_input.window_state.lock());
+      capture_mouse(window, &mut userdata.window_state.lock());
 
-      let modifiers = update_modifiers(window, subclass_input);
+      let modifiers = update_modifiers(window, userdata);
 
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: MouseInput {
           device_id: DEVICE_ID,
@@ -1558,11 +1529,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
       use crate::event::{ElementState::Released, MouseButton::Other, WindowEvent::MouseInput};
       let xbutton = util::GET_XBUTTON_WPARAM(wparam);
 
-      release_mouse(subclass_input.window_state.lock());
+      release_mouse(userdata.window_state.lock());
 
-      let modifiers = update_modifiers(window, subclass_input);
+      let modifiers = update_modifiers(window, userdata);
 
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: MouseInput {
           device_id: DEVICE_ID,
@@ -1580,7 +1551,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
       // can happen if `SetCapture` is called on our window when it already has the mouse
       // capture.
       if lparam.0 != window.0 as _ {
-        subclass_input.window_state.lock().mouse.capture_count = 0;
+        userdata.window_state.lock().mouse.capture_count = 0;
       }
       result = ProcResult::Value(LRESULT(0));
     }
@@ -1614,7 +1585,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
           let x = location.x as f64 + (input.x % 100) as f64 / 100f64;
           let y = location.y as f64 + (input.y % 100) as f64 / 100f64;
           let location = PhysicalPosition::new(x, y);
-          subclass_input.send_event(Event::WindowEvent {
+          userdata.send_event(Event::WindowEvent {
             window_id: RootWindowId(WindowId(window.0 as _)),
             event: WindowEvent::Touch(Touch {
               phase: if (input.dwFlags & TOUCHEVENTF_DOWN) != Default::default() {
@@ -1750,7 +1721,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
           let x = location.x as f64 + x.fract();
           let y = location.y as f64 + y.fract();
           let location = PhysicalPosition::new(x, y);
-          subclass_input.send_event(Event::WindowEvent {
+          userdata.send_event(Event::WindowEvent {
             window_id: RootWindowId(WindowId(window.0 as _)),
             event: WindowEvent::Touch(Touch {
               phase: if (pointer_info.pointerFlags & POINTER_FLAG_DOWN) != Default::default() {
@@ -1778,36 +1749,36 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
     win32wm::WM_NCACTIVATE => {
       let is_active = wparam != WPARAM(0);
-      let active_focus_changed = subclass_input.window_state.lock().set_active(is_active);
+      let active_focus_changed = userdata.window_state.lock().set_active(is_active);
       if active_focus_changed {
         if is_active {
-          gain_active_focus(window, subclass_input);
+          gain_active_focus(window, userdata);
         } else {
-          lose_active_focus(window, subclass_input);
+          lose_active_focus(window, userdata);
         }
       }
       result = ProcResult::DefWindowProc;
     }
 
     win32wm::WM_SETFOCUS => {
-      let active_focus_changed = subclass_input.window_state.lock().set_focused(true);
+      let active_focus_changed = userdata.window_state.lock().set_focused(true);
       if active_focus_changed {
-        gain_active_focus(window, subclass_input);
+        gain_active_focus(window, userdata);
       }
       result = ProcResult::Value(LRESULT(0));
     }
 
     win32wm::WM_KILLFOCUS => {
-      let active_focus_changed = subclass_input.window_state.lock().set_focused(false);
+      let active_focus_changed = userdata.window_state.lock().set_focused(false);
       if active_focus_changed {
-        lose_active_focus(window, subclass_input);
+        lose_active_focus(window, userdata);
       }
       result = ProcResult::Value(LRESULT(0));
     }
 
     win32wm::WM_SETCURSOR => {
       let set_cursor_to = {
-        let window_state = subclass_input.window_state.lock();
+        let window_state = userdata.window_state.lock();
         // The return value for the preceding `WM_NCHITTEST` message is conveniently
         // provided through the low-order word of lParam. We use that here since
         // `WM_MOUSEMOVE` seems to come after `WM_SETCURSOR` for a given cursor movement.
@@ -1833,7 +1804,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
     win32wm::WM_GETMINMAXINFO => {
       let mmi = lparam.0 as *mut MINMAXINFO;
 
-      let window_state = subclass_input.window_state.lock();
+      let window_state = userdata.window_state.lock();
       let is_decorated = window_state
         .window_flags()
         .contains(WindowFlags::MARKER_DECORATIONS);
@@ -1896,7 +1867,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
       let old_scale_factor: f64;
 
       let (allow_resize, is_decorated) = {
-        let mut window_state = subclass_input.window_state.lock();
+        let mut window_state = userdata.window_state.lock();
         old_scale_factor = window_state.scale_factor;
         window_state.scale_factor = new_scale_factor;
 
@@ -1977,7 +1948,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         new_physical_inner_size = old_physical_inner_size;
       }
 
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: ScaleFactorChanged {
           scale_factor: new_scale_factor,
@@ -1988,7 +1959,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
       let dragging_window: bool;
 
       {
-        let window_state = subclass_input.window_state.lock();
+        let window_state = userdata.window_state.lock();
         dragging_window = window_state
           .window_flags()
           .contains(WindowFlags::MARKER_IN_SIZE_MOVE);
@@ -2118,15 +2089,15 @@ unsafe fn public_window_callback_inner<T: 'static>(
     }
 
     win32wm::WM_SETTINGCHANGE => {
-      update_theme(subclass_input, window, true);
+      update_theme(userdata, window, true);
     }
 
     win32wm::WM_NCCALCSIZE => {
-      let window_flags = subclass_input.window_state.lock().window_flags();
-      let is_fullscreen = subclass_input.window_state.lock().fullscreen.is_some();
+      let window_flags = userdata.window_state.lock().window_flags();
+      let is_fullscreen = userdata.window_state.lock().fullscreen.is_some();
 
       if wparam == WPARAM(0) || window_flags.contains(WindowFlags::MARKER_DECORATIONS) {
-        result = ProcResult::DefSubclassProc;
+        result = ProcResult::DefWindowProc;
       } else {
         // adjust the maximized borderless window so it doesn't cover the taskbar
         if util::is_maximized(window).unwrap_or(false) {
@@ -2175,8 +2146,8 @@ unsafe fn public_window_callback_inner<T: 'static>(
       }
     }
 
-    win32wm::WM_NCHITTEST => {
-      let window_state = subclass_input.window_state.lock();
+    WM_NCHITTEST => {
+      let window_state = userdata.window_state.lock();
       let window_flags = window_state.window_flags();
 
       // Allow resizing unmaximized non-fullscreen undecorated window
@@ -2222,10 +2193,10 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
           result = hit_result
             .map(|r| ProcResult::Value(LRESULT(r as _)))
-            .unwrap_or(ProcResult::DefSubclassProc);
+            .unwrap_or(ProcResult::DefWindowProc);
         }
       } else {
-        result = ProcResult::DefSubclassProc;
+        result = ProcResult::DefWindowProc;
       }
     }
 
@@ -2239,42 +2210,37 @@ unsafe fn public_window_callback_inner<T: 'static>(
         let _ = DestroyWindow(window);
         result = ProcResult::Value(LRESULT(0));
       } else if msg == *SET_RETAIN_STATE_ON_SIZE_MSG_ID {
-        let mut window_state = subclass_input.window_state.lock();
+        let mut window_state = userdata.window_state.lock();
         window_state.set_window_flags_in_place(|f| {
           f.set(WindowFlags::MARKER_RETAIN_STATE_ON_SIZE, wparam.0 != 0)
         });
         result = ProcResult::Value(LRESULT(0));
       } else if msg == *CHANGE_THEME_MSG_ID {
-        update_theme(subclass_input, window, false);
+        update_theme(userdata, window, false);
         result = ProcResult::Value(LRESULT(0));
       } else if msg == *S_U_TASKBAR_RESTART {
-        let window_state = subclass_input.window_state.lock();
+        let window_state = userdata.window_state.lock();
         let _ = set_skip_taskbar(window, window_state.skip_taskbar);
       }
     }
   };
 
-  subclass_input
+  userdata
     .event_loop_runner
     .catch_unwind(callback)
     .unwrap_or_else(|| result = ProcResult::Value(LRESULT(-1)));
 
   match result {
-    ProcResult::DefSubclassProc => DefSubclassProc(window, msg, wparam, lparam),
     ProcResult::DefWindowProc => DefWindowProcW(window, msg, wparam, lparam),
     ProcResult::Value(val) => val,
   }
 }
 
-fn update_theme<T>(
-  subclass_input: &SubclassInput<T>,
-  window: HWND,
-  from_settings_change_event: bool,
-) {
-  let mut window_state = subclass_input.window_state.lock();
+fn update_theme<T>(userdata: &WindowData<T>, window: HWND, from_settings_change_event: bool) {
+  let mut window_state = userdata.window_state.lock();
   let preferred_theme = window_state
     .preferred_theme
-    .or(*subclass_input.event_loop_preferred_theme.lock());
+    .or(*userdata.event_loop_preferred_theme.lock());
   if from_settings_change_event && preferred_theme.is_some() {
     return;
   }
@@ -2283,7 +2249,7 @@ fn update_theme<T>(
     window_state.current_theme = new_theme;
     mem::drop(window_state);
     unsafe {
-      subclass_input.send_event(Event::WindowEvent {
+      userdata.send_event(Event::WindowEvent {
         window_id: RootWindowId(WindowId(window.0 as _)),
         event: WindowEvent::ThemeChanged(new_theme),
       })
@@ -2309,20 +2275,28 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
   msg: u32,
   wparam: WPARAM,
   lparam: LPARAM,
-  _: usize,
-  subclass_input_ptr: usize,
 ) -> LRESULT {
-  let subclass_input = Box::from_raw(subclass_input_ptr as *mut ThreadMsgTargetSubclassInput<T>);
+  let userdata_ptr = util::GetWindowLongPtrW(window, GWL_USERDATA) as *mut ThreadMsgTargetData<T>;
+  if userdata_ptr.is_null() {
+    // `userdata_ptr` will always be null for the first `WM_GETMINMAXINFO`, as well as `WM_NCCREATE` and
+    // `WM_CREATE`.
+    return DefWindowProcW(window, msg, wparam, lparam);
+  }
+  let userdata = Box::from_raw(userdata_ptr);
 
-  let mut subclass_removed = false;
+  if msg != WM_PAINT {
+    let _ = RedrawWindow(Some(window), None, None, RDW_INTERNALPAINT);
+  }
+
+  let mut userdata_removed = false;
 
   // I decided to bind the closure to `callback` and pass it to catch_unwind rather than passing
   // the closure to catch_unwind directly so that the match body indendation wouldn't change and
   // the git blame and history would be preserved.
   let callback = || match msg {
     win32wm::WM_NCDESTROY => {
-      remove_event_target_window_subclass::<T>(window);
-      subclass_removed = true;
+      SetWindowLongPtrW(window, GWL_USERDATA, 0);
+      userdata_removed = true;
       let _ = RedrawWindow(Some(window), None, None, RDW_INTERNALPAINT);
       LRESULT(0)
     }
@@ -2333,20 +2307,17 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
       // If the WM_PAINT handler in `public_window_callback` has already flushed the redraw
       // events, `handling_events` will return false and we won't emit a second
       // `RedrawEventsCleared` event.
-      if subclass_input.event_loop_runner.handling_events() {
-        if subclass_input.event_loop_runner.should_buffer() {
+      if userdata.event_loop_runner.handling_events() {
+        if userdata.event_loop_runner.should_buffer() {
           // This branch can be triggered when a nested win32 event loop is triggered
           // inside of the `event_handler` callback.
           let _ = RedrawWindow(Some(window), None, None, RDW_INTERNALPAINT);
         } else {
           // This WM_PAINT handler will never be re-entrant because `flush_paint_messages`
           // doesn't call WM_PAINT for the thread event target (i.e. this window).
-          assert!(flush_paint_messages(
-            None,
-            &subclass_input.event_loop_runner
-          ));
-          subclass_input.event_loop_runner.redraw_events_cleared();
-          process_control_flow(&subclass_input.event_loop_runner);
+          assert!(flush_paint_messages(None, &userdata.event_loop_runner));
+          userdata.event_loop_runner.redraw_events_cleared();
+          process_control_flow(&userdata.event_loop_runner);
         }
       }
 
@@ -2361,7 +2332,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
         _ => unreachable!(),
       };
 
-      subclass_input.send_event(Event::DeviceEvent {
+      userdata.send_event(Event::DeviceEvent {
         device_id: wrap_device_id(lparam.0),
         event,
       });
@@ -2372,7 +2343,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
 
     win32wm::WM_INPUT => {
       if let Some(data) = raw_input::get_raw_input_data(HRAWINPUT(lparam.0 as _)) {
-        handle_raw_input(&subclass_input, data);
+        handle_raw_input(&userdata, data);
         let _ = RedrawWindow(Some(window), None, None, RDW_INTERNALPAINT);
       }
 
@@ -2385,15 +2356,15 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
       // `wParam` is `FALSE` is for if the shutdown gets canceled,
       // and we don't need to handle that case since we didn't do anything prior in response to `WM_QUERYENDSESSION`
       if wparam.0 == TRUE.0 as usize {
-        subclass_input.event_loop_runner.loop_destroyed();
+        userdata.event_loop_runner.loop_destroyed();
       }
       // Note: after we return 0 here, Windows will shut us down
       LRESULT(0)
     }
 
     _ if msg == *USER_EVENT_MSG_ID => {
-      if let Ok(event) = subclass_input.user_event_receiver.recv() {
-        subclass_input.send_event(Event::UserEvent(event));
+      if let Ok(event) = userdata.user_event_receiver.recv() {
+        userdata.send_event(Event::UserEvent(event));
       }
       let _ = RedrawWindow(Some(window), None, None, RDW_INTERNALPAINT);
       LRESULT(0)
@@ -2406,7 +2377,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
     }
     _ if msg == *PROCESS_NEW_EVENTS_MSG_ID => {
       let _ = PostThreadMessageW(
-        subclass_input.event_loop_runner.wait_thread_id(),
+        userdata.event_loop_runner.wait_thread_id(),
         *CANCEL_WAIT_UNTIL_MSG_ID,
         WPARAM(0),
         LPARAM(0),
@@ -2414,7 +2385,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
 
       // if the control_flow is WaitUntil, make sure the given moment has actually passed
       // before emitting NewEvents
-      if let ControlFlow::WaitUntil(wait_until) = subclass_input.event_loop_runner.control_flow() {
+      if let ControlFlow::WaitUntil(wait_until) = userdata.event_loop_runner.control_flow() {
         let mut msg = MSG::default();
         while Instant::now() < wait_until {
           if PeekMessageW(&mut msg, None, 0, 0, PM_NOREMOVE).as_bool() {
@@ -2435,31 +2406,28 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
           }
         }
       }
-      subclass_input.event_loop_runner.poll();
+      userdata.event_loop_runner.poll();
       let _ = RedrawWindow(Some(window), None, None, RDW_INTERNALPAINT);
       LRESULT(0)
     }
     _ => DefSubclassProc(window, msg, wparam, lparam),
   };
 
-  let result = subclass_input
+  let result = userdata
     .event_loop_runner
     .catch_unwind(callback)
     .unwrap_or(LRESULT(-1));
-  if subclass_removed {
-    mem::drop(subclass_input);
+  if userdata_removed {
+    mem::drop(userdata);
   } else {
     // FIXME: this seems to leak intentionally?
     #[allow(unused_must_use)]
-    Box::into_raw(subclass_input);
+    Box::into_raw(userdata);
   }
   result
 }
 
-unsafe fn handle_raw_input<T: 'static>(
-  subclass_input: &ThreadMsgTargetSubclassInput<T>,
-  data: RAWINPUT,
-) {
+unsafe fn handle_raw_input<T: 'static>(userdata: &ThreadMsgTargetData<T>, data: RAWINPUT) {
   use crate::event::{
     DeviceEvent::{Button, Key, Motion, MouseMotion, MouseWheel},
     ElementState::{Pressed, Released},
@@ -2476,21 +2444,21 @@ unsafe fn handle_raw_input<T: 'static>(
       let y = mouse.lLastY as f64;
 
       if x != 0.0 {
-        subclass_input.send_event(Event::DeviceEvent {
+        userdata.send_event(Event::DeviceEvent {
           device_id,
           event: Motion { axis: 0, value: x },
         });
       }
 
       if y != 0.0 {
-        subclass_input.send_event(Event::DeviceEvent {
+        userdata.send_event(Event::DeviceEvent {
           device_id,
           event: Motion { axis: 1, value: y },
         });
       }
 
       if x != 0.0 || y != 0.0 {
-        subclass_input.send_event(Event::DeviceEvent {
+        userdata.send_event(Event::DeviceEvent {
           device_id,
           event: MouseMotion { delta: (x, y) },
         });
@@ -2503,7 +2471,7 @@ unsafe fn handle_raw_input<T: 'static>(
     ) {
       // We must cast to SHORT first, becaues `usButtonData` must be interpreted as signed.
       let delta = mouse.Anonymous.Anonymous.usButtonData as i16 as f32 / WHEEL_DELTA as f32;
-      subclass_input.send_event(Event::DeviceEvent {
+      userdata.send_event(Event::DeviceEvent {
         device_id,
         event: MouseWheel {
           delta: LineDelta(0.0, delta),
@@ -2520,7 +2488,7 @@ unsafe fn handle_raw_input<T: 'static>(
         // seem to be anything else reasonable to do for a mouse
         // button ID.
         let button = (index + 1) as _;
-        subclass_input.send_event(Event::DeviceEvent {
+        userdata.send_event(Event::DeviceEvent {
           device_id,
           event: Button { button, state },
         });
@@ -2626,7 +2594,7 @@ unsafe fn handle_raw_input<T: 'static>(
         _ => (),
       }
     }
-    subclass_input.send_event(Event::DeviceEvent {
+    userdata.send_event(Event::DeviceEvent {
       device_id,
       event: Key(RawKeyEvent {
         physical_key: code,

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -867,19 +867,25 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
       let initdata = createstruct.lpCreateParams;
       let initdata = &mut *(initdata as *mut InitData<'_, T>);
 
-      let runner = initdata.event_loop.runner_shared.clone();
-      if let Some((win, userdata)) = runner.catch_unwind(|| (initdata.post_init)(window)) {
-        initdata.window = Some(win);
-        let userdata = Box::into_raw(Box::new(userdata));
-        util::SetWindowLongPtrW(window, GWL_USERDATA, userdata as isize);
-        userdata
-      } else {
-        return LRESULT(-1);
-      }
+      return match unsafe { initdata.on_nccreate(window) } {
+        Some(userdata) => unsafe {
+          util::SetWindowLongPtrW(window, GWL_USERDATA, userdata);
+          DefWindowProcW(window, msg, wparam, lparam)
+        },
+        None => LRESULT(-1), // failed to create the window
+      };
     }
     // Getting here should quite frankly be impossible,
     // but we'll make window creation fail here just in case.
     (0, WM_CREATE) => return LRESULT(-1),
+    (_, WM_CREATE) => unsafe {
+      let createstruct = &mut *(lparam.0 as *mut CREATESTRUCTW);
+      let initdata = createstruct.lpCreateParams;
+      let initdata = &mut *(initdata as *mut InitData<'_, T>);
+
+      initdata.on_create();
+      return DefWindowProcW(window, msg, wparam, lparam);
+    },
     (0, _) => return DefWindowProcW(window, msg, wparam, lparam),
     _ => userdata as *mut WindowData<T>,
   };
@@ -889,7 +895,7 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
 
     userdata.recurse_depth.set(userdata.recurse_depth.get() + 1);
 
-    let result = public_window_callback_inner(window, msg, wparam, lparam, &userdata);
+    let result = public_window_callback_inner(window, msg, wparam, lparam, userdata);
 
     let userdata_removed = userdata.userdata_removed.get();
     let recurse_depth = userdata.recurse_depth.get() - 1;

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -859,7 +859,7 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
   wparam: WPARAM,
   lparam: LPARAM,
 ) -> LRESULT {
-  let userdata = GetWindowLongPtrW(window, GWL_USERDATA);
+  let userdata = util::GetWindowLongPtrW(window, GWL_USERDATA);
   let userdata_ptr = match (userdata, msg) {
     (0, WM_NCCREATE) => {
       let createstruct = &mut *(lparam.0 as *mut CREATESTRUCTW);
@@ -1051,7 +1051,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
     }
 
     win32wm::WM_NCDESTROY => {
-      SetWindowLongPtrW(window, GWL_USERDATA, 0);
+      util::SetWindowLongPtrW(window, GWL_USERDATA, 0);
       userdata.userdata_removed.set(true);
       result = ProcResult::Value(LRESULT(0));
     }
@@ -2292,7 +2292,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
   // the git blame and history would be preserved.
   let callback = || match msg {
     win32wm::WM_NCDESTROY => {
-      SetWindowLongPtrW(window, GWL_USERDATA, 0);
+      util::SetWindowLongPtrW(window, GWL_USERDATA, 0);
       userdata_removed = true;
       let _ = RedrawWindow(Some(window), None, None, RDW_INTERNALPAINT);
       LRESULT(0)

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -899,7 +899,7 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
   };
 
   if userdata_removed && recurse_depth == 0 {
-    drop(Box::from_raw(userdata_ptr));
+    drop(Box::from_raw(userdata_ptr))
   }
 
   result
@@ -2284,10 +2284,6 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
   }
   let userdata = Box::from_raw(userdata_ptr);
 
-  if msg != WM_PAINT {
-    let _ = RedrawWindow(Some(window), None, None, RDW_INTERNALPAINT);
-  }
-
   let mut userdata_removed = false;
 
   // I decided to bind the closure to `callback` and pass it to catch_unwind rather than passing
@@ -2418,11 +2414,9 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
     .catch_unwind(callback)
     .unwrap_or(LRESULT(-1));
   if userdata_removed {
-    mem::drop(userdata);
+    drop(userdata);
   } else {
-    // FIXME: this seems to leak intentionally?
-    #[allow(unused_must_use)]
-    Box::into_raw(userdata);
+    Box::leak(userdata);
   }
   result
 }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -21,7 +21,7 @@ use std::{
   time::{Duration, Instant},
 };
 use windows::{
-  core::{s, BOOL, PCWSTR},
+  core::{s, w, BOOL, PCWSTR},
   Win32::{
     Foundation::{
       HANDLE, HINSTANCE, HWND, LPARAM, LRESULT, POINT, RECT, TRUE, WAIT_TIMEOUT, WPARAM,
@@ -43,7 +43,6 @@ use windows::{
     },
   },
 };
-use windows_core::w;
 
 use crate::{
   dpi::{PhysicalPosition, PhysicalSize, PixelUnit},
@@ -54,7 +53,7 @@ use crate::{
   monitor::MonitorHandle as RootMonitorHandle,
   platform_impl::platform::{
     dark_mode::try_window_theme,
-    dpi::{become_dpi_aware, dpi_to_scale_factor, enable_non_client_dpi_scaling},
+    dpi::{become_dpi_aware, dpi_to_scale_factor},
     keyboard::is_msg_keyboard_related,
     keyboard_layout::LAYOUT_CACHE,
     minimal_ime::is_msg_ime_related,
@@ -1019,10 +1018,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
       result = ProcResult::Value(LRESULT(0));
     }
 
-    win32wm::WM_NCCREATE => {
-      enable_non_client_dpi_scaling(window);
-      result = ProcResult::DefWindowProc;
-    }
     win32wm::WM_NCLBUTTONDOWN => {
       if wparam.0 == HTCAPTION as _ {
         let _ = PostMessageW(Some(window), WM_MOUSEMOVE, WPARAM(0), lparam);

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -27,7 +27,7 @@ use crate::{
 pub(crate) type EventLoopRunnerShared<T> = Rc<EventLoopRunner<T>>;
 pub(crate) struct EventLoopRunner<T: 'static> {
   // The event loop's win32 handles
-  thread_msg_target: HWND,
+  pub(super) thread_msg_target: HWND,
   wait_thread_id: u32,
 
   control_flow: Cell<ControlFlow>,

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -27,7 +27,7 @@ use crate::{
 pub(crate) type EventLoopRunnerShared<T> = Rc<EventLoopRunner<T>>;
 pub(crate) struct EventLoopRunner<T: 'static> {
   // The event loop's win32 handles
-  pub(super) thread_msg_target: HWND,
+  thread_msg_target: HWND,
   wait_thread_id: u32,
 
   control_flow: Cell<ControlFlow>,

--- a/src/platform_impl/windows/keyboard.rs
+++ b/src/platform_impl/windows/keyboard.rs
@@ -108,7 +108,7 @@ impl KeyEventBuilder {
         }
 
         if msg_kind == win32wm::WM_SYSKEYDOWN {
-          *result = ProcResult::DefSubclassProc;
+          *result = ProcResult::DefWindowProc;
         } else {
           *result = ProcResult::Value(LRESULT(0));
         }
@@ -268,7 +268,7 @@ impl KeyEventBuilder {
       }
       win32wm::WM_KEYUP | win32wm::WM_SYSKEYUP => {
         if msg_kind == win32wm::WM_SYSKEYUP {
-          *result = ProcResult::DefSubclassProc;
+          *result = ProcResult::DefWindowProc;
         } else {
           *result = ProcResult::Value(LRESULT(0));
         }

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -21,7 +21,7 @@ use once_cell::sync::Lazy;
 use windows::{
   core::{BOOL, HRESULT, PCSTR, PCWSTR},
   Win32::{
-    Foundation::{COLORREF, FARPROC, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM},
+    Foundation::{COLORREF, FARPROC, HWND, LPARAM, POINT, RECT, WPARAM},
     Globalization::lstrlenW,
     Graphics::Gdi::{ClientToScreen, InvalidateRgn, HMONITOR},
     System::LibraryLoader::*,
@@ -396,15 +396,6 @@ pub fn PRIMARYLANGID(hkl: HKL) -> u32 {
 #[inline]
 pub fn RGB<T: Into<u32>>(r: T, g: T, b: T) -> COLORREF {
   COLORREF(r.into() | (g.into() << 8) | (b.into() << 16))
-}
-
-pub unsafe extern "system" fn call_default_window_proc(
-  hwnd: HWND,
-  msg: u32,
-  wparam: WPARAM,
-  lparam: LPARAM,
-) -> LRESULT {
-  DefWindowProcW(hwnd, msg, wparam, lparam)
 }
 
 pub fn get_instance_handle() -> windows::Win32::Foundation::HMODULE {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -11,6 +11,7 @@ use std::{
   ffi::OsStr,
   io, mem,
   os::windows::ffi::OsStrExt,
+  panic,
   sync::Arc,
 };
 
@@ -1140,7 +1141,7 @@ impl<T> InitData<'_, T> {
 
       let file_drop_runner = self.event_loop.runner_shared.clone();
       let file_drop_handler: IDropTarget = FileDropHandler::new(
-        win.window.0,
+        win.hwnd(),
         Box::new(move |event| {
           if let Ok(e) = event.map_nonuser_event() {
             file_drop_runner.send_event(e)
@@ -1149,13 +1150,13 @@ impl<T> InitData<'_, T> {
       )
       .into();
 
-      assert!(RegisterDragDrop(win.window.0, &file_drop_handler).is_ok());
+      assert!(RegisterDragDrop(win.hwnd(), &file_drop_handler).is_ok());
       Some(file_drop_handler)
     } else {
       None
     };
 
-    self.event_loop.runner_shared.register_window(win.window.0);
+    self.event_loop.runner_shared.register_window(win.hwnd());
 
     KEY_EVENT_BUILDERS
       .lock()
@@ -1176,17 +1177,15 @@ impl<T> InitData<'_, T> {
   // callback.
   pub unsafe fn on_nccreate(&mut self, window: HWND) -> Option<isize> {
     let runner = self.event_loop.runner_shared.clone();
-    let result = runner.catch_unwind(|| {
+    let (win, userdata) = runner.catch_unwind(|| {
       let window = unsafe { self.create_window(window) };
       let window_data = unsafe { self.create_window_data(&window) };
       (window, window_data)
-    });
+    })?;
 
-    result.map(|(win, userdata)| {
-      self.window = Some(win);
-      let userdata = Box::into_raw(Box::new(userdata));
-      userdata as _
-    })
+    self.window = Some(win);
+    let userdata = Box::into_raw(Box::new(userdata));
+    Some(userdata as _)
   }
 
   pub unsafe fn on_create(&mut self) {
@@ -1273,8 +1272,6 @@ unsafe fn init<T: 'static>(
       None
     }
   };
-
-  // creating the real window this time, by using the functions in `extra_functions`
 
   let (style, ex_style) = window_flags.to_window_styles();
   let title = util::encode_wide(&attributes.title);
@@ -1379,6 +1376,11 @@ unsafe fn init<T: 'static>(
     GetModuleHandleW(PCWSTR::null()).map(Into::into).ok(),
     Some(&mut initdata as *mut _ as *mut _),
   )?;
+
+  // If the window creation in `InitData` panicked, then should resume panicking here
+  if let Err(panic_error) = event_loop.runner_shared.take_panic_error() {
+    panic::resume_unwind(panic_error)
+  }
 
   if !IsWindow(Some(handle)).as_bool() {
     return Err(os_error!(OsError::IoError(io::Error::last_os_error())));

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1187,8 +1187,7 @@ where
         pl_attribs.clone(),
         window_flags,
         event_loop,
-      )
-      .unwrap();
+      );
       let window_data = create_window_data(&mut window);
       (window, window_data)
     },
@@ -1306,12 +1305,12 @@ unsafe fn post_init<T: 'static>(
   pl_attribs: PlatformSpecificWindowBuilderAttributes,
   window_flags: WindowFlags,
   event_loop: &EventLoopWindowTarget<T>,
-) -> Result<Window, RootOsError> {
+) -> Window {
   // Register for touch events if applicable
   {
     let digitizer = GetSystemMetrics(SM_DIGITIZER) as u32;
     if digitizer & NID_READY != 0 {
-      RegisterTouchWindow(real_window.0, TWF_WANTPALM)?;
+      let _ = RegisterTouchWindow(real_window.0, TWF_WANTPALM);
     }
   }
 
@@ -1387,7 +1386,7 @@ unsafe fn post_init<T: 'static>(
   win.set_visible(attributes.visible);
   win.set_closable(attributes.closable);
 
-  Ok(win)
+  win
 }
 
 unsafe fn register_window_class<T: 'static>(window_classname: &str) -> Vec<u16> {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -18,9 +18,7 @@ use crossbeam_channel as channel;
 use windows::{
   core::PCWSTR,
   Win32::{
-    Foundation::{
-      self as win32f, HINSTANCE, HMODULE, HWND, LPARAM, LRESULT, POINT, POINTS, RECT, WPARAM,
-    },
+    Foundation::{self as win32f, HINSTANCE, HMODULE, HWND, LPARAM, POINT, POINTS, RECT, WPARAM},
     Graphics::{
       Dwm::{DwmEnableBlurBehindWindow, DWM_BB_BLURREGION, DWM_BB_ENABLE, DWM_BLURBEHIND},
       Gdi::*,
@@ -29,7 +27,7 @@ use windows::{
     UI::{
       Input::{Ime::*, KeyboardAndMouse::*, Touch::*},
       Shell::{ITaskbarList4 as ITaskbarList, TaskbarList, *},
-      WindowsAndMessaging::{self as win32wm, *},
+      WindowsAndMessaging::*,
     },
   },
 };
@@ -61,6 +59,8 @@ use super::{
   keyboard::{KeyEventBuilder, KEY_EVENT_BUILDERS},
   util::calculate_insets_for_dpi,
 };
+
+use super::event_loop::WindowData;
 
 /// A simple non-owning wrapper around a window.
 #[derive(Clone, Copy)]
@@ -97,7 +97,7 @@ impl Window {
     // done. you owe me -- ossi
     unsafe {
       let drag_and_drop = pl_attr.drag_and_drop;
-      init(w_attr, pl_attr, event_loop).map(|win| {
+      init(w_attr, pl_attr, event_loop, |win| {
         let file_drop_handler = if drag_and_drop {
           // It is ok if the initialize result is `S_FALSE` because it might happen that
           // multiple windows are created on the same thread.
@@ -132,17 +132,16 @@ impl Window {
           None
         };
 
-        let subclass_input = event_loop::SubclassInput {
+        event_loop.runner_shared.register_window(win.window.0);
+
+        WindowData {
           window_state: win.window_state.clone(),
           event_loop_runner: event_loop.runner_shared.clone(),
           _file_drop_handler: file_drop_handler,
-          subclass_removed: Cell::new(false),
+          userdata_removed: Cell::new(false),
           recurse_depth: Cell::new(0),
           event_loop_preferred_theme: event_loop.preferred_theme.clone(),
-        };
-
-        event_loop::subclass_window(win.window.0, subclass_input);
-        win
+        }
       })
     }
   }
@@ -1113,13 +1112,26 @@ impl Drop for Window {
   }
 }
 
-unsafe fn init<T: 'static>(
+pub(super) struct InitData<'a, T: 'static> {
+  // inputs
+  pub event_loop: &'a EventLoopWindowTarget<T>,
+  pub post_init: &'a dyn Fn(HWND) -> (Window, WindowData<T>),
+  // outputs
+  pub window: Option<Window>,
+}
+
+unsafe fn init<T, F>(
   attributes: WindowAttributes,
   pl_attribs: PlatformSpecificWindowBuilderAttributes,
   event_loop: &EventLoopWindowTarget<T>,
-) -> Result<Window, RootOsError> {
+  create_window_data: F,
+) -> Result<Window, RootOsError>
+where
+  T: 'static,
+  F: Fn(&mut Window) -> WindowData<T>,
+{
   // registering the window class
-  let class_name = register_window_class(&pl_attribs.window_classname);
+  let class_name = register_window_class::<T>(&pl_attribs.window_classname);
 
   let mut window_flags = WindowFlags::empty();
   window_flags.set(WindowFlags::MARKER_DECORATIONS, attributes.decorations);
@@ -1166,109 +1178,135 @@ unsafe fn init<T: 'static>(
     }
   };
 
-  // creating the real window this time, by using the functions in `extra_functions`
-  let real_window = {
-    let (style, ex_style) = window_flags.to_window_styles();
-    let title = util::encode_wide(&attributes.title);
-
-    let (target_monitor, position) = attributes
-      .position
-      .and_then(|p| {
-        monitor::available_monitors()
-          .into_iter()
-          .find_map(|monitor| {
-            let dpi = monitor.dpi();
-            let scale_factor = dpi_to_scale_factor(dpi);
-            let position = p.to_physical::<i32>(scale_factor);
-            let (x, y): (i32, i32) = monitor.position().into();
-            let (width, height): (i32, i32) = monitor.size().into();
-
-            let frame_thickness = if window_flags.contains_shadow() {
-              util::get_frame_thickness(dpi)
-            } else {
-              0
-            };
-
-            // Only the starting position x needs to be accounted
-            if x <= position.x + frame_thickness
-              && position.x <= x + width
-              && y <= position.y
-              && position.y <= y + height
-            {
-              Some((monitor, position.into()))
-            } else {
-              None
-            }
-          })
-      })
-      .unwrap_or_else(|| (monitor::primary_monitor(), (CW_USEDEFAULT, CW_USEDEFAULT)));
-
-    let desired_size = attributes
-      .inner_size
-      .unwrap_or_else(|| PhysicalSize::new(800, 600).into());
-    let clamped_size = attributes
-      .inner_size_constraints
-      .clamp(desired_size, target_monitor.scale_factor());
-
-    // Best effort: try to create the window with the requested inner size
-    let adjusted_size = {
-      let (mut w, mut h): (i32, i32) = clamped_size
-        .to_physical::<u32>(target_monitor.scale_factor())
-        .into();
-
-      if window_flags.contains(WindowFlags::MARKER_DECORATIONS) {
-        let mut rect = RECT {
-          left: 0,
-          top: 0,
-          right: w,
-          bottom: h,
-        };
-
-        unsafe {
-          AdjustWindowRectEx(
-            &mut rect,
-            window_flags.to_adjusted_window_styles().0,
-            pl_attribs.menu.is_some(),
-            ex_style,
-          )?;
-        }
-
-        w = rect.right - rect.left;
-        h = rect.bottom - rect.top;
-      } else if window_flags.undecorated_with_shadows() {
-        let dpi = target_monitor.dpi();
-        let insets = calculate_insets_for_dpi(dpi);
-        w += insets.left + insets.right;
-        h += insets.top + insets.bottom;
-      }
-
-      (w, h)
-    };
-
-    let handle = CreateWindowExW(
-      ex_style,
-      PCWSTR::from_raw(class_name.as_ptr()),
-      PCWSTR::from_raw(title.as_ptr()),
-      style,
-      position.0,
-      position.1,
-      adjusted_size.0,
-      adjusted_size.1,
-      parent,
-      pl_attribs.menu,
-      GetModuleHandleW(PCWSTR::null()).map(Into::into).ok(),
-      Some(Box::into_raw(Box::new(window_flags)) as _),
-    )?;
-
-    if !IsWindow(Some(handle)).as_bool() {
-      return Err(os_error!(OsError::IoError(io::Error::last_os_error())));
-    }
-
-    super::dark_mode::allow_dark_mode_for_window(handle, true);
-
-    WindowWrapper(handle)
+  let mut initdata = InitData {
+    event_loop,
+    post_init: &|hwnd| {
+      let mut window = post_init(
+        WindowWrapper(hwnd),
+        attributes.clone(),
+        pl_attribs.clone(),
+        window_flags,
+        event_loop,
+      )
+      .unwrap();
+      let window_data = create_window_data(&mut window);
+      (window, window_data)
+    },
+    window: None,
   };
 
+  // creating the real window this time, by using the functions in `extra_functions`
+
+  let (style, ex_style) = window_flags.to_window_styles();
+  let title = util::encode_wide(&attributes.title);
+
+  let (target_monitor, position) = attributes
+    .position
+    .and_then(|p| {
+      monitor::available_monitors()
+        .into_iter()
+        .find_map(|monitor| {
+          let dpi = monitor.dpi();
+          let scale_factor = dpi_to_scale_factor(dpi);
+          let position = p.to_physical::<i32>(scale_factor);
+          let (x, y): (i32, i32) = monitor.position().into();
+          let (width, height): (i32, i32) = monitor.size().into();
+
+          let frame_thickness = if window_flags.contains_shadow() {
+            util::get_frame_thickness(dpi)
+          } else {
+            0
+          };
+
+          // Only the starting position x needs to be accounted
+          if x <= position.x + frame_thickness
+            && position.x <= x + width
+            && y <= position.y
+            && position.y <= y + height
+          {
+            Some((monitor, position.into()))
+          } else {
+            None
+          }
+        })
+    })
+    .unwrap_or_else(|| (monitor::primary_monitor(), (CW_USEDEFAULT, CW_USEDEFAULT)));
+
+  let desired_size = attributes
+    .inner_size
+    .unwrap_or_else(|| PhysicalSize::new(800, 600).into());
+  let clamped_size = attributes
+    .inner_size_constraints
+    .clamp(desired_size, target_monitor.scale_factor());
+
+  // Best effort: try to create the window with the requested inner size
+  let adjusted_size = {
+    let (mut w, mut h): (i32, i32) = clamped_size
+      .to_physical::<u32>(target_monitor.scale_factor())
+      .into();
+
+    if window_flags.contains(WindowFlags::MARKER_DECORATIONS) {
+      let mut rect = RECT {
+        left: 0,
+        top: 0,
+        right: w,
+        bottom: h,
+      };
+
+      unsafe {
+        AdjustWindowRectEx(
+          &mut rect,
+          window_flags.to_adjusted_window_styles().0,
+          pl_attribs.menu.is_some(),
+          ex_style,
+        )?;
+      }
+
+      w = rect.right - rect.left;
+      h = rect.bottom - rect.top;
+    } else if window_flags.undecorated_with_shadows() {
+      let dpi = target_monitor.dpi();
+      let insets = calculate_insets_for_dpi(dpi);
+      w += insets.left + insets.right;
+      h += insets.top + insets.bottom;
+    }
+
+    (w, h)
+  };
+
+  let handle = CreateWindowExW(
+    ex_style,
+    PCWSTR::from_raw(class_name.as_ptr()),
+    PCWSTR::from_raw(title.as_ptr()),
+    style,
+    position.0,
+    position.1,
+    adjusted_size.0,
+    adjusted_size.1,
+    parent,
+    pl_attribs.menu,
+    GetModuleHandleW(PCWSTR::null()).map(Into::into).ok(),
+    Some(&mut initdata as *mut _ as *mut _),
+  )?;
+
+  if !IsWindow(Some(handle)).as_bool() {
+    return Err(os_error!(OsError::IoError(io::Error::last_os_error())));
+  }
+
+  super::dark_mode::allow_dark_mode_for_window(handle, true);
+
+  // If the handle is non-null, then window creation must have succeeded, which means
+  // that we *must* have populated the `InitData.window` field.
+  Ok(initdata.window.unwrap())
+}
+
+unsafe fn post_init<T: 'static>(
+  real_window: WindowWrapper,
+  attributes: WindowAttributes,
+  pl_attribs: PlatformSpecificWindowBuilderAttributes,
+  window_flags: WindowFlags,
+  event_loop: &EventLoopWindowTarget<T>,
+) -> Result<Window, RootOsError> {
   // Register for touch events if applicable
   {
     let digitizer = GetSystemMetrics(SM_DIGITIZER) as u32;
@@ -1352,13 +1390,13 @@ unsafe fn init<T: 'static>(
   Ok(win)
 }
 
-unsafe fn register_window_class(window_classname: &str) -> Vec<u16> {
+unsafe fn register_window_class<T: 'static>(window_classname: &str) -> Vec<u16> {
   let class_name = util::encode_wide(window_classname);
 
   let class = WNDCLASSEXW {
     cbSize: mem::size_of::<WNDCLASSEXW>() as u32,
     style: CS_HREDRAW | CS_VREDRAW | CS_OWNDC,
-    lpfnWndProc: Some(window_proc),
+    lpfnWndProc: Some(super::event_loop::public_window_callback::<T>),
     cbClsExtra: 0,
     cbWndExtra: 0,
     hInstance: HINSTANCE(GetModuleHandleW(PCWSTR::null()).unwrap_or_default().0),
@@ -1377,62 +1415,6 @@ unsafe fn register_window_class(window_classname: &str) -> Vec<u16> {
   RegisterClassExW(&class);
 
   class_name
-}
-
-unsafe extern "system" fn window_proc(
-  window: HWND,
-  msg: u32,
-  wparam: WPARAM,
-  lparam: LPARAM,
-) -> LRESULT {
-  // This window procedure is only needed until the subclass procedure is attached.
-  // we need this because we need to respond to WM_NCCALCSIZE as soon as possible
-  // in order to make the window borderless if needed.
-  match msg {
-    win32wm::WM_NCCALCSIZE => {
-      let userdata = util::GetWindowLongPtrW(window, GWL_USERDATA);
-      if userdata != 0 {
-        let window_flags = WindowFlags::from_bits_truncate(userdata as _);
-
-        if wparam == WPARAM(0) || window_flags.contains(WindowFlags::MARKER_DECORATIONS) {
-          return DefWindowProcW(window, msg, wparam, lparam);
-        }
-
-        // adjust the maximized borderless window so it doesn't cover the taskbar
-        if util::is_maximized(window).unwrap_or(false) {
-          let params = &mut *(lparam.0 as *mut NCCALCSIZE_PARAMS);
-          if let Ok(monitor_info) =
-            monitor::get_monitor_info(MonitorFromRect(&params.rgrc[0], MONITOR_DEFAULTTONULL))
-          {
-            params.rgrc[0] = monitor_info.monitorInfo.rcWork;
-          }
-        } else if window_flags.contains(WindowFlags::MARKER_UNDECORATED_SHADOW) {
-          let params = &mut *(lparam.0 as *mut NCCALCSIZE_PARAMS);
-
-          let insets = util::calculate_window_insets(window);
-
-          params.rgrc[0].left += insets.left;
-          params.rgrc[0].top += insets.top;
-          params.rgrc[0].right -= insets.right;
-          params.rgrc[0].bottom -= insets.bottom;
-        }
-        return LRESULT(0); // return 0 here to make the window borderless
-      }
-
-      DefWindowProcW(window, msg, wparam, lparam)
-    }
-    win32wm::WM_NCCREATE => {
-      let userdata = util::GetWindowLongPtrW(window, GWL_USERDATA);
-      if userdata == 0 {
-        let createstruct = &*(lparam.0 as *const CREATESTRUCTW);
-        let userdata = createstruct.lpCreateParams;
-        let window_flags = Box::from_raw(userdata as *mut WindowFlags);
-        util::SetWindowLongPtrW(window, GWL_USERDATA, window_flags.bits() as _);
-      }
-      DefWindowProcW(window, msg, wparam, lparam)
-    }
-    _ => DefWindowProcW(window, msg, wparam, lparam),
-  }
 }
 
 struct ComInitialized(Option<()>);

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -95,55 +95,7 @@ impl Window {
     // First person to remove the need for cloning here gets a cookie!
     //
     // done. you owe me -- ossi
-    unsafe {
-      let drag_and_drop = pl_attr.drag_and_drop;
-      init(w_attr, pl_attr, event_loop, |win| {
-        let file_drop_handler = if drag_and_drop {
-          // It is ok if the initialize result is `S_FALSE` because it might happen that
-          // multiple windows are created on the same thread.
-          if let Err(error) = OleInitialize(None) {
-            match error.code() {
-              win32f::OLE_E_WRONGCOMPOBJ => {
-                panic!("OleInitialize failed! Result was: `OLE_E_WRONGCOMPOBJ`")
-              }
-              win32f::RPC_E_CHANGED_MODE => panic!(
-                "OleInitialize failed! Result was: `RPC_E_CHANGED_MODE`. \
-                Make sure other crates are not using multithreaded COM library \
-                on the same thread or disable drag and drop support."
-              ),
-              _ => (),
-            };
-          }
-
-          let file_drop_runner = event_loop.runner_shared.clone();
-          let file_drop_handler: IDropTarget = FileDropHandler::new(
-            win.window.0,
-            Box::new(move |event| {
-              if let Ok(e) = event.map_nonuser_event() {
-                file_drop_runner.send_event(e)
-              }
-            }),
-          )
-          .into();
-
-          assert!(RegisterDragDrop(win.window.0, &file_drop_handler).is_ok());
-          Some(file_drop_handler)
-        } else {
-          None
-        };
-
-        event_loop.runner_shared.register_window(win.window.0);
-
-        WindowData {
-          window_state: win.window_state.clone(),
-          event_loop_runner: event_loop.runner_shared.clone(),
-          _file_drop_handler: file_drop_handler,
-          userdata_removed: Cell::new(false),
-          recurse_depth: Cell::new(0),
-          event_loop_preferred_theme: event_loop.preferred_theme.clone(),
-        }
-      })
-    }
+    unsafe { init::<T>(w_attr, pl_attr, event_loop) }
   }
 
   pub fn set_title(&self, text: &str) {
@@ -1115,21 +1067,165 @@ impl Drop for Window {
 pub(super) struct InitData<'a, T: 'static> {
   // inputs
   pub event_loop: &'a EventLoopWindowTarget<T>,
-  pub post_init: &'a dyn Fn(HWND) -> (Window, WindowData<T>),
+  pub attributes: WindowAttributes,
+  pub pl_attribs: PlatformSpecificWindowBuilderAttributes,
+  pub window_flags: WindowFlags,
   // outputs
   pub window: Option<Window>,
 }
 
-unsafe fn init<T, F>(
+impl<T> InitData<'_, T> {
+  unsafe fn create_window(&self, window: HWND) -> Window {
+    // Register for touch events if applicable
+    {
+      let digitizer = GetSystemMetrics(SM_DIGITIZER) as u32;
+      if digitizer & NID_READY != 0 {
+        let _ = RegisterTouchWindow(window, TWF_WANTPALM);
+      }
+    }
+
+    let dpi = hwnd_dpi(window);
+    let scale_factor = dpi_to_scale_factor(dpi);
+
+    // If the system theme is dark, we need to set the window theme now
+    // before we update the window flags (and possibly show the
+    // window for the first time).
+    let current_theme = try_window_theme(
+      window,
+      self
+        .attributes
+        .preferred_theme
+        .or(*self.event_loop.preferred_theme.lock()),
+      false,
+    );
+
+    let window_state = {
+      let window_state = WindowState::new(
+        &self.attributes,
+        None,
+        scale_factor,
+        current_theme,
+        self.attributes.preferred_theme,
+        self.attributes.background_color,
+      );
+      let window_state = Arc::new(Mutex::new(window_state));
+      WindowState::set_window_flags(window_state.lock(), window, |f| *f = self.window_flags);
+      window_state
+    };
+
+    Window {
+      window: WindowWrapper(window),
+      window_state,
+      thread_executor: self.event_loop.create_thread_executor(),
+    }
+  }
+
+  unsafe fn create_window_data(&self, win: &Window) -> event_loop::WindowData<T> {
+    let file_drop_handler = if self.pl_attribs.drag_and_drop {
+      // It is ok if the initialize result is `S_FALSE` because it might happen that
+      // multiple windows are created on the same thread.
+      if let Err(error) = OleInitialize(None) {
+        match error.code() {
+          win32f::OLE_E_WRONGCOMPOBJ => {
+            panic!("OleInitialize failed! Result was: `OLE_E_WRONGCOMPOBJ`")
+          }
+          win32f::RPC_E_CHANGED_MODE => panic!(
+            "OleInitialize failed! Result was: `RPC_E_CHANGED_MODE`. \
+                Make sure other crates are not using multithreaded COM library \
+                on the same thread or disable drag and drop support."
+          ),
+          _ => (),
+        };
+      }
+
+      let file_drop_runner = self.event_loop.runner_shared.clone();
+      let file_drop_handler: IDropTarget = FileDropHandler::new(
+        win.window.0,
+        Box::new(move |event| {
+          if let Ok(e) = event.map_nonuser_event() {
+            file_drop_runner.send_event(e)
+          }
+        }),
+      )
+      .into();
+
+      assert!(RegisterDragDrop(win.window.0, &file_drop_handler).is_ok());
+      Some(file_drop_handler)
+    } else {
+      None
+    };
+
+    self.event_loop.runner_shared.register_window(win.window.0);
+
+    KEY_EVENT_BUILDERS
+      .lock()
+      .insert(win.id(), KeyEventBuilder::default());
+
+    WindowData {
+      window_state: win.window_state.clone(),
+      event_loop_runner: self.event_loop.runner_shared.clone(),
+      _file_drop_handler: file_drop_handler,
+      userdata_removed: Cell::new(false),
+      recurse_depth: Cell::new(0),
+      event_loop_preferred_theme: self.event_loop.preferred_theme.clone(),
+    }
+  }
+
+  // Returns a pointer to window user data on success.
+  // The user data will be registered for the window and can be accessed within the window event
+  // callback.
+  pub unsafe fn on_nccreate(&mut self, window: HWND) -> Option<isize> {
+    let runner = self.event_loop.runner_shared.clone();
+    let result = runner.catch_unwind(|| {
+      let window = unsafe { self.create_window(window) };
+      let window_data = unsafe { self.create_window_data(&window) };
+      (window, window_data)
+    });
+
+    result.map(|(win, userdata)| {
+      self.window = Some(win);
+      let userdata = Box::into_raw(Box::new(userdata));
+      userdata as _
+    })
+  }
+
+  pub unsafe fn on_create(&mut self) {
+    let win = self.window.as_mut().expect("failed window creation");
+
+    // making the window transparent
+    if self.attributes.transparent && !self.pl_attribs.no_redirection_bitmap {
+      // Empty region for the blur effect, so the window is fully transparent
+      let region = CreateRectRgn(0, 0, -1, -1);
+
+      let bb = DWM_BLURBEHIND {
+        dwFlags: DWM_BB_ENABLE | DWM_BB_BLURREGION,
+        fEnable: true.into(),
+        hRgnBlur: region,
+        fTransitionOnMaximized: false.into(),
+      };
+
+      let _ = DwmEnableBlurBehindWindow(win.hwnd(), &bb);
+      let _ = DeleteObject(region.into());
+    }
+
+    let _ = win.set_skip_taskbar(self.pl_attribs.skip_taskbar);
+    win.set_window_icon(self.attributes.window_icon.clone());
+    win.set_taskbar_icon(self.pl_attribs.taskbar_icon.clone());
+
+    if self.attributes.content_protection {
+      win.set_content_protection(true);
+    }
+
+    win.set_visible(self.attributes.visible);
+    win.set_closable(self.attributes.closable);
+  }
+}
+
+unsafe fn init<T: 'static>(
   attributes: WindowAttributes,
   pl_attribs: PlatformSpecificWindowBuilderAttributes,
   event_loop: &EventLoopWindowTarget<T>,
-  create_window_data: F,
-) -> Result<Window, RootOsError>
-where
-  T: 'static,
-  F: Fn(&mut Window) -> WindowData<T>,
-{
+) -> Result<Window, RootOsError> {
   // registering the window class
   let class_name = register_window_class::<T>(&pl_attribs.window_classname);
 
@@ -1176,22 +1272,6 @@ where
       window_flags.set(WindowFlags::ON_TASKBAR, true);
       None
     }
-  };
-
-  let mut initdata = InitData {
-    event_loop,
-    post_init: &|hwnd| {
-      let mut window = post_init(
-        WindowWrapper(hwnd),
-        attributes.clone(),
-        pl_attribs.clone(),
-        window_flags,
-        event_loop,
-      );
-      let window_data = create_window_data(&mut window);
-      (window, window_data)
-    },
-    window: None,
   };
 
   // creating the real window this time, by using the functions in `extra_functions`
@@ -1273,6 +1353,18 @@ where
     (w, h)
   };
 
+  let fullscreen = attributes.fullscreen.clone();
+  let maximized = attributes.maximized;
+  let menu = pl_attribs.menu;
+
+  let mut initdata = InitData {
+    event_loop,
+    attributes,
+    pl_attribs,
+    window_flags,
+    window: None,
+  };
+
   let handle = CreateWindowExW(
     ex_style,
     PCWSTR::from_raw(class_name.as_ptr()),
@@ -1283,7 +1375,7 @@ where
     adjusted_size.0,
     adjusted_size.1,
     parent,
-    pl_attribs.menu,
+    menu,
     GetModuleHandleW(PCWSTR::null()).map(Into::into).ok(),
     Some(&mut initdata as *mut _ as *mut _),
   )?;
@@ -1296,97 +1388,19 @@ where
 
   // If the handle is non-null, then window creation must have succeeded, which means
   // that we *must* have populated the `InitData.window` field.
-  Ok(initdata.window.unwrap())
-}
+  let window = initdata.window.unwrap();
 
-unsafe fn post_init<T: 'static>(
-  real_window: WindowWrapper,
-  attributes: WindowAttributes,
-  pl_attribs: PlatformSpecificWindowBuilderAttributes,
-  window_flags: WindowFlags,
-  event_loop: &EventLoopWindowTarget<T>,
-) -> Window {
-  // Register for touch events if applicable
-  {
-    let digitizer = GetSystemMetrics(SM_DIGITIZER) as u32;
-    if digitizer & NID_READY != 0 {
-      let _ = RegisterTouchWindow(real_window.0, TWF_WANTPALM);
-    }
+  // Need to set FULLSCREEN or MAXIMIZED after CreateWindowEx
+  // This is because if the size is changed in WM_CREATE, the restored size will be stored in that
+  // size.
+  if fullscreen.is_some() {
+    window.set_fullscreen(fullscreen);
+    force_window_active(window.hwnd());
+  } else if maximized {
+    window.set_maximized(true);
   }
 
-  let dpi = hwnd_dpi(real_window.0);
-  let scale_factor = dpi_to_scale_factor(dpi);
-
-  // making the window transparent
-  if attributes.transparent && !pl_attribs.no_redirection_bitmap {
-    // Empty region for the blur effect, so the window is fully transparent
-    let region = CreateRectRgn(0, 0, -1, -1);
-
-    let bb = DWM_BLURBEHIND {
-      dwFlags: DWM_BB_ENABLE | DWM_BB_BLURREGION,
-      fEnable: true.into(),
-      hRgnBlur: region,
-      fTransitionOnMaximized: false.into(),
-    };
-
-    let _ = DwmEnableBlurBehindWindow(real_window.0, &bb);
-    let _ = DeleteObject(region.into());
-  }
-
-  // If the system theme is dark, we need to set the window theme now
-  // before we update the window flags (and possibly show the
-  // window for the first time).
-  let current_theme = try_window_theme(
-    real_window.0,
-    attributes
-      .preferred_theme
-      .or(*event_loop.preferred_theme.lock()),
-    false,
-  );
-
-  let window_state = {
-    let window_state = WindowState::new(
-      &attributes,
-      None,
-      scale_factor,
-      current_theme,
-      attributes.preferred_theme,
-      attributes.background_color,
-    );
-    let window_state = Arc::new(Mutex::new(window_state));
-    WindowState::set_window_flags(window_state.lock(), real_window.0, |f| *f = window_flags);
-    window_state
-  };
-
-  let win = Window {
-    window: real_window,
-    window_state,
-    thread_executor: event_loop.create_thread_executor(),
-  };
-
-  KEY_EVENT_BUILDERS
-    .lock()
-    .insert(win.id(), KeyEventBuilder::default());
-
-  let _ = win.set_skip_taskbar(pl_attribs.skip_taskbar);
-  win.set_window_icon(attributes.window_icon);
-  win.set_taskbar_icon(pl_attribs.taskbar_icon);
-
-  if attributes.fullscreen.is_some() {
-    win.set_fullscreen(attributes.fullscreen);
-    force_window_active(win.window.0);
-  } else if attributes.maximized {
-    win.set_maximized(true);
-  }
-
-  if attributes.content_protection {
-    win.set_content_protection(true);
-  }
-
-  win.set_visible(attributes.visible);
-  win.set_closable(attributes.closable);
-
-  win
+  Ok(window)
 }
 
 unsafe fn register_window_class<T: 'static>(window_classname: &str) -> Vec<u16> {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1364,7 +1364,7 @@ unsafe fn init<T: 'static>(
     window: None,
   };
 
-  let handle = CreateWindowExW(
+  let result = CreateWindowExW(
     ex_style,
     PCWSTR::from_raw(class_name.as_ptr()),
     PCWSTR::from_raw(title.as_ptr()),
@@ -1377,16 +1377,14 @@ unsafe fn init<T: 'static>(
     menu,
     GetModuleHandleW(PCWSTR::null()).map(Into::into).ok(),
     Some(&mut initdata as *mut _ as *mut _),
-  )?;
+  );
 
   // If the window creation in `InitData` panicked, then should resume panicking here
   if let Err(panic_error) = event_loop.runner_shared.take_panic_error() {
     panic::resume_unwind(panic_error)
   }
 
-  if !IsWindow(Some(handle)).as_bool() {
-    return Err(os_error!(OsError::IoError(io::Error::last_os_error())));
-  }
+  let handle = result?;
 
   super::dark_mode::allow_dark_mode_for_window(handle, true);
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -40,7 +40,7 @@ use crate::{
   monitor::MonitorHandle as RootMonitorHandle,
   platform_impl::platform::{
     dark_mode::try_window_theme,
-    dpi::{dpi_to_scale_factor, hwnd_dpi},
+    dpi::{dpi_to_scale_factor, enable_non_client_dpi_scaling, hwnd_dpi},
     drop_handler::FileDropHandler,
     event_loop::{self, EventLoopWindowTarget, DESTROY_MSG_ID},
     icon::{self, IconType},
@@ -1113,6 +1113,8 @@ impl<T> InitData<'_, T> {
       WindowState::set_window_flags(window_state.lock(), window, |f| *f = self.window_flags);
       window_state
     };
+
+    enable_non_client_dpi_scaling(window);
 
     Window {
       window: WindowWrapper(window),


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Re-land of #140

The original reason for the revert in https://github.com/tauri-apps/tao/pull/156#issuecomment-884843341 was that transparent was broken, this change made sure that still works, tested with the transparent example locally

Fix #1230

The main reason for this change is to fix `with_background_color` doesn't work on initial load since the subclass is attached too late to receive the `WM_ERASEBKGND` message. It might also catch some other similar type of bugs.

This would also pull tao towards winit a bit more so when we switch back, there're lesser behavior change we need to go through.