### PR TITLE
fix(windows): dpi getter leaks `HDC` handles

### DIFF
--- a/.changes/dpi-leak-hdc-handle.md
+++ b/.changes/dpi-leak-hdc-handle.md
@@ -1,0 +1,5 @@
+---
+tao: patch
+---
+
+Fix getting the DPI internally leaks `HDC` handles on Windows. Also only call `GetDC` when on < Windows 8.1 which improves its performance.

--- a/src/platform_impl/windows/dpi.rs
+++ b/src/platform_impl/windows/dpi.rs
@@ -69,10 +69,6 @@ pub fn dpi_to_scale_factor(dpi: u32) -> f64 {
 }
 
 pub unsafe fn hwnd_dpi(hwnd: HWND) -> u32 {
-  let hdc = GetDC(Some(hwnd));
-  if hdc.is_invalid() {
-    panic!("[tao] `GetDC` returned null!");
-  }
   if let Some(GetDpiForWindow) = *GET_DPI_FOR_WINDOW {
     // We are on Windows 10 Anniversary Update (1607) or later.
     match GetDpiForWindow(hwnd) {
@@ -96,9 +92,15 @@ pub unsafe fn hwnd_dpi(hwnd: HWND) -> u32 {
   } else {
     // We are on Vista or later.
     if IsProcessDPIAware().as_bool() {
+      let hdc = GetDC(Some(hwnd));
+      if hdc.is_invalid() {
+        panic!("[tao] `GetDC` returned null!");
+      }
       // If the process is DPI aware, then scaling must be handled by the application using
       // this DPI value.
-      GetDeviceCaps(Some(hdc), LOGPIXELSX) as u32
+      let dpi = GetDeviceCaps(Some(hdc), LOGPIXELSX) as u32;
+      ReleaseDC(Some(hwnd), hdc);
+      dpi
     } else {
       // If the process is DPI unaware, then scaling is performed by the OS; we thus return
       // 96 (scale factor 1.0) to prevent the window from being re-scaled by both the


### PR DESCRIPTION
Mirror https://github.com/tauri-apps/tauri/pull/15614