### PR TITLE
fix(windows): Fix cursor visibility toggle not working on Windows 

### DIFF
--- a/.changes/fix-windows-cursor.md
+++ b/.changes/fix-windows-cursor.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix cursor visibility not working on window creation and over child windows (like WebView2) on Windows. Closes tauri-apps/tauri#10231

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1296,6 +1296,35 @@ unsafe fn public_window_callback_inner<T: 'static>(
       result = ProcResult::Value(LRESULT(0));
     }
 
+    // When the cursor moves over non-client area (title bar, resize borders),
+    // refresh cursor visibility so ShowCursor counter is reset appropriately.
+    // Also request WM_NCMOUSELEAVE so we can re-hide when leaving non-client area.
+    win32wm::WM_NCMOUSEMOVE => {
+      {
+        let mut w = userdata.window_state.lock();
+        w.mouse.set_cursor_flags(window, |f| *f = *f).ok();
+      }
+
+      let _ = TrackMouseEvent(&mut TRACKMOUSEEVENT {
+        cbSize: mem::size_of::<TRACKMOUSEEVENT>() as u32,
+        dwFlags: TME_LEAVE | TME_NONCLIENT,
+        hwndTrack: window,
+        dwHoverTime: HOVER_DEFAULT,
+      });
+
+      result = ProcResult::DefWindowProc;
+    }
+
+    // When the cursor leaves non-client area (returns to client area or leaves window),
+    // refresh cursor visibility to re-apply ShowCursor(FALSE) if needed.
+    win32wm::WM_NCMOUSELEAVE => {
+      {
+        let mut w = userdata.window_state.lock();
+        w.mouse.set_cursor_flags(window, |f| *f = *f).ok();
+      }
+      result = ProcResult::Value(LRESULT(0));
+    }
+
     win32wm::WM_MOUSEWHEEL => {
       use crate::event::MouseScrollDelta::LineDelta;
 
@@ -1753,27 +1782,31 @@ unsafe fn public_window_callback_inner<T: 'static>(
     }
 
     win32wm::WM_SETCURSOR => {
-      let set_cursor_to = {
-        let window_state = userdata.window_state.lock();
-        // The return value for the preceding `WM_NCHITTEST` message is conveniently
-        // provided through the low-order word of lParam. We use that here since
-        // `WM_MOUSEMOVE` seems to come after `WM_SETCURSOR` for a given cursor movement.
-        let in_client_area = u32::from(util::LOWORD(lparam.0 as u32)) == HTCLIENT;
-        if in_client_area {
-          Some(window_state.mouse.cursor)
-        } else {
-          None
-        }
-      };
+      let window_state = userdata.window_state.lock();
+      // The low-order word of lParam contains the hit-test result (e.g., HTCLIENT).
+      // Additionally, wParam contains the HWND under the cursor. If it is not
+      // our own window (e.g., it's a child window like WebView2), we delegate
+      // to DefWindowProc to avoid overwriting its cursor settings.
+      let in_client_area = u32::from(util::LOWORD(lparam.0 as u32)) == HTCLIENT;
+      let is_hidden = window_state
+        .mouse
+        .cursor_flags()
+        .contains(CursorFlags::HIDDEN);
+      let cursor = window_state.mouse.cursor;
+      drop(window_state);
 
-      match set_cursor_to {
-        Some(cursor) => {
-          if let Ok(cursor) = LoadCursorW(None, cursor.to_windows_cursor()) {
-            SetCursor(Some(cursor));
-          }
-          result = ProcResult::Value(LRESULT(0));
-        }
-        None => result = ProcResult::DefWindowProc,
+      let is_cursor_over_foreign_hwnd = HWND(wparam.0 as *mut _) != window;
+
+      if is_hidden && in_client_area {
+        SetCursor(None);
+        result = ProcResult::Value(LRESULT(1));
+      } else if is_cursor_over_foreign_hwnd || !in_client_area {
+        result = ProcResult::DefWindowProc;
+      } else if let Ok(cursor) = LoadCursorW(None, cursor.to_windows_cursor()) {
+        SetCursor(Some(cursor));
+        result = ProcResult::Value(LRESULT(1));
+      } else {
+        result = ProcResult::DefWindowProc;
       }
     }
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -12,8 +12,8 @@ use crate::{
 use parking_lot::MutexGuard;
 use std::io;
 use windows::Win32::{
-  Foundation::{HWND, LPARAM, RECT, WPARAM},
-  Graphics::Gdi::InvalidateRgn,
+  Foundation::{HWND, LPARAM, POINT, RECT, WPARAM},
+  Graphics::Gdi::{InvalidateRgn, ScreenToClient},
   UI::WindowsAndMessaging::*,
 };
 
@@ -498,7 +498,21 @@ impl CursorFlags {
       }
     }
 
-    let cursor_in_client = self.contains(CursorFlags::IN_WINDOW);
+    let cursor_in_client = unsafe {
+      let mut pt = POINT::default();
+      if GetCursorPos(&mut pt).is_ok() {
+        let mut pt_client = pt;
+        let mut rect = RECT::default();
+        ScreenToClient(window, &mut pt_client).as_bool()
+          && GetClientRect(window, &mut rect).is_ok()
+          && pt_client.x >= 0
+          && pt_client.x < rect.right
+          && pt_client.y >= 0
+          && pt_client.y < rect.bottom
+      } else {
+        self.contains(CursorFlags::IN_WINDOW)
+      }
+    };
     if cursor_in_client {
       util::set_cursor_hidden(self.contains(CursorFlags::HIDDEN));
     } else {


### PR DESCRIPTION
## Summary

This PR fixes an issue where `window.set_cursor_visible(false)` does not work correctly on Windows.
I rewrote https://github.com/tauri-apps/tao/pull/1203.

## Tests

1. cargo test -> PASS
2. cargo fmt --check -> PASS
3. cargo clippy -- -D warnings -> PASS only for the scope of this PR. There are multiple warnings in the code unrelated to this PR, which are not addressed.
4. Added `main_window.set_cursor_visible(false);` to line 41 of `tao\examples\parentwindow.rs` and tested. See the video.
5. Tested with `tao\examples\cursor.rs`. Works normally.
6. Created a test TauriApp and tested the behavior. See the video.
Setup - Created a new Tauri command and implemented it to be called from the frontend:
```rust
// src-tauri\src\lib.rs
#[tauri::command]
fn hide_cursor(window: tauri::WebviewWindow) {
    let _ = window.set_cursor_visible(false);
}

#[tauri::command]
fn show_cursor(window: tauri::WebviewWindow) {
    let _ = window.set_cursor_visible(true);
}
```

https://github.com/user-attachments/assets/e9812926-ccc1-4224-b89e-37e7c6675398


## Environment

```bash
rustup show
Default host: x86_64-pc-windows-msvc
rustup home:  C:\Users\keufcp\.rustup

installed toolchains
--------------------
stable-x86_64-pc-windows-msvc (active, default)

active toolchain
----------------
name: stable-x86_64-pc-windows-msvc
active because: it's the default toolchain
installed targets:
  aarch64-linux-android
  wasm32-unknown-unknown
  wasm32-wasip2
  x86_64-linux-android
  x86_64-pc-windows-msvc

```

```
OS name:                 Microsoft Windows 11 Pro
OS version:              10.0.26200 N/A Build 26200
BIOS version:            American Megatrends Inc. 1825, 2025/10/09
```

Closes tauri-apps/tauri#10231
