### PR TITLE
refactor(windows): only call `set_skip_taskbar` when needed

### DIFF
--- a/.changes/fix-set_skip_taskbar.md
+++ b/.changes/fix-set_skip_taskbar.md
@@ -2,4 +2,4 @@
 "tao": patch
 ---
 
-Skip `set_skip_taskbar` when not hiding. Reason: If Explorer is not responding, the app will hang too. Can be verified with Process Explorer by suspending explorer.exe.
+On Windows, skip `set_skip_taskbar` if `skip_taskbar` is false when creating the window and on taskbar restars.

--- a/.changes/fix-set_skip_taskbar.md
+++ b/.changes/fix-set_skip_taskbar.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Skip `set_skip_taskbar` when not hiding. Reason: If Explorer is not responding, the app will hang too. Can be verified with Process Explorer by suspending explorer.exe.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2195,7 +2195,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         result = ProcResult::Value(LRESULT(0));
       } else if msg == *S_U_TASKBAR_RESTART {
         let skip_taskbar = userdata.window_state.lock().skip_taskbar;
-        if window_state.skip_taskbar {
+        if skip_taskbar {
           let _ = set_skip_taskbar(window, true);
         }
       }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2195,7 +2195,9 @@ unsafe fn public_window_callback_inner<T: 'static>(
         result = ProcResult::Value(LRESULT(0));
       } else if msg == *S_U_TASKBAR_RESTART {
         let skip_taskbar = userdata.window_state.lock().skip_taskbar;
-        let _ = set_skip_taskbar(window, skip_taskbar);
+        if window_state.skip_taskbar {
+          let _ = set_skip_taskbar(window, true);
+        }
       }
     }
   };

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1216,7 +1216,9 @@ impl<T> InitData<'_, T> {
       let _ = DeleteObject(region.into());
     }
 
-    let _ = win.set_skip_taskbar(self.pl_attribs.skip_taskbar);
+    if self.pl_attribs.skip_taskbar {
+      let _ = win.set_skip_taskbar(true);
+    }
     win.set_window_icon(self.attributes.window_icon.clone());
     win.set_taskbar_icon(self.pl_attribs.taskbar_icon.clone());
 


### PR DESCRIPTION
Reason: If Explorer is not responding, the app will hang too. Can be verified with Process Explorer by suspending explorer.exe.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->