### PR TITLE
fix(android): `EventLoopProxy::send_event` not always delivering the event immediately

### DIFF
--- a/.changes/delayed-android-send-event.md
+++ b/.changes/delayed-android-send-event.md
@@ -1,0 +1,5 @@
+---
+tao: patch
+---
+
+Fix `EventLoopProxy::send_event` sometimes doesn't deliver the event until the next `EventLoopProxy::send_event` call

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -508,7 +508,7 @@ pub struct EventLoopProxy<T: 'static> {
 
 impl<T> EventLoopProxy<T> {
   pub fn send_event(&self, event: T) -> Result<(), event_loop::EventLoopClosed<T>> {
-    _ = self.queue.try_send(event);
+    let _ = self.queue.send(event);
     self.looper.wake();
     Ok(())
   }


### PR DESCRIPTION
Fix https://github.com/tauri-apps/tauri/issues/14994

This took me so much testing to figure out. The `try_send` from `crossbeam_channel` does not block which made the next event loop wake call sometimes gets before it so when event loop wakes up, there's no message untill the next wake.