### PR TITLE
feat(windows): add `with_window_created`, a pre-show window callback

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -315,6 +315,25 @@ pub trait WindowBuilderExtWindows {
 
   /// Sets right-to-left layout.
   fn with_rtl(self, rtl: bool) -> WindowBuilder;
+
+  /// Sets a callback to run against the window's `HWND` once it has been created and
+  /// fully configured, but before it is shown for the first time.
+  ///
+  /// It runs while the window is still handling `WM_CREATE`, on the thread that is
+  /// building it, so `Window::new` has not returned and there is no [`Window`] to hand
+  /// over yet - only the raw handle. It is the last point at which the window can be
+  /// changed without the change being seen: the styles, the class, the icons and the
+  /// taskbar state are all in place, and nothing has put the window on the screen.
+  ///
+  /// The callback runs for every window the builder creates, once each. A panic inside
+  /// it is caught and resumed out of `WindowBuilder::build`, rather than unwinding
+  /// through the window procedure.
+  ///
+  /// Note that `maximized` and `fullscreen` are applied after the window has been shown,
+  /// so a window built with either is not yet in that state here.
+  fn with_window_created<F>(self, callback: F) -> WindowBuilder
+  where
+    F: Fn(HWND) + Send + Sync + 'static;
 }
 
 impl WindowBuilderExtWindows for WindowBuilder {
@@ -375,6 +394,15 @@ impl WindowBuilderExtWindows for WindowBuilder {
   #[inline]
   fn with_rtl(mut self, rtl: bool) -> WindowBuilder {
     self.platform_specific.rtl = rtl;
+    self
+  }
+
+  #[inline]
+  fn with_window_created<F>(mut self, callback: F) -> WindowBuilder
+  where
+    F: Fn(HWND) + Send + Sync + 'static,
+  {
+    self.platform_specific.window_created = Some(std::sync::Arc::new(callback));
     self
   }
 }

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -30,6 +30,10 @@ pub enum Parent {
   OwnedBy(HWND),
 }
 
+/// A callback run against the raw `HWND` of a window that has been created but not yet
+/// shown. `Arc` rather than `Box` because the builder it is stored on is `Clone`.
+pub type WindowCreatedCallback = std::sync::Arc<dyn Fn(isize) + Send + Sync + 'static>;
+
 #[derive(Clone)]
 pub struct PlatformSpecificWindowBuilderAttributes {
   pub parent: Parent,
@@ -41,6 +45,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
   pub drag_and_drop: bool,
   pub decoration_shadow: bool,
   pub rtl: bool,
+  pub window_created: Option<WindowCreatedCallback>,
 }
 
 impl Default for PlatformSpecificWindowBuilderAttributes {
@@ -55,6 +60,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
       window_classname: "Window Class".to_string(),
       decoration_shadow: true,
       rtl: false,
+      window_created: None,
     }
   }
 }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1224,6 +1224,18 @@ impl<T> InitData<'_, T> {
       win.set_content_protection(true);
     }
 
+    // The last point at which the window can be changed unseen: it is configured and it
+    // is not on the screen yet. Caught rather than left to unwind, since the frame below
+    // this one is the window procedure; `init` resumes the panic once `CreateWindowExW`
+    // has returned.
+    if let Some(callback) = self.pl_attribs.window_created.clone() {
+      let hwnd = win.hwnd().0 as isize;
+      let _ = self
+        .event_loop
+        .runner_shared
+        .catch_unwind(move || callback(hwnd));
+    }
+
     win.set_visible(self.attributes.visible);
     win.set_closable(self.attributes.closable);
   }


### PR DESCRIPTION
There is no point at which an application can act on its own window between `CreateWindowExW` and the window's first appearance. Everything tao hands back - the `Window`, the events - is reached after the window has been shown at least once, so anything that has to be right on the first frame can only be corrected afterwards, where it is seen.

Hand the raw `HWND` from `WM_CREATE`, after the window has been configured and before `set_visible`.

Fixes https://github.com/tauri-apps/tauri/issues/15841

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tao/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
