### PR TITLE
fix(ios): emit `Opened` event for URLs on cold start

### DIFF
--- a/.changes/ios-cold-start-deep-link.md
+++ b/.changes/ios-cold-start-deep-link.md
@@ -2,4 +2,4 @@
 "tao": patch
 ---
 
-On iOS, emit `Event::Opened` for URLs delivered in the scene connection options, so deep links open the app from a cold start. Also stop panicking on unparseable universal link URLs.
+On iOS, emit `Event::Opened` for URLs delivered in the scene connection options — custom-scheme and file URLs from the URL contexts, universal links from the user activities — so deep links open the app from a cold start. Also stop panicking on unparseable universal link URLs.

--- a/.changes/ios-cold-start-deep-link.md
+++ b/.changes/ios-cold-start-deep-link.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On iOS, emit `Event::Opened` for URLs delivered in the scene connection options, so deep links open the app from a cold start. Also stop panicking on unparseable universal link URLs.

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -28,7 +28,7 @@ use crate::{
       CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate, CGRect, CGSize, NSInteger,
       NSOperatingSystemVersion, NSUInteger,
     },
-    scene::multiple_scenes_enabled,
+    scene::{emit_opened_from_url_contexts, multiple_scenes_enabled},
   },
   window::WindowId as RootWindowId,
 };
@@ -530,6 +530,8 @@ pub unsafe fn connect_scene(scene: &UIScene, options: &UISceneConnectionOptions)
       }));
     }
   }
+
+  emit_opened_from_url_contexts(&options.URLContexts());
 }
 
 pub unsafe fn register_window_for_scene(window: id) {

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -28,7 +28,10 @@ use crate::{
       CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate, CGRect, CGSize, NSInteger,
       NSOperatingSystemVersion, NSUInteger,
     },
-    scene::{emit_opened_from_url_contexts, multiple_scenes_enabled},
+    scene::{
+      emit_opened, multiple_scenes_enabled, url_strings_from_url_contexts,
+      url_strings_from_user_activities,
+    },
   },
   window::WindowId as RootWindowId,
 };
@@ -531,7 +534,13 @@ pub unsafe fn connect_scene(scene: &UIScene, options: &UISceneConnectionOptions)
     }
   }
 
-  emit_opened_from_url_contexts(&options.URLContexts());
+  // on cold start every deep link arrives here instead of through the callbacks
+  // that handle them while the app is running: custom schemes and file URLs in
+  // the URL contexts, universal links in the user activities, since
+  // scene:continueUserActivity: is not called for the launch activity
+  let mut url_strings = url_strings_from_url_contexts(&options.URLContexts());
+  url_strings.extend(url_strings_from_user_activities(&options.userActivities()));
+  emit_opened(&url_strings, "scene:willConnectToSession:options:");
 }
 
 pub unsafe fn register_window_for_scene(window: id) {

--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -17,6 +17,20 @@ use crate::{
   window::WindowId as RootWindowId,
 };
 
+pub(crate) fn emit_opened_from_url_contexts(url_contexts: &NSSet<UIOpenURLContext>) {
+  let url_strings: Vec<String> = url_contexts
+    .iter()
+    .filter_map(|ctx| ctx.URL().absoluteString().map(|s| s.to_string()))
+    .collect();
+
+  let urls = parse_url_strings(&url_strings);
+  if !urls.is_empty() {
+    unsafe {
+      app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::Opened { urls }));
+    }
+  }
+}
+
 // true when the system allows the app to display multiple scenes and multiple_scenes_enabled() returns true
 // https://developer.apple.com/documentation/uikit/uiapplication/supportsmultiplescenes?language=objc
 pub unsafe fn app_supports_multiple_scenes() -> bool {
@@ -108,26 +122,7 @@ define_class!(
 
     #[unsafe(method(scene:openURLContexts:))]
     fn scene_openURLContexts(&self, _scene: &UIScene, url_contexts: &NSSet<UIOpenURLContext>) {
-      unsafe {
-        let urls: Vec<url::Url> = url_contexts
-          .iter()
-          .filter_map(|ctx| {
-            ctx.URL().absoluteString().and_then(|url| {
-              let url = url.to_string();
-              url
-                .parse()
-                .map_err(|e| {
-                  log::error!("failed to parse URL {url} from scene:openURLContexts: {e}");
-                  e
-                })
-                .ok()
-            })
-          })
-          .collect();
-        if !urls.is_empty() {
-          app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::Opened { urls }));
-        }
-      }
+      emit_opened_from_url_contexts(url_contexts);
     }
 
     #[unsafe(method(stateRestorationActivityForScene:))]
@@ -162,10 +157,10 @@ define_class!(
           .webpageURL()
           .and_then(|url| url.absoluteString())
         {
-          let url = url.to_string().parse::<url::Url>().unwrap();
-          app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::Opened {
-            urls: vec![url],
-          }));
+          let urls = parse_url_strings(&[url.to_string()]);
+          if !urls.is_empty() {
+            app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::Opened { urls }));
+          }
         }
       }
     }
@@ -196,3 +191,93 @@ define_class!(
     }
   }
 );
+
+fn parse_url_strings(url_strings: &[String]) -> Vec<url::Url> {
+  url_strings
+    .iter()
+    .filter_map(|s| {
+      s.parse()
+        .map_err(|e| {
+          log::error!("failed to parse URL {s}: {e}");
+          e
+        })
+        .ok()
+    })
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_parse_url_strings() {
+    let input = vec![
+      "https://example.com".to_string(),
+      "invalid-url".to_string(),
+      "https://another.com/path".to_string(),
+    ];
+
+    let urls = parse_url_strings(&input);
+    assert_eq!(urls.len(), 2);
+    // url::Url normalizes an empty path to "/"
+    assert_eq!(urls[0].as_str(), "https://example.com/");
+    assert_eq!(urls[1].as_str(), "https://another.com/path");
+  }
+
+  #[test]
+  fn test_parse_url_strings_empty_input() {
+    assert!(parse_url_strings(&[]).is_empty());
+  }
+
+  #[test]
+  fn test_parse_url_strings_all_invalid() {
+    let input = vec![
+      String::new(),
+      "not a url".to_string(),
+      // parses up to the host, which is empty
+      "https://".to_string(),
+    ];
+    assert!(parse_url_strings(&input).is_empty());
+  }
+
+  #[test]
+  fn test_parse_url_strings_deep_link_round_trip() {
+    // the payloads scene:openURLContexts: actually delivers: custom URL
+    // schemes, universal links with query and fragment, and file URLs
+    // from the share sheet's "Open in..."
+    let cases = [
+      "tauri://callback?token=abc",
+      "myapp:main",
+      "https://example.com/auth?code=1&state=2#frag",
+      "file:///private/var/mobile/Containers/doc%20name.pdf",
+    ];
+
+    for case in cases {
+      let urls = parse_url_strings(&[case.to_string()]);
+      assert_eq!(urls.len(), 1, "expected {case} to parse");
+      assert_eq!(urls[0].as_str(), case);
+    }
+
+    let urls = parse_url_strings(&["tauri://callback?token=abc".to_string()]);
+    assert_eq!(urls[0].scheme(), "tauri");
+    assert_eq!(urls[0].host_str(), Some("callback"));
+    assert_eq!(urls[0].query(), Some("token=abc"));
+  }
+
+  #[test]
+  fn test_parse_url_strings_normalization() {
+    // consumers receive URLs normalized per the WHATWG URL spec
+    let cases = [
+      ("HTTPS://EXAMPLE.COM/Path", "https://example.com/Path"),
+      ("https://example.com/a b", "https://example.com/a%20b"),
+      ("https://example.com:443/page", "https://example.com/page"),
+    ];
+
+    for (input, expected) in cases {
+      let urls = parse_url_strings(&[input.to_string()]);
+      assert_eq!(urls.len(), 1, "expected {input} to parse");
+      assert_eq!(urls[0].as_str(), expected);
+    }
+  }
+}

--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -17,13 +17,38 @@ use crate::{
   window::WindowId as RootWindowId,
 };
 
-pub(crate) fn emit_opened_from_url_contexts(url_contexts: &NSSet<UIOpenURLContext>) {
-  let url_strings: Vec<String> = url_contexts
+// custom URL schemes and file URLs, delivered both on cold start
+// (UISceneConnectionOptions) and while the app is running (scene:openURLContexts:)
+pub(crate) fn url_strings_from_url_contexts(url_contexts: &NSSet<UIOpenURLContext>) -> Vec<String> {
+  url_contexts
     .iter()
     .filter_map(|ctx| ctx.URL().absoluteString().map(|s| s.to_string()))
-    .collect();
+    .collect()
+}
 
-  let urls = parse_url_strings(&url_strings);
+// universal links, delivered both on cold start (UISceneConnectionOptions) and
+// while the app is running (scene:continueUserActivity:). activities that carry
+// no webpage URL, such as handoff or state restoration, are skipped
+pub(crate) fn url_strings_from_user_activities(
+  user_activities: &NSSet<NSUserActivity>,
+) -> Vec<String> {
+  user_activities
+    .iter()
+    .filter_map(|activity| webpage_url_string(&activity))
+    .collect()
+}
+
+fn webpage_url_string(user_activity: &NSUserActivity) -> Option<String> {
+  user_activity
+    .webpageURL()
+    .and_then(|url| url.absoluteString())
+    .map(|s| s.to_string())
+}
+
+// `source` names the delivery path the URLs came from, so a parse failure can be
+// traced back to the callback that produced it
+pub(crate) fn emit_opened(url_strings: &[String], source: &str) {
+  let urls = parse_url_strings(url_strings, source);
   if !urls.is_empty() {
     unsafe {
       app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::Opened { urls }));
@@ -122,7 +147,10 @@ define_class!(
 
     #[unsafe(method(scene:openURLContexts:))]
     fn scene_openURLContexts(&self, _scene: &UIScene, url_contexts: &NSSet<UIOpenURLContext>) {
-      emit_opened_from_url_contexts(url_contexts);
+      emit_opened(
+        &url_strings_from_url_contexts(url_contexts),
+        "scene:openURLContexts:",
+      );
     }
 
     #[unsafe(method(stateRestorationActivityForScene:))]
@@ -151,17 +179,9 @@ define_class!(
 
     #[unsafe(method(scene:continueUserActivity:))]
     fn scene_continueUserActivity(&self, _scene: &UIScene, user_activity: &NSUserActivity) {
-      unsafe {
-        // universal app links
-        if let Some(url) = user_activity
-          .webpageURL()
-          .and_then(|url| url.absoluteString())
-        {
-          let urls = parse_url_strings(&[url.to_string()]);
-          if !urls.is_empty() {
-            app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::Opened { urls }));
-          }
-        }
+      // universal app links
+      if let Some(url_string) = webpage_url_string(user_activity) {
+        emit_opened(&[url_string], "scene:continueUserActivity:");
       }
     }
 
@@ -192,13 +212,13 @@ define_class!(
   }
 );
 
-fn parse_url_strings(url_strings: &[String]) -> Vec<url::Url> {
+fn parse_url_strings(url_strings: &[String], source: &str) -> Vec<url::Url> {
   url_strings
     .iter()
     .filter_map(|s| {
       s.parse()
         .map_err(|e| {
-          log::error!("failed to parse URL {s}: {e}");
+          log::error!("failed to parse URL {s} from {source}: {e}");
           e
         })
         .ok()
@@ -210,6 +230,8 @@ fn parse_url_strings(url_strings: &[String]) -> Vec<url::Url> {
 mod tests {
   use super::*;
 
+  const SOURCE: &str = "test";
+
   #[test]
   fn test_parse_url_strings() {
     let input = vec![
@@ -218,7 +240,7 @@ mod tests {
       "https://another.com/path".to_string(),
     ];
 
-    let urls = parse_url_strings(&input);
+    let urls = parse_url_strings(&input, SOURCE);
     assert_eq!(urls.len(), 2);
     // url::Url normalizes an empty path to "/"
     assert_eq!(urls[0].as_str(), "https://example.com/");
@@ -227,7 +249,7 @@ mod tests {
 
   #[test]
   fn test_parse_url_strings_empty_input() {
-    assert!(parse_url_strings(&[]).is_empty());
+    assert!(parse_url_strings(&[], SOURCE).is_empty());
   }
 
   #[test]
@@ -238,7 +260,7 @@ mod tests {
       // parses up to the host, which is empty
       "https://".to_string(),
     ];
-    assert!(parse_url_strings(&input).is_empty());
+    assert!(parse_url_strings(&input, SOURCE).is_empty());
   }
 
   #[test]
@@ -254,15 +276,32 @@ mod tests {
     ];
 
     for case in cases {
-      let urls = parse_url_strings(&[case.to_string()]);
+      let urls = parse_url_strings(&[case.to_string()], SOURCE);
       assert_eq!(urls.len(), 1, "expected {case} to parse");
       assert_eq!(urls[0].as_str(), case);
     }
 
-    let urls = parse_url_strings(&["tauri://callback?token=abc".to_string()]);
+    let urls = parse_url_strings(&["tauri://callback?token=abc".to_string()], SOURCE);
     assert_eq!(urls[0].scheme(), "tauri");
     assert_eq!(urls[0].host_str(), Some("callback"));
     assert_eq!(urls[0].query(), Some("token=abc"));
+  }
+
+  #[test]
+  fn test_parse_url_strings_universal_link_round_trip() {
+    // the webpage URLs a universal link carries, whether it arrives in the
+    // connection options on cold start or in scene:continueUserActivity:
+    let cases = [
+      "https://example.com/",
+      "https://example.com/invite/abc?ref=email#section",
+      "https://example.com/%D0%BF%D1%83%D1%82%D1%8C",
+    ];
+
+    for case in cases {
+      let urls = parse_url_strings(&[case.to_string()], SOURCE);
+      assert_eq!(urls.len(), 1, "expected {case} to parse");
+      assert_eq!(urls[0].as_str(), case);
+    }
   }
 
   #[test]
@@ -275,7 +314,7 @@ mod tests {
     ];
 
     for (input, expected) in cases {
-      let urls = parse_url_strings(&[input.to_string()]);
+      let urls = parse_url_strings(&[input.to_string()], SOURCE);
       assert_eq!(urls.len(), 1, "expected {input} to parse");
       assert_eq!(urls[0].as_str(), expected);
     }

--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -4,7 +4,7 @@
 use objc2::{define_class, rc::Retained, MainThreadMarker, MainThreadOnly};
 use objc2_foundation::{
   NSBundle, NSDictionary, NSError, NSNumber, NSObject, NSObjectProtocol, NSSet, NSString,
-  NSUserActivity,
+  NSUserActivity, NSUserActivityTypeBrowsingWeb,
 };
 use objc2_ui_kit::{
   UIApplication, UIOpenURLContext, UIScene, UISceneConnectionOptions, UISceneDelegate,
@@ -27,8 +27,8 @@ pub(crate) fn url_strings_from_url_contexts(url_contexts: &NSSet<UIOpenURLContex
 }
 
 // universal links, delivered both on cold start (UISceneConnectionOptions) and
-// while the app is running (scene:continueUserActivity:). activities that carry
-// no webpage URL, such as handoff or state restoration, are skipped
+// while the app is running (scene:continueUserActivity:). activities of any
+// other type, such as handoff or state restoration, are skipped
 pub(crate) fn url_strings_from_user_activities(
   user_activities: &NSSet<NSUserActivity>,
 ) -> Vec<String> {
@@ -39,6 +39,16 @@ pub(crate) fn url_strings_from_user_activities(
 }
 
 fn webpage_url_string(user_activity: &NSUserActivity) -> Option<String> {
+  // a webpage URL alone does not make an activity a universal link: handoff
+  // activities carry one as the page to open when the app is not installed
+  // https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app
+  if !user_activity
+    .activityType()
+    .isEqualToString(unsafe { NSUserActivityTypeBrowsingWeb })
+  {
+    return None;
+  }
+
   user_activity
     .webpageURL()
     .and_then(|url| url.absoluteString())


### PR DESCRIPTION
Closes #1248

## Problem

On a cold start, URLs delivered through `connectionOptions.URLContexts` in `scene:willConnectToSession:options:` were ignored, so `Event::Opened` was never emitted. Deep links (custom URL schemes and universal links, e.g. via `tauri-plugin-deep-link`) only worked while the app was already running, where `scene:openURLContexts:` handles them.

## Changes

- Extract the shared URL-contexts handling into `emit_opened_from_url_contexts` in `scene.rs` and call it from both `scene:openURLContexts:` (warm start) and `connect_scene` (cold start).
- Extract the pure `parse_url_strings` helper and reuse it for universal links in `scene:continueUserActivity:`, which previously panicked (`.unwrap()`) on URLs the `url` crate cannot parse; such URLs are now logged and skipped.
- Add unit tests for `parse_url_strings`: deep-link round-trips (custom schemes, query/fragment, file URLs), invalid input filtering, empty input, and WHATWG normalization behavior.

## Test plan

CI compiles the tests for the iOS target (`cargo test --no-run`) but does not execute them; all five tests were executed locally and pass. `cargo check --target aarch64-apple-ios --tests` is warning-free for the touched files and `cargo fmt --check` passes.