### PR TITLE
fix(ios): dispatch events while a scroll view is tracking

### DIFF
--- a/.changes/ios-runloop-common-modes.md
+++ b/.changes/ios-runloop-common-modes.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On iOS, run the event loop observers in `kCFRunLoopCommonModes` so queued events are dispatched while a `UIScrollView` is tracking or decelerating, instead of waiting for the scroll to stop.

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -311,7 +311,7 @@ fn setup_control_flow_observers() {
       control_flow_begin_handler,
       ptr::null_mut(),
     );
-    CFRunLoopAddObserver(main_loop, begin_observer, kCFRunLoopDefaultMode);
+    CFRunLoopAddObserver(main_loop, begin_observer, kCFRunLoopCommonModes);
 
     let main_end_observer = CFRunLoopObserverCreate(
       ptr::null_mut(),
@@ -321,7 +321,7 @@ fn setup_control_flow_observers() {
       control_flow_main_end_handler,
       ptr::null_mut(),
     );
-    CFRunLoopAddObserver(main_loop, main_end_observer, kCFRunLoopDefaultMode);
+    CFRunLoopAddObserver(main_loop, main_end_observer, kCFRunLoopCommonModes);
 
     let end_observer = CFRunLoopObserverCreate(
       ptr::null_mut(),
@@ -331,7 +331,7 @@ fn setup_control_flow_observers() {
       control_flow_end_handler,
       ptr::null_mut(),
     );
-    CFRunLoopAddObserver(main_loop, end_observer, kCFRunLoopDefaultMode);
+    CFRunLoopAddObserver(main_loop, end_observer, kCFRunLoopCommonModes);
   }
 }
 


### PR DESCRIPTION
### Problem

On iOS, no event is dispatched to the application while a `UIScrollView` is
tracking a finger or decelerating. Events queued during that window are
delivered only once the scroll comes to rest, so a tap on a button outside the
scroller appears to do nothing for as long as the momentum lasts.

### Cause

`setup_control_flow_observers` registers all three control-flow observers in
`kCFRunLoopDefaultMode`:

```rust
CFRunLoopAddObserver(main_loop, begin_observer, kCFRunLoopDefaultMode);
CFRunLoopAddObserver(main_loop, main_end_observer, kCFRunLoopDefaultMode);
CFRunLoopAddObserver(main_loop, end_observer, kCFRunLoopDefaultMode);
```

While scrolling, UIKit runs the main run loop in `UITrackingRunLoopMode`, so
these observers never fire and nothing drives the event loop.

The `EventLoopProxy` wake source is already registered in
`kCFRunLoopCommonModes` (line 222), so the run loop *is* woken during a scroll
— it simply has no observer in that mode to dispatch what arrived. The existing
`kCFRunLoopExit => ()` comments ("Mode is changed to others like
`UITrackingRunLoopMode`") show the mode switch was already known about.

### Fix

Register the three observers in `kCFRunLoopCommonModes`, which includes
`UITrackingRunLoopMode`, matching the mode the wake source already uses.

### Testing

Verified on a physical iPhone 14 Pro (iOS 26.6.1) running a WebView-based
Wry/Dioxus application. Before: tapping a navigation button during a momentum
scroll did nothing until the scroll stopped. After: the tap is handled
immediately, with no change to scrolling or inertia and no perceptible jank
from the loop now running during tracking.

To be explicit about the limits of that evidence: this is one device and one
application, and it is a behaviour change for every iOS consumer — the event
loop now runs during tracking, so an app doing heavy work per iteration will do
that work while the user scrolls. That is the correct trade (the alternative is
dropped interactivity), but it is worth a maintainer's judgement.
