### PR TITLE
fix(android): drain EventLoopProxy user events on every poll iteration

### DIFF
--- a/.changes/android-always-drain-user-events.md
+++ b/.changes/android-always-drain-user-events.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+Fix Android event loop hanging on first IPC call. When the `ndk_glue` event pipe and the wake fd became ready at the same time, `ALooper_pollAll` could return the fd event instead of `ALOOPER_POLL_WAKE`, so the loop never drained the user-event channel and every invoke response sat there forever. The event loop now drains pending user events on every iteration, regardless of what the poll reported.

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -424,31 +424,14 @@ impl<T: 'static> EventLoop<T> {
             }
           */
         }
-        Some(EventSource::User) => {
-          while let Ok(event) = self.receiver.try_recv() {
-            self.call_event_handler(event_handler, control_flow, event::Event::UserEvent(event));
-          }
-        }
-        None => {}
+        _ => {}
       }
 
-      // FIX: Always drain pending user events after every poll iteration,
-      // not only when `first_event == Some(EventSource::User)`.
+      // We need to treat every event as if they were from [`EventLoopProxy::send_event`]
       //
-      // On Android, `ALooper_pollAll` can return an fd event (e.g. the
-      // `ndk_glue` event pipe, ident=0) instead of `ALOOPER_POLL_WAKE` when
-      // both the wake fd and an fd are ready in the same epoll batch. In
-      // that case `Poll::Wake` is never reported and the `EventSource::User`
-      // arm above never drains `self.receiver`, so events queued via
-      // `EventLoopProxy::send_event` sit in the channel forever — breaking
-      // every IPC response, window getter, and `run_on_main_thread` call.
-      //
-      // Draining unconditionally is safe because:
-      //  * If `EventSource::User` already drained above, `try_recv` returns
-      //    immediately on an empty channel.
-      //  * User events are independent of the Callback/InputQueue
-      //    processing order — they are dispatched via `Event::UserEvent`.
-      //  * The crossbeam receiver is lock-free and `try_recv` is cheap.
+      // > All return values may also imply ALOOPER_POLL_WAKE. If you call this in a loop,
+      // > you must treat all return values as if they also indicated ALOOPER_POLL_WAKE.
+      // > https://developer.android.com/ndk/reference/group/looper#alooper_pollonce
       while let Ok(event) = self.receiver.try_recv() {
         self.call_event_handler(event_handler, control_flow, event::Event::UserEvent(event));
       }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -432,6 +432,27 @@ impl<T: 'static> EventLoop<T> {
         None => {}
       }
 
+      // FIX: Always drain pending user events after every poll iteration,
+      // not only when `first_event == Some(EventSource::User)`.
+      //
+      // On Android, `ALooper_pollAll` can return an fd event (e.g. the
+      // `ndk_glue` event pipe, ident=0) instead of `ALOOPER_POLL_WAKE` when
+      // both the wake fd and an fd are ready in the same epoll batch. In
+      // that case `Poll::Wake` is never reported and the `EventSource::User`
+      // arm above never drains `self.receiver`, so events queued via
+      // `EventLoopProxy::send_event` sit in the channel forever — breaking
+      // every IPC response, window getter, and `run_on_main_thread` call.
+      //
+      // Draining unconditionally is safe because:
+      //  * If `EventSource::User` already drained above, `try_recv` returns
+      //    immediately on an empty channel.
+      //  * User events are independent of the Callback/InputQueue
+      //    processing order — they are dispatched via `Event::UserEvent`.
+      //  * The crossbeam receiver is lock-free and `try_recv` is cheap.
+      while let Ok(event) = self.receiver.try_recv() {
+        self.call_event_handler(event_handler, control_flow, event::Event::UserEvent(event));
+      }
+
       self.call_event_handler(event_handler, control_flow, event::Event::MainEventsCleared);
 
       if let Some(window_id) = resized_window_id {


### PR DESCRIPTION
## Summary

On Android, `ALooper_pollAll` can return an fd event (e.g. the `ndk_glue`
event pipe, ident=0) instead of `ALOOPER_POLL_WAKE` when both the wake fd and
an fd are ready in the same epoll batch. In that case `Poll::Wake` is never
reported, the `EventSource::User` arm never drains `self.receiver`, and events
queued via `EventLoopProxy::send_event` sit in the channel forever.

This breaks every IPC response, window getter, and `run_on_main_thread` call
on Android — the app hangs on first invoke because responses never reach the
renderer.

## Fix

Drain `self.receiver` unconditionally after every poll iteration, not only
when `first_event == Some(EventSource::User)`.

Safety:
- If `EventSource::User` already drained above, `try_recv` returns immediately
  on an empty channel.
- User events are independent of the Callback/InputQueue processing order,
  they are dispatched via `Event::UserEvent`.
- The crossbeam receiver is lock-free and `try_recv` is cheap.

## Testing

Tested on Samsung S22 Ultra (Android 16) with a Tauri 2.11.5 app using
tao 0.36.0 + tauri-runtime-wry 2.11.4. Without the fix, the first
`invoke()` hangs indefinitely. With the fix, all invokes resolve in <100ms.