### PR TITLE
fix(ios): emit WindowEvent::Destroyed when a scene disconnects

### DIFF
--- a/.changes/ios-scene-did-disconnect.md
+++ b/.changes/ios-scene-did-disconnect.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On iOS, emit `WindowEvent::Destroyed` for a scene's windows when the scene disconnects. Previously `sceneDidDisconnect:` was a no-op, so windows tied to a scene never reported their destruction when the system reclaimed the scene.

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -876,6 +876,11 @@ pub unsafe fn handle_events_cleared() {
 }
 
 // requires main thread
+pub unsafe fn is_terminated() -> bool {
+  matches!(AppState::get_mut().state(), AppStateImpl::Terminated)
+}
+
+// requires main thread
 pub unsafe fn terminated() {
   let mut this = AppState::get_mut();
   let mut event_handler = this.terminated_transition();

--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -80,6 +80,10 @@ define_class!(
       }
     }
 
+    // iOS may disconnect a scene because the user closed it, or because
+    // the system discarded a backgrounded scene to free resources. A
+    // restored scene goes through `scene:willConnectToSession:` again
+    // and gets a new `UIWindow` and `WindowId`.
     #[unsafe(method(sceneDidDisconnect:))]
     fn sceneDidDisconnect(&self, scene: &UIScene) {
       unsafe {

--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -87,8 +87,19 @@ define_class!(
     #[unsafe(method(sceneDidDisconnect:))]
     fn sceneDidDisconnect(&self, scene: &UIScene) {
       unsafe {
+        if app_state::is_terminated() {
+          log::debug!("ignoring `sceneDidDisconnect` after application termination");
+          return;
+        }
+
         if let Some(window_scene) = scene.downcast_ref::<UIWindowScene>() {
-          for window in window_scene.windows() {
+          let windows = window_scene.windows();
+
+          if windows.is_empty() {
+            log::debug!("`sceneDidDisconnect` called for a `UIWindowScene` with no windows; no `WindowEvent::Destroyed` events were emitted");
+          }
+
+          for window in windows {
             app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::WindowEvent {
               window_id: RootWindowId(window.into()),
               event: WindowEvent::Destroyed,

--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -93,19 +93,11 @@ define_class!(
         }
 
         if let Some(window_scene) = scene.downcast_ref::<UIWindowScene>() {
-          let windows = window_scene.windows();
-
-          if windows.is_empty() {
+          if window_scene.windows().is_empty() {
             log::debug!("`sceneDidDisconnect` called for a `UIWindowScene` with no windows; no `WindowEvent::Destroyed` events were emitted");
           }
-
-          for window in windows {
-            app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::WindowEvent {
-              window_id: RootWindowId(window.into()),
-              event: WindowEvent::Destroyed,
-            }));
-          }
         }
+        handle_scene_window_events(scene, || WindowEvent::Destroyed);
       }
     }
 

--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -81,7 +81,18 @@ define_class!(
     }
 
     #[unsafe(method(sceneDidDisconnect:))]
-    fn sceneDidDisconnect(&self, _scene: &UIScene) {}
+    fn sceneDidDisconnect(&self, scene: &UIScene) {
+      unsafe {
+        if let Some(window_scene) = scene.downcast_ref::<UIWindowScene>() {
+          for window in window_scene.windows() {
+            app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::WindowEvent {
+              window_id: RootWindowId(window.into()),
+              event: WindowEvent::Destroyed,
+            }));
+          }
+        }
+      }
+    }
 
     #[unsafe(method(sceneDidBecomeActive:))]
     fn sceneDidBecomeActive(&self, scene: &UIScene) {

--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -49,7 +49,13 @@ pub unsafe fn multiple_scenes_enabled() -> bool {
 
 unsafe fn handle_scene_window_events(scene: &UIScene, event: impl Fn() -> WindowEvent<'static>) {
   if let Some(window_scene) = scene.downcast_ref::<UIWindowScene>() {
-    for window in window_scene.windows() {
+    let windows = window_scene.windows();
+
+    if windows.is_empty() {
+      log::debug!("scene has no windows; no window events were emitted");
+    }
+
+    for window in windows {
       app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::WindowEvent {
         window_id: RootWindowId(window.into()),
         event: event(),
@@ -92,11 +98,6 @@ define_class!(
           return;
         }
 
-        if let Some(window_scene) = scene.downcast_ref::<UIWindowScene>() {
-          if window_scene.windows().is_empty() {
-            log::debug!("`sceneDidDisconnect` called for a `UIWindowScene` with no windows; no `WindowEvent::Destroyed` events were emitted");
-          }
-        }
         handle_scene_window_events(scene, || WindowEvent::Destroyed);
       }
     }
@@ -104,14 +105,7 @@ define_class!(
     #[unsafe(method(sceneDidBecomeActive:))]
     fn sceneDidBecomeActive(&self, scene: &UIScene) {
       unsafe {
-        if let Some(window_scene) = scene.downcast_ref::<UIWindowScene>() {
-          for window in window_scene.windows() {
-            app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::WindowEvent {
-              window_id: RootWindowId(window.into()),
-              event: WindowEvent::Focused(true),
-            }));
-          }
-        }
+        handle_scene_window_events(scene, || WindowEvent::Focused(true));
       }
     }
 


### PR DESCRIPTION
closes #1260

Implements `sceneDidDisconnect:` on the iOS scene delegate, which was previously a no-op.

When the system reclaims a scene, we now emit a `WindowEvent::Destroyed` for each of the scene's windows, so consumers are notified that the windows are gone.

