### PR TITLE
fix(macos): memory leaks in window lifecycle and event loop proxy

### DIFF
--- a/.changes/macos-memory-leaks.md
+++ b/.changes/macos-memory-leaks.md
@@ -1,0 +1,5 @@
+---
+"tao": patch
+---
+
+On macOS, fix memory leaks on window creation, destruction, and `EventLoopProxy` clone drop.

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -7,6 +7,7 @@ use crate::{
   platform_impl::platform::{
     app_state::AppState,
     ffi::{id, BOOL, YES},
+    util,
   },
 };
 
@@ -119,6 +120,8 @@ extern "C" fn dealloc(this: &Object, _: Sel) {
     // As soon as the box is constructed it is immediately dropped, releasing the underlying
     // memory
     drop(Box::from_raw(state_ptr as *mut RefCell<AuxDelegateState>));
+    let superclass = util::superclass(this);
+    let _: () = msg_send![super(this, superclass), dealloc];
   }
 }
 

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -310,6 +310,9 @@ unsafe impl<T: Send> Sync for Proxy<T> {}
 impl<T> Drop for Proxy<T> {
   fn drop(&mut self) {
     unsafe {
+      let rl = CFRunLoopGetMain();
+      CFRunLoopRemoveSource(rl, self.source, kCFRunLoopCommonModes);
+      CFRunLoopSourceInvalidate(self.source);
       CFRelease(self.source as _);
     }
   }

--- a/src/platform_impl/macos/observer.rs
+++ b/src/platform_impl/macos/observer.rs
@@ -57,7 +57,7 @@ extern "C" {
     context: *mut CFRunLoopSourceContext,
   ) -> CFRunLoopSourceRef;
   pub fn CFRunLoopAddSource(rl: CFRunLoopRef, source: CFRunLoopSourceRef, mode: CFRunLoopMode);
-  #[allow(dead_code)]
+  pub fn CFRunLoopRemoveSource(rl: CFRunLoopRef, source: CFRunLoopSourceRef, mode: CFRunLoopMode);
   pub fn CFRunLoopSourceInvalidate(source: CFRunLoopSourceRef);
   pub fn CFRunLoopSourceSignal(source: CFRunLoopSourceRef);
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -269,6 +269,8 @@ extern "C" fn dealloc(this: &Object, _sel: Sel) {
     let marked_text: *mut NSMutableAttributedString = *this.get_ivar("markedText");
     let _: () = msg_send![marked_text, release];
     drop(Box::from_raw(state as *mut ViewState));
+    let superclass = util::superclass(this);
+    let _: () = msg_send![super(this, superclass), dealloc];
   }
 }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -252,7 +252,7 @@ fn create_window(
       defer: NO,
     ];
 
-    Retained::retain(ns_window_ptr).and_then(|r| r.downcast::<NSWindow>().ok()).map(|ns_window| {
+    Retained::<Object>::from_raw(ns_window_ptr.cast()).and_then(|r| r.downcast::<NSWindow>().ok()).map(|ns_window| {
       #[allow(deprecated)]
       {
         *((*ns_window_ptr).get_mut_ivar::<Bool>("focusable")) = attrs.focusable.into();

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -283,6 +283,10 @@ extern "C" fn dealloc(this: &Object, _sel: Sel) {
   with_state(this, |state| unsafe {
     drop(Box::from_raw(state as *mut WindowDelegateState));
   });
+  unsafe {
+    let superclass = util::superclass(this);
+    let _: () = msg_send![super(this, superclass), dealloc];
+  }
 }
 
 extern "C" fn init_with_tao(this: &Object, _sel: Sel, state: *mut c_void) -> id {


### PR DESCRIPTION
1. Closed windows were never freed. `create_window` wrapped the `alloc` + `initWithContentRect:` result in `Retained::retain`, adding a reference that was never balanced — and since tao sets `setReleasedWhenClosed(false)`, `close()` wouldn't release it either. Every destroyed window kept its `NSWindow`, `TaoView`, view state and AppKit-internal data alive. Now wrapped with `Retained::from_raw`, the ownership pattern documented by objc2 for `alloc`/`init` (see the [`Retained::from_raw` example](https://docs.rs/objc2/0.6.4/objc2/rc/struct.Retained.html#method.from_raw)). This matches upstream winit, which also keeps `setReleasedWhenClosed(false)` for Rust-side lifetime control but creates its window without the extra retain — [`window_delegate.rs` L563–577 (v0.30.9)](https://github.com/rust-windowing/winit/blob/v0.30.9/src/platform_impl/macos/window_delegate.rs#L563-L577), including the comment "It is very important for correct memory management that we disable the extra release that would otherwise happen when calling `close` on the window."

---

2. Instances and run loop sources were never freed. The hand-written `dealloc` overrides (`TaoView`, `TaoWindowDelegate`, `TaoAppDelegate`) cleaned up ivars but didn't call super, so the object itself leaked on every window destroy; and each `EventLoopProxy` clone leaked a `CFRunLoopSource` on the main run loop because `Drop` only released the creation reference. `dealloc` now chains to super (same pattern as `sendEvent:` in `app.rs`) — upstream winit gets this for free by declaring its classes with objc2's `declare_class!` ([`view.rs` L144–156, v0.30.9](https://github.com/rust-windowing/winit/blob/v0.30.9/src/platform_impl/macos/view.rs#L144-L156)), whose generated `dealloc` drops ivars and calls super, exactly what tao's hand-written classes (marked `// TODO: Use define_class!`) are missing. `Drop` now removes and invalidates the source before releasing — intentionally stricter than winit, whose proxy drop is CFRelease-only today ([`event_loop.rs` L458–464](https://github.com/rust-windowing/winit/blob/v0.30.9/src/platform_impl/macos/event_loop.rs#L458-L464)), making the cleanup deterministic on all macOS versions.
