### PR TITLE
fix(windows): use DefWindowProcW for thread event target

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -33,8 +33,7 @@ use windows::{
       Controls::{self as win32c, HOVER_DEFAULT},
       Input::{KeyboardAndMouse::*, Pointer::*, Touch::*, *},
       Shell::{
-        DefSubclassProc, SHAppBarMessage, ABE_BOTTOM, ABE_LEFT, ABE_RIGHT, ABE_TOP,
-        ABM_GETAUTOHIDEBAR, APPBARDATA,
+        SHAppBarMessage, ABE_BOTTOM, ABE_LEFT, ABE_RIGHT, ABE_TOP, ABM_GETAUTOHIDEBAR, APPBARDATA,
       },
       WindowsAndMessaging::{self as win32wm, *},
     },
@@ -2294,7 +2293,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
       }
 
       // Default WM_PAINT behaviour. This makes sure modals and popups are shown immediatly when opening them.
-      DefSubclassProc(window, msg, wparam, lparam)
+      DefWindowProcW(window, msg, wparam, lparam)
     }
 
     win32wm::WM_INPUT_DEVICE_CHANGE => {
@@ -2319,7 +2318,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
         let _ = RedrawWindow(Some(window), None, None, RDW_INTERNALPAINT);
       }
 
-      DefSubclassProc(window, msg, wparam, lparam)
+      DefWindowProcW(window, msg, wparam, lparam)
     }
 
     // We don't process `WM_QUERYENDSESSION` yet until we introduce the same mechanism as Tauri's `ExitRequested` event
@@ -2382,7 +2381,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
       let _ = RedrawWindow(Some(window), None, None, RDW_INTERNALPAINT);
       LRESULT(0)
     }
-    _ => DefSubclassProc(window, msg, wparam, lparam),
+    _ => DefWindowProcW(window, msg, wparam, lparam),
   };
 
   let result = userdata


### PR DESCRIPTION
Commit 5f209bd8f6d087ecc1aad6610ca798e378a179cd registered `thread_event_target_callback` directly as `lpfnWndProc` but left three `DefSubclassProc` calls. A regular `WNDPROC` must delegate to `DefWindowProcW`.

The old default handling returned `FALSE` for `WM_QUERYENDSESSION` and vetoed Windows shutdown in https://github.com/cjpais/Handy/issues/1710.

Verification:
- `cargo check --lib --target x86_64-pc-windows-gnu` passed.
- A manual Windows 11 build 22631 probe changed the `Tao Thread Event Target` `WM_QUERYENDSESSION` response from `0x0` before the patch to `0x1` after it.