### PR TITLE
chore(deps): relax `windows` versions to `=0.61, <=0.62`

### DIFF
--- a/.changes/windows-0.61-or-0.62.md
+++ b/.changes/windows-0.61-or-0.62.md
@@ -1,0 +1,5 @@
+---
+"tao": minor
+---
+
+Relaxed `windows` and `windows-core` crate versions to from `0.61` to `=0.61, <=0.62`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,10 +67,10 @@ softbuffer = "0.4"
 parking_lot = "0.12"
 unicode-segmentation = "1.11"
 windows-version = "0.1"
-windows-core = "0.61"
+windows-core = ">=0.61, <=0.62"
 
 [target."cfg(target_os = \"windows\")".dependencies.windows]
-version = "0.61"
+version = ">=0.61, <=0.62"
 features = [
   "Win32_Devices_HumanInterfaceDevice",
   "Win32_Foundation",

--- a/src/platform_impl/windows/drop_handler.rs
+++ b/src/platform_impl/windows/drop_handler.rs
@@ -42,7 +42,7 @@ impl FileDropHandler {
   }
 
   unsafe fn iterate_filenames<F>(
-    data_obj: windows_core::Ref<'_, IDataObject>,
+    data_obj: windows::core::Ref<'_, IDataObject>,
     callback: F,
   ) -> Option<HDROP>
   where
@@ -108,7 +108,7 @@ impl FileDropHandler {
 impl IDropTarget_Impl for FileDropHandler_Impl {
   fn DragEnter(
     &self,
-    pDataObj: windows_core::Ref<'_, IDataObject>,
+    pDataObj: windows::core::Ref<'_, IDataObject>,
     _grfKeyState: MODIFIERKEYS_FLAGS,
     _pt: &POINTL,
     pdwEffect: *mut DROPEFFECT,
@@ -159,7 +159,7 @@ impl IDropTarget_Impl for FileDropHandler_Impl {
 
   fn Drop(
     &self,
-    pDataObj: windows_core::Ref<'_, IDataObject>,
+    pDataObj: windows::core::Ref<'_, IDataObject>,
     _grfKeyState: MODIFIERKEYS_FLAGS,
     _pt: &POINTL,
     _pdwEffect: *mut DROPEFFECT,

--- a/src/platform_impl/windows/icon.rs
+++ b/src/platform_impl/windows/icon.rs
@@ -5,13 +5,12 @@
 use std::{fmt, mem, path::Path, sync::Arc};
 
 use windows::{
-  core::PCWSTR,
+  core::{Owned, PCWSTR},
   Win32::{
     Foundation::{HWND, LPARAM, WPARAM},
     UI::WindowsAndMessaging::*,
   },
 };
-use windows_core::Owned;
 
 use crate::{dpi::PhysicalSize, icon::*, platform_impl::platform::util};
 


### PR DESCRIPTION
Since we have no public types containing `windows` types, this should be safe to do.

Alternatively, we wait for this minor released and going straight to 0.62 and bump MSRV in next minor