### PR TITLE
fix(windows): don't panic on re-entrant or post-destroy event dispatch

### DIFF
--- a/.changes/windows-event-loop-reentrancy-panics.md
+++ b/.changes/windows-event-loop-reentrancy-panics.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Avoid panicking (and aborting the application) on Windows when the event loop is driven re-entrantly or after it has been destroyed. Re-entrant dispatches now skip the event and late state transitions from the `Destroyed` state are ignored instead of hitting `panic!("cannot move state from Destroyed")` or the "event handler is re-entrant" expectation.

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -241,19 +241,27 @@ impl<T> EventLoopRunner<T> {
 
   unsafe fn call_event_handler(&self, event: Event<'_, T>) {
     self.catch_unwind(|| {
-            let mut control_flow = self.control_flow.take();
-            let mut event_handler = self.event_handler.take()
-                .expect("either event handler is re-entrant (likely), or no event handler is registered (very unlikely)");
+      let mut control_flow = self.control_flow.take();
+      match self.event_handler.take() {
+        Some(mut event_handler) => {
+          if let ControlFlow::ExitWithCode(code) = control_flow {
+            event_handler(event, &mut ControlFlow::ExitWithCode(code));
+          } else {
+            event_handler(event, &mut control_flow);
+          }
 
-            if let ControlFlow::ExitWithCode(code) = control_flow  {
-                event_handler(event, &mut ControlFlow::ExitWithCode(code));
-            } else {
-                event_handler(event, &mut control_flow);
-            }
-
-            assert!(self.event_handler.replace(Some(event_handler)).is_none());
-            self.control_flow.set(control_flow);
-        });
+          assert!(self.event_handler.replace(Some(event_handler)).is_none());
+          self.control_flow.set(control_flow);
+        }
+        // The handler is only taken while it is running, so a `None` here means
+        // this is a re-entrant call: a Win32 message was dispatched synchronously
+        // (e.g. by a window procedure or `PeekMessageW`) while we were already
+        // inside the user callback, or an event arrived after the loop was torn
+        // down. Skip the event instead of panicking so a re-entrant dispatch can
+        // no longer crash the whole application.
+        None => self.control_flow.set(control_flow),
+      }
+    });
   }
 
   unsafe fn dispatch_buffered_events(&self) {
@@ -368,7 +376,11 @@ impl<T> EventLoopRunner<T> {
         self.call_event_handler(Event::LoopDestroyed);
       }
 
-      (Destroyed, _) => panic!("cannot move state from Destroyed"),
+      // The event loop has already been destroyed. Late Win32 messages (for
+      // example paint flushes dispatched re-entrantly while the loop is tearing
+      // down) can still try to drive a state transition. Restore the `Destroyed`
+      // state and ignore the request instead of aborting the whole application.
+      (Destroyed, _) => self.runner_state.set(Destroyed),
     }
   }
 


### PR DESCRIPTION
## Summary

On Windows, the event loop runner can **abort the whole application** in two situations, both tracked in #1180 and observed in production crash telemetry:

1. **Re-entrant dispatch** — `call_event_handler` calls
   `.expect("either event handler is re-entrant (likely), or no event handler is registered (very unlikely)")`.
   The handler is `None` whenever a Win32 message is dispatched *synchronously* while we are already inside the user callback (e.g. a window procedure or a `PeekMessageW` pumping `WM_PAINT`/IME messages), or when an event arrives after the loop has been torn down.

2. **Transition out of `Destroyed`** — `move_state_to` hits
   `panic!("cannot move state from Destroyed")` when a late message (for example a paint flush dispatched re-entrantly during teardown) tries to drive a state transition after the loop is destroyed.

The stack traces in #1180 show the re-entry arriving through Win32 message dispatch during paint flushing, so an unlucky message at the wrong time crashes the app.

## What changed

- `call_event_handler`: when the handler has already been taken (re-entrant call, or loop torn down), **skip the event** and restore `ControlFlow` instead of panicking.
- `move_state_to`: transitioning *from* `Destroyed` is now a **no-op** — the runner stays `Destroyed` — instead of panicking.

This matches the behavior the issue asks for: *"Even if an event handler is re-entrant or the state is destroyed, it should ideally not cause a hard panic that crashes the application."* It is intentionally minimal and does not attempt the larger winit `run` API rework (winit#2767).

## Verification

- `cargo check --lib --target x86_64-pc-windows-gnu` passes.
- `cargo fmt` clean.

Refs #1180