### PR TITLE
fix(ios): use method_id to return Retained<T> for preferredWindowingC…

### DIFF
--- a/src/platform_impl/ios/scene.rs
+++ b/src/platform_impl/ios/scene.rs
@@ -185,14 +185,12 @@ define_class!(
 
   #[allow(non_snake_case)]
   unsafe impl UIWindowSceneDelegate for TaoSceneDelegate {
-    #[unsafe(method(preferredWindowingControlStyleForScene:))]
+    #[unsafe(method_id(preferredWindowingControlStyleForScene:))]
     fn preferredWindowingControlStyleForScene(
       &self,
       _window_scene: &UIWindowScene,
-    ) -> Option<std::ptr::NonNull<UISceneWindowingControlStyle>> {
-      std::ptr::NonNull::new(Retained::autorelease_ptr(
-        UISceneWindowingControlStyle::minimalStyle(),
-      ))
+    ) -> Retained<UISceneWindowingControlStyle> {
+      UISceneWindowingControlStyle::minimalStyle()
     }
   }
 );


### PR DESCRIPTION
Resolves tauri-apps/tauri#15521. Follow-up to #1250.

## Description

iPadOS 26 adds macOS-style system window controls to the top-left corner of every windowed scene. Because a Tao window hosts a fullscreen `WKWebView` with no native toolbar, these controls do not contribute to the safe area and float on top of, overlapping, the web content. There is no native toolbar for them to integrate with.

## Fix

Using `#[unsafe(method_id(...))]` instead lets the method return `Retained<UISceneWindowingControlStyle>` directly, matching the `UIWindowSceneDelegate` signature. objc2 now handles the autorelease automatically using the standard Objective-C return convention.

No behavioral change—iPadOS 26 still uses `.minimal` windowing controls—but the implementation is simpler and relies on objc2's supported return handling.

## Testing

- `cargo check --target aarch64-apple-ios -p tao` compiles with no errors.
- `cargo check -p tao` (macOS host) still compiles, confirming the dependency bump does not regress the desktop build.
- Verified on iPadOS 26 on a physical device

## Related

https://github.com/madsmtm/objc2/issues/849