### PR TITLE
fix(macos): compute screen coordinates in points, not display pixels

### DIFF
--- a/.changes/fix-macos-coordinate-space.md
+++ b/.changes/fix-macos-coordinate-space.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On macOS, screen-coordinate conversions mixed Cocoa points with `CGDisplay` pixels: the y-flip helpers used `pixels_high()` where the frame values are points, `MonitorHandle::size` fed pixel extents through a logical conversion, and `cursor_position` converted with the primary monitor's scale regardless of which monitor the cursor was on. Window and monitor positions, sizes, and the cursor position are now computed in points and converted with the correct monitor's scale factor, fixing wrong geometry on any system whose primary display scale is not 1.0. `set_outer_position` now converts physical targets with the scale of the monitor the position lands on, so moving a window to `outer_position()` no longer relocates it across monitors, and `MonitorHandle::scale_factor` derives the backing scale from CoreGraphics when the `NSScreen` lookup fails instead of silently reporting 1.0.

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -172,6 +172,19 @@ pub fn from_point(x: f64, y: f64) -> Option<MonitorHandle> {
   None
 }
 
+// `monitor_from_physical_point` gets the monitor whose physical (pixel) rect
+// contains the given point in tao's top-left-origin physical screen space.
+pub fn monitor_from_physical_point(x: f64, y: f64) -> Option<MonitorHandle> {
+  available_monitors().into_iter().find(|monitor| {
+    let position = monitor.position();
+    let size = monitor.size();
+    x >= position.x as f64
+      && x < position.x as f64 + size.width as f64
+      && y >= position.y as f64
+      && y < position.y as f64 + size.height as f64
+  })
+}
+
 impl fmt::Debug for MonitorHandle {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     // TODO: Do this using the proper fmt API
@@ -214,11 +227,13 @@ impl MonitorHandle {
   }
 
   pub fn size(&self) -> PhysicalSize<u32> {
-    let MonitorHandle(display_id) = *self;
-    let display = CGDisplay::new(display_id);
-    let height = display.pixels_high();
-    let width = display.pixels_wide();
-    PhysicalSize::from_logical::<_, f64>((width as f64, height as f64), self.scale_factor())
+    // `CGDisplayBounds` is in points; `pixels_high`/`pixels_wide` are not, and
+    // feeding pixels through a logical conversion double-scales Retina sizes.
+    let bounds = unsafe { CGDisplayBounds(self.native_identifier()) };
+    PhysicalSize::from_logical::<_, f64>(
+      (bounds.size.width, bounds.size.height),
+      self.scale_factor(),
+    )
   }
 
   #[inline]
@@ -231,11 +246,19 @@ impl MonitorHandle {
   }
 
   pub fn scale_factor(&self) -> f64 {
-    let screen = match self.ns_screen() {
-      Some(screen) => screen,
-      None => return 1.0, // default to 1.0 when we can't find the screen
-    };
-    NSScreen::backingScaleFactor(&screen) as f64
+    if let Some(screen) = self.ns_screen() {
+      return NSScreen::backingScaleFactor(&screen) as f64;
+    }
+    // The NSScreen lookup fails for handles that went stale across a display
+    // reconfiguration. Derive the backing scale from CoreGraphics instead of
+    // silently reporting 1.0, which mis-scales every conversion downstream.
+    let bounds = unsafe { CGDisplayBounds(self.0) };
+    if bounds.size.width > 0.0 {
+      if let Some(mode) = CGDisplay::new(self.0).display_mode() {
+        return (mode.pixel_width() as f64 / bounds.size.width).max(1.0);
+      }
+    }
+    1.0
   }
 
   pub fn video_modes(&self) -> impl Iterator<Item = RootVideoMode> {

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -84,8 +84,12 @@ impl Clone for IdRef {
 // For consistency with other platforms, this will...
 // 1. translate the bottom-left window corner into the top-left window corner
 // 2. translate the coordinate from a bottom-left origin coordinate system to a top-left one
+//
+// The flip must happen in points, the unit of `NSRect`: the main display's
+// bounds height in points, not `pixels_high()`. On a Retina primary the two
+// differ by the scale factor, which shears every multi-monitor coordinate.
 pub fn bottom_left_to_top_left(rect: NSRect) -> f64 {
-  CGDisplay::main().pixels_high() as f64 - (rect.origin.y + rect.size.height)
+  CGDisplay::main().bounds().size.height - (rect.origin.y + rect.size.height)
 }
 
 /// Converts from tao screen-coordinates to macOS screen-coordinates.
@@ -94,15 +98,19 @@ pub fn bottom_left_to_top_left(rect: NSRect) -> f64 {
 pub fn window_position(position: LogicalPosition<f64>) -> NSPoint {
   NSPoint::new(
     position.x,
-    CGDisplay::main().pixels_high() as f64 - position.y,
+    CGDisplay::main().bounds().size.height - position.y,
   )
 }
 
 pub fn cursor_position() -> Result<PhysicalPosition<f64>, ExternalError> {
   let point: NSPoint = unsafe { msg_send![class!(NSEvent), mouseLocation] };
-  let y = CGDisplay::main().pixels_high() as f64 - point.y;
-  let point = LogicalPosition::new(point.x, y);
-  Ok(point.to_physical(super::monitor::primary_monitor().scale_factor()))
+  let y = CGDisplay::main().bounds().size.height - point.y;
+  // Convert with the scale of the monitor the cursor is actually on; the
+  // primary's scale is only the fallback for a point outside every display.
+  let scale_factor = super::monitor::from_point(point.x, y)
+    .unwrap_or_else(super::monitor::primary_monitor)
+    .scale_factor();
+  Ok(LogicalPosition::new(point.x, y).to_physical(scale_factor))
 }
 
 pub unsafe fn superclass<'a>(this: &'a Object) -> &'a Class {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -724,7 +724,18 @@ impl UnownedWindow {
   }
 
   pub fn set_outer_position(&self, position: Position) {
-    let scale_factor = self.scale_factor();
+    // A physical target must convert with the scale of the monitor it lands
+    // on: using the window's current scale sends a position computed for a
+    // different-scale monitor to the wrong logical point, which also breaks
+    // `set_position(outer_position())` round-trips across monitors.
+    let scale_factor = match &position {
+      Position::Physical(physical) => {
+        monitor::monitor_from_physical_point(physical.x as f64, physical.y as f64)
+          .map(|monitor| monitor.scale_factor())
+          .unwrap_or_else(|| self.scale_factor())
+      }
+      Position::Logical(_) => self.scale_factor(),
+    };
     let position = position.to_logical(scale_factor);
     unsafe {
       util::set_frame_top_left_point_async(&self.ns_window, util::window_position(position));


### PR DESCRIPTION
The y-flip helpers subtracted Cocoa point values from pixels_high(), MonitorHandle::size fed pixel extents through a logical conversion, and cursor_position converted with the primary monitor's scale regardless of the cursor's monitor: all wrong by the scale factor whenever the primary display is not at 1.0. This flips against the main display's bounds height in points, sizes monitors from CGDisplayBounds, converts the cursor with its containing monitor's scale, and makes set_outer_position convert physical targets with the scale of the monitor they land on, so set_position(outer_position()) round-trips across mixed-scale monitors. Validated on a 4K 1x main plus Retina 2x secondary, including through display hot-plug. Context and landing order: https://github.com/tauri-apps/tauri/issues/7890#issuecomment-5012641117