### PR TITLE
fix(macos): reapply traffic light inset on title change and fullscreen exit

### DIFF
--- a/.changes/fix-macos-traffic-light-reset.md
+++ b/.changes/fix-macos-traffic-light-reset.md
@@ -1,0 +1,7 @@
+---
+"tao": patch
+---
+
+On macOS, re-apply the custom traffic light inset after a title change and
+after leaving fullscreen, so the buttons no longer jump back to their default
+position on those events.

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -17,6 +17,7 @@ use crate::{
   dpi::LogicalSize,
   platform_impl::platform::{
     ffi::{self, id, NO, YES},
+    view::reapply_traffic_light_inset,
     window::SharedState,
   },
 };
@@ -219,11 +220,16 @@ pub unsafe fn make_key_and_order_front_sync(ns_window: &NSWindow) {
 // `setTitle:` isn't thread-safe. Calling it from another thread invalidates the
 // window drag regions, which throws an exception when not done in the main
 // thread
-pub unsafe fn set_title_async(ns_window: &NSWindow, title: String) {
+pub unsafe fn set_title_async(ns_window: &NSWindow, ns_view: &NSView, title: String) {
   let ns_window = MainThreadSafe(ns_window.retain());
+  let ns_view = MainThreadSafe(ns_view.retain());
   DispatchQueue::main().exec_async(move || {
     let title = NSString::from_str(&title);
     ns_window.setTitle(&title);
+    // `setTitle:` moves the traffic light buttons back to their default spot.
+    // Re-apply the configured inset kept on the view so the custom position
+    // survives a title change (#13044).
+    reapply_traffic_light_inset(&ns_window, &ns_view);
   });
 }
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -1180,3 +1180,18 @@ pub unsafe fn inset_traffic_lights(window: &NSWindow, position: LogicalPosition<
     button.setFrameOrigin(rect.origin);
   }
 }
+
+// Re-apply the custom traffic light inset stored on the view, if one was set.
+// AppKit resets the buttons to their default position on some events (title
+// change, leaving fullscreen) without triggering a `drawRect:`, so callers use
+// this to restore the configured position afterwards (#13044, #15451).
+pub unsafe fn reapply_traffic_light_inset(ns_window: &NSWindow, ns_view: &NSView) {
+  let state_ptr: *mut c_void = *ns_view.get_ivar("taoState");
+  if state_ptr.is_null() {
+    return;
+  }
+  let state = &*(state_ptr as *mut ViewState);
+  if let Some(position) = state.traffic_light_inset {
+    inset_traffic_lights(ns_window, position);
+  }
+}

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -655,7 +655,7 @@ impl UnownedWindow {
 
   pub fn set_title(&self, title: &str) {
     unsafe {
-      util::set_title_async(&self.ns_window, title.to_string());
+      util::set_title_async(&self.ns_window, &self.ns_view, title.to_string());
     }
   }
 

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -29,7 +29,7 @@ use crate::{
     event::{EventProxy, EventWrapper},
     ffi::{id, nil, BOOL, NO, YES},
     util::{self, IdRef},
-    view::ViewState,
+    view::{reapply_traffic_light_inset, ViewState},
     window::{get_ns_theme, get_window_id, UnownedWindow},
   },
   window::{Fullscreen, WindowId},
@@ -605,6 +605,9 @@ extern "C" fn window_did_exit_fullscreen(this: &Object, _: Sel, _: id) {
       if let Some(target_fullscreen) = target_fullscreen {
         window.set_fullscreen(target_fullscreen);
       }
+      // Leaving fullscreen resets the traffic light buttons to their default
+      // position without a `drawRect:`, so re-apply the custom inset (#15451).
+      unsafe { reapply_traffic_light_inset(&window.ns_window, &window.ns_view) };
     });
     state.emit_resize_event();
     state.emit_move_event();


### PR DESCRIPTION
Moving the traffic-light-reset fix down to tao, per the discussion on tauri-apps/tauri#15628.

### What
On macOS the custom traffic light inset (`set_traffic_light_inset`) is lost on two events:
- **`setTitle:`** — the buttons snap back to default (tauri-apps/tauri#13044)
- **leaving fullscreen** of a maximized window — same reset (tauri-apps/tauri#15451)

Both reporters noted resizing the window fixes it, which is the tell: `draw_rect` already re-insets on redraw (view.rs), but neither `setTitle:` nor `windowDidExitFullScreen:` triggers a `drawRect:`, so the position stays default until the next redraw.

### How
Reapply the inset **already stored on the view's `ViewState` (`traffic_light_inset`)** after both events:
- `set_title_async` re-insets right after `setTitle:`
- `window_did_exit_fullscreen` re-insets after the transition completes

No new state — the value is read back from the existing `taoState` ivar, so it can't drift from what `set_traffic_light_inset` wrote. New helper `reapply_traffic_light_inset(ns_window, ns_view)` in `view.rs`.

@FabianLars this is the ivar-based version we talked about — supersedes your `refresh-lights` branch (that one threaded a new `SharedState.traffic_lights_position` and only covered the title case). Also covers fullscreen exit here. `cargo check` is green; I don't have a mac to smoke-test the button positions, so a visual check would be appreciated.