### PR TITLE
fix(windows): `Window` functions panics after `EventLoop` dropped

### DIFF
--- a/.changes/no-panic-execute-in-thread.md
+++ b/.changes/no-panic-execute-in-thread.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On Windows, fix `Window` functions panics after the parent event loop dropped, they log the errors instead

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -530,16 +530,20 @@ impl EventLoopThreadExecutor {
 
         let raw = Box::into_raw(boxed2);
 
-        let res = PostMessageW(
+        let result = PostMessageW(
           Some(self.target_window),
           *EXEC_MSG_ID,
           WPARAM(raw as _),
           LPARAM(0),
         );
-        assert!(
-          res.is_ok(),
-          "PostMessage failed ; is the messages queue full?"
-        );
+        // This can happen when we outlive the parent [`EventLoopWindowTarget`] at which point the `target_window` has already been destroyed
+        if let Err(error) = result {
+          log::error!(
+            "PostMessage failed ; is the messages queue full? Error code {} - {}",
+            error.code(),
+            error.message()
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
Reference: https://github.com/tauri-apps/tauri/pull/15812#issuecomment-5277377030

Mirror https://github.com/tauri-apps/wry/pull/1426