### PR TITLE
fix(android): fix the android_binding macro

### DIFF
--- a/.changes/fix-android-binding-macro.md
+++ b/.changes/fix-android-binding-macro.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix a mismatched meta-variable name in the `android_binding` macro.

--- a/src/platform_impl/android/ndk_glue.rs
+++ b/src/platform_impl/android/ndk_glue.rs
@@ -77,7 +77,7 @@ const DATA_URL_ENCODING_SET: &AsciiSet = &CONTROLS
 #[macro_export]
 macro_rules! android_binding {
   ($domain:ident, $package:ident, $activity:ident, $on_activity_create:path, $main:ident) => {
-    ::tao::android_binding!($domain, $package, $activity, $setup, $main, ::tao)
+    ::tao::android_binding!($domain, $package, $activity, $on_activity_create, $main, ::tao)
   };
   ($domain:ident, $package:ident, $activity:ident, $on_activity_create:path, $main:ident, $tao:path) => {{
     // NOTE: be careful when changing how this use statement is written


### PR DESCRIPTION
A mismatched meta-variable name in the `android_binding` macro was introduced during the refactoring of https://github.com/tauri-apps/tao/commit/4e7c2f4. This PR fixes the usage of the meta-variable so that the macro becomes usable again (currently, any usage of the macro without a custom tao path fails with `error: no rules expected $`).