### PR TITLE
fix(ios): use autorelease_ptr to fix UISceneConfiguration crash

### DIFF
--- a/.changes/ios-multiwindow-crash.md
+++ b/.changes/ios-multiwindow-crash.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Prevent use-after-free in iOS `configurationForConnectingSceneSession` that crashes release builds on launch.

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -643,7 +643,7 @@ pub fn create_delegate_class() {
 
       // Dynamically set the delegate class name
       config.setDelegateClass(Some(super::scene::TaoSceneDelegate::class()));
-      Retained::as_ptr(&config) as _
+      Retained::autorelease_ptr(config) as _
     }
   }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen` 

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Resolves #1244

## Description

[configuration_for_connecting_scene_session](cci:1://file:///Users/matthew/Bethel/Projects/jw-library/src-tauri/patches/tao/src/platform_impl/ios/view.rs:628:2-647:3) uses `Retained::as_ptr(&config)` to return a `UISceneConfiguration` to UIKit. The `Retained` is dropped at the end of the block, calling `objc_release` and deallocating the object before UIKit retains it. In release builds the optimizer drops `config` immediately after `as_ptr`, causing a reliable crash in `-[UIApplication _connectUISceneFromFBSScene:transitionContext:]`.

## Fix

Replace `Retained::as_ptr(&config)` with `Retained::autorelease_ptr(config)`, which transfers ownership to the autorelease pool and keeps the object alive until UIKit retains it.

## Testing

Verified on a physical iPad running iOS 26:

1. Unpatched release build — crashes on every launch
2. Patched release build — launches successfully
3. Reverted to unpatched — crash returns
4. Re-applied patch — launches successfully