### PR TITLE
fix(macos): don't abort on drags without file paths

### DIFF
--- a/.changes/fix-macos-drag-drop-abort.md
+++ b/.changes/fix-macos-drag-drop-abort.md
@@ -1,0 +1,9 @@
+---
+"tao": patch
+---
+
+On macOS, fix an abort (`SIGABRT`) when a drag entered or was dropped on a window while carrying
+no `NSFilenamesPboardType` entry, which is the case for text, URLs and promised files (for example
+a track dragged out of Music.app). The pasteboard was unwrapped unconditionally inside the
+`draggingEntered:` and `performDragOperation:` callbacks, and since those cannot unwind, the
+resulting panic aborted the process instead of propagating. Such drags now report no paths.

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -6,6 +6,7 @@ use std::{
   f64,
   ffi::CStr,
   os::raw::c_void,
+  path::PathBuf,
   sync::{Arc, Weak},
 };
 
@@ -413,27 +414,38 @@ extern "C" fn window_did_resign_key(this: &Object, _: Sel, _: id) {
   trace!("Completed `windowDidResignKey:`");
 }
 
+/// Collects the file paths of a dragging pasteboard, empty if it carries none.
+unsafe fn collect_paths(sender: id) -> Vec<PathBuf> {
+  let pb: Retained<NSPasteboard> = msg_send![sender, draggingPasteboard];
+
+  let Some(filenames) = NSPasteboard::propertyListForType(&pb, appkit::NSFilenamesPboardType)
+  else {
+    return Vec::new();
+  };
+  let Ok(filenames) = filenames.downcast::<NSArray>() else {
+    return Vec::new();
+  };
+
+  filenames
+    .iter()
+    .filter_map(|file| file.downcast::<NSString>().ok())
+    .map(|file| {
+      let path = CStr::from_ptr(NSString::UTF8String(&file))
+        .to_string_lossy()
+        .into_owned();
+      PathBuf::from(path)
+    })
+    .collect()
+}
+
 /// Invoked when the dragged image enters destination bounds or frame
 extern "C" fn dragging_entered(this: &Object, _: Sel, sender: id) -> BOOL {
   trace!("Triggered `draggingEntered:`");
 
-  use std::path::PathBuf;
-
-  let pb: Retained<NSPasteboard> = unsafe { msg_send![sender, draggingPasteboard] };
-  let filenames =
-    unsafe { NSPasteboard::propertyListForType(&pb, appkit::NSFilenamesPboardType) }.unwrap();
-
-  for file in unsafe { Retained::cast_unchecked::<NSArray>(filenames) } {
-    let file = unsafe { Retained::cast_unchecked::<NSString>(file) };
-
-    unsafe {
-      let f = NSString::UTF8String(&file);
-      let path = CStr::from_ptr(f).to_string_lossy().into_owned();
-
-      with_state(this, |state| {
-        state.emit_event(WindowEvent::HoveredFile(PathBuf::from(path)));
-      });
-    }
+  for path in unsafe { collect_paths(sender) } {
+    with_state(this, |state| {
+      state.emit_event(WindowEvent::HoveredFile(path));
+    });
   }
 
   trace!("Completed `draggingEntered:`");
@@ -451,23 +463,10 @@ extern "C" fn prepare_for_drag_operation(_: &Object, _: Sel, _: id) -> BOOL {
 extern "C" fn perform_drag_operation(this: &Object, _: Sel, sender: id) -> BOOL {
   trace!("Triggered `performDragOperation:`");
 
-  use std::path::PathBuf;
-
-  let pb: Retained<NSPasteboard> = unsafe { msg_send![sender, draggingPasteboard] };
-  let filenames =
-    unsafe { NSPasteboard::propertyListForType(&pb, appkit::NSFilenamesPboardType) }.unwrap();
-
-  for file in unsafe { Retained::cast_unchecked::<NSArray>(filenames) } {
-    let file = unsafe { Retained::cast_unchecked::<NSString>(file) };
-
-    unsafe {
-      let f = NSString::UTF8String(&file);
-      let path = CStr::from_ptr(f).to_string_lossy().into_owned();
-
-      with_state(this, |state| {
-        state.emit_event(WindowEvent::DroppedFile(PathBuf::from(path)));
-      });
-    }
+  for path in unsafe { collect_paths(sender) } {
+    with_state(this, |state| {
+      state.emit_event(WindowEvent::DroppedFile(path));
+    });
   }
 
   trace!("Completed `performDragOperation:`");


### PR DESCRIPTION
Fixes: ([tauri-apps/tauri#14624](https://github.com/tauri-apps/tauri/issues/14624)).

## What

On macOS, guard the drag-and-drop pasteboard reads — a shared `collect_paths` helper behind
`draggingEntered:` and `performDragOperation:` that treats a missing or non-array
`NSFilenamesPboardType` property list as "no paths", using checked downcasts instead of
`Retained::cast_unchecked`.

## Why

Both handlers unwrapped `propertyListForType(NSFilenamesPboardType)` unconditionally. Drags
carrying no such entry — text, URLs, or promised files such as a track dragged out of Music.app
or Rekordbox — yield nil there, so the unwrap panicked. Both are `extern "C"` callbacks invoked
by AppKit and cannot unwind, so the panic hit `panic_cannot_unwind` and aborted the process with
`SIGABRT` before any event reached the application, making it uncatchable from application code.

## Changes

* macOS `window_delegate`: new `collect_paths(sender) -> Vec<PathBuf>` helper; `draggingEntered:`
  and `performDragOperation:` build their events from it instead of unwrapping the pasteboard.
* Checked `downcast` in place of `Retained::cast_unchecked` for the property list array and its
  elements, so unexpected contents are skipped rather than reinterpreted.
* `.changes` entry (`tao: patch`).