### PR TITLE
fix(windows): release window state lock before taskbar update (fix: #1263)

### DIFF
--- a/.changes/taskbar-created-lock.md
+++ b/.changes/taskbar-created-lock.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Release the window state lock before updating taskbar visibility on Windows to avoid a reentrant `TaskbarCreated` deadlock.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2195,8 +2195,8 @@ unsafe fn public_window_callback_inner<T: 'static>(
         update_theme(userdata, window, false);
         result = ProcResult::Value(LRESULT(0));
       } else if msg == *S_U_TASKBAR_RESTART {
-        let window_state = userdata.window_state.lock();
-        let _ = set_skip_taskbar(window, window_state.skip_taskbar);
+        let skip_taskbar = userdata.window_state.lock().skip_taskbar;
+        let _ = set_skip_taskbar(window, skip_taskbar);
       }
     }
   };


### PR DESCRIPTION
## Summary

- Release the window state lock before calling `set_skip_taskbar` when handling the `TaskbarCreated` message.
- Add a patch change file for `tao`.

## Problem

The `TaskbarCreated` handler previously held `window_state` while calling `set_skip_taskbar`.

Updating the taskbar state can synchronously trigger reentrant window handling that attempts to acquire the same lock, potentially causing the application to deadlock and become unresponsive.

The issue is timing-dependent, so restarting Explorer or resuming from sleep does not reproduce it every time.

## Fix

Copy `skip_taskbar` while briefly holding the lock, then release the lock before calling `set_skip_taskbar`.

## Testing

- `cargo test`
- `git diff --check`

Fixes #1263

Related upstream fix: rust-windowing/winit#4563