### PR TITLE
fix(macos): don't register run loop observer/timer in event tracking mode (fixes status-item menu dismissal)

### DIFF
--- a/.changes/fix-macos-menu-dismissal.md
+++ b/.changes/fix-macos-menu-dismissal.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On macOS, register the event-loop control-flow observers, the `EventLoopWaker` timer, and the `EventLoopProxy` source in `kCFRunLoopDefaultMode` + `NSModalPanelRunLoopMode` instead of `kCFRunLoopCommonModes`. This keeps them out of `NSEventTrackingRunLoopMode`, so opening a native menu (e.g. an `NSStatusItem`/tray-icon menu, or any `NSMenu`) no longer causes tao to pump the event loop during the menu's nested tracking loop and dismiss it.

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -333,7 +333,7 @@ impl<T> Proxy<T> {
       let mut context: CFRunLoopSourceContext = mem::zeroed();
       context.perform = Some(event_loop_proxy_handler);
       let source = CFRunLoopSourceCreate(ptr::null_mut(), CFIndex::MAX - 1, &mut context);
-      CFRunLoopAddSource(rl, source, kCFRunLoopCommonModes);
+      add_to_run_loop_modes(|mode| CFRunLoopAddSource(rl, source, mode));
       CFRunLoopWakeUp(rl);
 
       Proxy { sender, source }

--- a/src/platform_impl/macos/observer.rs
+++ b/src/platform_impl/macos/observer.rs
@@ -19,7 +19,7 @@ use crate::platform_impl::platform::{
 
 #[link(name = "CoreFoundation", kind = "framework")]
 extern "C" {
-  pub static kCFRunLoopCommonModes: CFRunLoopMode;
+  pub static kCFRunLoopDefaultMode: CFRunLoopMode;
 
   pub fn CFRunLoopGetMain() -> CFRunLoopRef;
   pub fn CFRunLoopWakeUp(rl: CFRunLoopRef);
@@ -63,6 +63,30 @@ extern "C" {
 
   pub fn CFAbsoluteTimeGetCurrent() -> CFAbsoluteTime;
   pub fn CFRelease(cftype: *const c_void);
+}
+
+#[link(name = "AppKit", kind = "framework")]
+extern "C" {
+  // The run loop mode AppKit uses for modal panels (e.g. `runModalForWindow:`).
+  // It is an `NSString *`, which is toll-free bridged to `CFStringRef`.
+  pub static NSModalPanelRunLoopMode: CFRunLoopMode;
+}
+
+/// Adds `source`-like objects to the run loop modes tao needs to keep the event
+/// loop responsive, *without* using `kCFRunLoopCommonModes`.
+///
+/// `kCFRunLoopCommonModes` also includes `NSEventTrackingRunLoopMode`, the mode
+/// AppKit runs its nested tracking loop in while a native menu (e.g. an
+/// `NSStatusItem`/tray-icon menu, or any `NSMenu`) is open. Registering tao's
+/// control-flow observers there makes them fire *during* menu tracking; the
+/// `BeforeWaiting` observer then pumps the event loop and processes app state,
+/// which dismisses the open menu.
+///
+/// Instead we register in the default mode and the modal-panel mode explicitly,
+/// so modal dialogs keep working while menu tracking is left untouched.
+pub(crate) unsafe fn add_to_run_loop_modes<F: Fn(CFRunLoopMode)>(add: F) {
+  add(kCFRunLoopDefaultMode);
+  add(NSModalPanelRunLoopMode);
 }
 
 pub enum CFAllocator {}
@@ -216,7 +240,7 @@ impl RunLoop {
       handler,
       context,
     );
-    CFRunLoopAddObserver(self.0, observer, kCFRunLoopCommonModes);
+    add_to_run_loop_modes(|mode| CFRunLoopAddObserver(self.0, observer, mode));
   }
 }
 
@@ -274,7 +298,8 @@ impl Default for EventLoopWaker {
         wakeup_main_loop,
         ptr::null_mut(),
       );
-      CFRunLoopAddTimer(CFRunLoopGetMain(), timer, kCFRunLoopCommonModes);
+      let main = CFRunLoopGetMain();
+      add_to_run_loop_modes(|mode| CFRunLoopAddTimer(main, timer, mode));
       EventLoopWaker { timer }
     }
   }


### PR DESCRIPTION
Closes #1324.

### Problem

On macOS an open native menu (an `NSStatusItem` / tray-icon menu, or any `NSMenu`) is dismissed by itself shortly after opening when the event loop is driven by tao.

tao registers its event-loop machinery in **`kCFRunLoopCommonModes`**:

- the control-flow `CFRunLoopObserver`s (`observer.rs`, `RunLoop::add_observer`),
- the `EventLoopWaker` `CFRunLoopTimer` (`observer.rs`, `impl Default for EventLoopWaker`),
- the `EventLoopProxy` `CFRunLoopSource` (`event_loop.rs`, `Proxy::new`).

`kCFRunLoopCommonModes` includes `NSEventTrackingRunLoopMode`, the mode AppKit spins its nested tracking loop in while a menu is open. So the `BeforeWaiting` observer (`control_flow_end_handler` -> `AppState::cleared`) fires *inside* the menu's tracking loop and runs a full pump of tao's machinery (`handle_user_events`, `MainEventsCleared`, redraw dispatch, ...). Servicing the app mid-tracking ends the menu's tracking session, dismissing the menu. When idle the waker is parked at `f64::MAX`, so this is the *observer* being live in tracking mode, not a tao timer.

### Fix

Register those objects in `kCFRunLoopDefaultMode` + `NSModalPanelRunLoopMode` explicitly, via a small `add_to_run_loop_modes` helper, instead of the blanket `kCFRunLoopCommonModes`. This leaves `NSEventTrackingRunLoopMode` untouched (menu tracking is no longer interrupted) while keeping the default mode and modal-panel mode working. The proxy source is routed through the same helper so a proxy-driven wakeup during menu tracking can't reintroduce the dismissal.

The diff is intentionally minimal; no observer/timer/source behavior changes other than which run-loop modes they are attached to.

### Tradeoff considered (why this is a draft)

`kCFRunLoopCommonModes` is deliberate: it also keeps the loop running during window **live-resize**, which runs in `NSEventTrackingRunLoopMode`. Excluding that mode means tao's observer will no longer emit `MainEventsCleared` / `RedrawRequested` *during* a live window resize, so GPU-rendered windowed apps could stop repainting until the drag ends. Menu tracking and resize tracking share the same run-loop mode, so mode selection alone can't distinguish them.

Opening as a **draft** to get maintainers' preference on the tradeoff. Options, from least to most invasive:

1. This PR: drop `NSEventTrackingRunLoopMode` (fixes menus; may affect live-resize redraw continuity).
2. Keep common modes but make `AppState::cleared`/`wakeup` a no-op while a menu tracking session is active (needs a reliable "menu is open" signal).
3. Gate the mode selection behind an opt-in option so windowed apps that rely on live-resize redraw keep the old behavior.

Happy to switch to whichever direction you prefer.

### Testing

- `cargo build`, `cargo build --examples`, `cargo fmt -- --check`, and `cargo clippy` all pass on macOS (rustc 1.98.0) with no new warnings from the change.
- Built a `tao` + `tray-icon` reproducer (included in the linked issue) against this branch; it compiles and links. I was not able to visually confirm dismissal-vs-fixed behavior in this environment (no interactive GUI session available), so a maintainer sanity-check of the on-screen behavior on a desktop would be appreciated.

### Environment

- macOS 26.6.2 (build 25G83), rustc 1.98.0
- Change also applies unchanged to current `dev`.
