### PR TITLE
fix(windows): make EventLoopRunnerShared refcount atomic (Rc -> Arc)

### DIFF
--- a/.changes/windows-arc-event-loop-runner.md
+++ b/.changes/windows-arc-event-loop-runner.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On Windows, use `Arc` for the internal event loop runner handle, fixing use-after-free crashes when the event loop window target is cloned and dropped across threads (tauri-apps/tauri#15408).

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -194,7 +194,7 @@ impl<T: 'static> EventLoop<T> {
     thread::spawn(move || wait_thread(thread_id, HWND(send_thread_msg_target as _)));
     let wait_thread_id = get_wait_thread_id();
 
-    let runner_shared = Rc::new(EventLoopRunner::new(thread_msg_target, wait_thread_id));
+    let runner_shared = std::sync::Arc::new(EventLoopRunner::new(thread_msg_target, wait_thread_id));
 
     let thread_msg_sender =
       insert_event_target_window_data::<T>(thread_msg_target, runner_shared.clone());

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -7,7 +7,7 @@ use std::{
   cell::{Cell, RefCell},
   collections::{HashSet, VecDeque},
   mem, panic,
-  rc::Rc,
+  sync::Arc,
   time::Instant,
 };
 
@@ -24,7 +24,10 @@ use crate::{
   window::WindowId,
 };
 
-pub(crate) type EventLoopRunnerShared<T> = Rc<EventLoopRunner<T>>;
+// Consumers clone and drop this handle on non-main threads (EventLoopWindowTarget
+// travels through unsafe-Send wrappers), so the refcount must be atomic.
+// The runner's interior stays main-thread-only.
+pub(crate) type EventLoopRunnerShared<T> = Arc<EventLoopRunner<T>>;
 pub(crate) struct EventLoopRunner<T: 'static> {
   // The event loop's win32 handles
   thread_msg_target: HWND,


### PR DESCRIPTION
Fixes tauri-apps/tauri#15408. Crash-dump analysis confirming the suspected clone chain is in tauri-apps/tauri#15793 (closed as duplicate of 15408).

`EventLoopRunnerShared` on Windows is a non-atomic `Rc`. tauri-runtime-wry clones `EventLoopWindowTarget` across threads through its unsafe `Send`/`Sync` context types, and those clones are dropped on tokio worker threads. Concurrent `Rc::clone` on the main thread and `Rc::drop` off-thread desync the refcount, so the runner is freed while the event loop is still running. The observable results are sporadic `STATUS_HEAP_CORRUPTION (0xc0000374)`, `STATUS_STACK_BUFFER_OVERRUN (0xc0000409)` and `ACCESS_VIOLATION (0xc0000005)` crashes, including a reproducible teardown crash in `EventLoopRunner::reset_runner` and an `Rc::clone` at strong count 0 caught by the stdlib UB check.

This PR switches the shared handle to `Arc` so the refcount is atomic. The inner `Cell`s are still only touched on the main thread, so no further synchronization is introduced.

Validation on the affected application (Windows 10, WebView2 150): before the change it crashed within 10–25 scripted page reloads (and within 25–50 min of normal use); with the change it survived 100+ back-to-back reloads and multi-hour sessions. The crash reproduced again immediately after reverting to the unpatched build.
