### PR TITLE
fix(windows): delay maximize window if hidden

### DIFF
--- a/.changes/windows-delay-maximize-if-hidden.md
+++ b/.changes/windows-delay-maximize-if-hidden.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On Windows, delay maximizing the window if it's hidden to avoid it flashing briefly. This also changed the size and position returned to pre-maximized states if you query them with the window being hidden and called `maximize`

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -357,7 +357,10 @@ impl WindowFlags {
       }
     }
 
-    if diff.contains(WindowFlags::MAXIMIZED) || new.contains(WindowFlags::MAXIMIZED) {
+    if (diff.contains(WindowFlags::MAXIMIZED) || new.contains(WindowFlags::MAXIMIZED))
+      // This is to avoid the window from flashing
+      && !(new.contains(WindowFlags::MAXIMIZED) && !new.contains(WindowFlags::VISIBLE))
+    {
       unsafe {
         let _ = ShowWindow(
           window,


### PR DESCRIPTION
Fix #1142
Fix https://github.com/tauri-apps/tauri/issues/14068

On Windows, delay maximizing the window if it's hidden to avoid it flashing briefly. This also changed the size and position returned to pre-maximized states if you query them with the window being hidden and called `maximize`

This is mainly for the tauri's window-state plugin since you need to set `visible: false` to avoid flashing. This will allow you to set both maximized + hidden without causing a flashing window.