### PR TITLE
fix(ios): use minimal windowing control style on iPadOS 26

### DIFF
--- a/.changes/ios-windowing-control-style.md
+++ b/.changes/ios-windowing-control-style.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix iPadOS 26 system window controls overlapping `WKWebView` content by implementing `preferredWindowingControlStyleForScene:` on the scene delegate and returning the `minimal` style. The optional protocol method is a no-op on iOS versions earlier than 26.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,47 +1616,49 @@ dependencies = [
  "bitflags 2.7.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation 0.3.0",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
 name = "objc2-cloud-kit"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1948a9be5f469deadbd6bcb86ad7ff9e47b4f632380139722f7d9840c0d42c"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
  "bitflags 2.7.0",
  "objc2 0.6.4",
- "objc2-foundation 0.3.0",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
 name = "objc2-core-data"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f860f8e841f6d32f754836f51e6bc7777cd7e7053cf18528233f6811d3eceb4"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
  "objc2 0.6.4",
- "objc2-foundation 0.3.0",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.7.0",
+ "dispatch2",
  "objc2 0.6.4",
 ]
 
 [[package]]
 name = "objc2-core-graphics"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dca602628b65356b6513290a21a6405b4d4027b8b250f0b98dddbb28b7de02"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.7.0",
+ "dispatch2",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
@@ -1664,22 +1666,34 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-image"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffa6bea72bf42c78b0b34e89c0bafac877d5f80bf91e159a5d96ea7f693ca56"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
 dependencies = [
  "objc2 0.6.4",
- "objc2-foundation 0.3.0",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
 name = "objc2-core-location"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d31f4c5b5192304996badc466aeadffe1411d73a9bbd3b18b6b2ee9d048b07bd"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
 dependencies = [
  "objc2 0.6.4",
- "objc2-foundation 0.3.0",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.7.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -1702,9 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.7.0",
  "objc2 0.6.4",
@@ -1713,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-io-surface"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161a8b87e32610086e1a7a9e9ec39f84459db7b3a0881c1f16ca5a2605581c19"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.7.0",
  "objc2 0.6.4",
@@ -1749,21 +1763,21 @@ dependencies = [
 
 [[package]]
 name = "objc2-quartz-core"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb3794501bb1bee12f08dcad8c61f2a5875791ad1c6f47faa71a0f033f20071"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.7.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation 0.3.0",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
 name = "objc2-ui-kit"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777a571be14a42a3990d4ebedaeb8b54cd17377ec21b92e8200ac03797b3bee1"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.7.0",
  "block2 0.6.2",
@@ -1774,19 +1788,20 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-core-image",
  "objc2-core-location",
- "objc2-foundation 0.3.0",
- "objc2-quartz-core 0.3.0",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "objc2-user-notifications",
 ]
 
 [[package]]
 name = "objc2-user-notifications"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670fe793adbf3b5e93686d48a05a7ed7ee53dfa65d106ced4805fae8969059b2"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
  "objc2 0.6.4",
- "objc2-foundation 0.3.0",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2424,7 +2439,7 @@ dependencies = [
  "ndk-sys",
  "objc2 0.6.4",
  "objc2-app-kit",
- "objc2-foundation 0.3.0",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "once_cell",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,8 @@ objc2-ui-kit = { version = "0.3", features = [
   "UIScene",
   "UISceneOptions",
   "UIOpenURLContext",
+  "UISceneWindowingControlStyle",
+  "UIWindowScene",
 ] }
 objc2-foundation = { version = "0.3", default-features = false, features = [
   "NSProcessInfo",

--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -8,7 +8,7 @@ use objc2_foundation::{
 };
 use objc2_ui_kit::{
   UIApplication, UIOpenURLContext, UIScene, UISceneConnectionOptions, UISceneDelegate,
-  UISceneSession, UIWindowScene,
+  UISceneSession, UISceneWindowingControlStyle, UIWindowScene, UIWindowSceneDelegate,
 };
 
 use crate::{
@@ -181,5 +181,18 @@ define_class!(
 
     #[unsafe(method(scene:didUpdateUserActivity:))]
     fn scene_didUpdateUserActivity(&self, _scene: &UIScene, _user_activity: &NSUserActivity) {}
+  }
+
+  #[allow(non_snake_case)]
+  unsafe impl UIWindowSceneDelegate for TaoSceneDelegate {
+    #[unsafe(method(preferredWindowingControlStyleForScene:))]
+    fn preferredWindowingControlStyleForScene(
+      &self,
+      _window_scene: &UIWindowScene,
+    ) -> Option<std::ptr::NonNull<UISceneWindowingControlStyle>> {
+      std::ptr::NonNull::new(Retained::autorelease_ptr(
+        UISceneWindowingControlStyle::minimalStyle(),
+      ))
+    }
   }
 );


### PR DESCRIPTION
Resolves tauri-apps/tauri#15521

## Description

iPadOS 26 adds macOS-style system window controls to the top-left corner of every windowed scene. Because a Tao window hosts a fullscreen `WKWebView` with no native toolbar, these controls do not contribute to the safe area and float on top of, overlapping, the web content. There is no native toolbar for them to integrate with.

## Fix

Implement `UIWindowSceneDelegate`'s optional `preferredWindowingControlStyle(for:)` method on `TaoSceneDelegate`, returning the `minimal` style. The `minimal` style places the controls in a safe-area strip above the content instead of floating over it. This is the same approach taken by Flutter and Capacitor.

No runtime version check is needed: `preferredWindowingControlStyleForScene:` is an optional protocol method the system only sends on iPadOS 26+, and the `UISceneWindowingControlStyle` class is resolved lazily at call time. On earlier iOS versions the conformance is inert and nothing changes.

This also enables the `UISceneWindowingControlStyle` and `UIWindowScene` features on `objc2-ui-kit` and bumps the `objc2` crate family `0.3.0` -> `0.3.2`, since the `UISceneWindowingControlStyle` type does not exist in `0.3.0`. The bump is patch-level and the macOS build is unaffected.

## Testing

- `cargo check --target aarch64-apple-ios -p tao` compiles with no errors.
- `cargo check -p tao` (macOS host) still compiles, confirming the dependency bump does not regress the desktop build.
- Verified on iPadOS 26 on a physical device

## Related

https://github.com/madsmtm/objc2/issues/849